### PR TITLE
Access some functions by International Table spacegroup name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ set(SOURCES ${PROJECT_SOURCE_DIR}/src/arithmetic.c
 add_library(symspg SHARED ${SOURCES})
 set_property(TARGET symspg PROPERTY VERSION ${serial})
 set_property(TARGET symspg PROPERTY SOVERSION ${soserial})
-install(TARGETS symspg LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+if (WIN32)
+	install(TARGETS symspg RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+else()
+	install(TARGETS symspg LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+endif()
 
 # Static link library
 add_library(symspg_static STATIC ${SOURCES})

--- a/python/spglib/__init__.py
+++ b/python/spglib/__init__.py
@@ -51,6 +51,13 @@ from .spglib import (get_version,
                      get_BZ_grid_points_by_rotations,
                      relocate_BZ_grid_address,
                      get_stabilized_reciprocal_mesh,
-                     get_error_message)
+                     get_error_message,
+                     get_hall_number_from_international,
+                     get_ir_reciprocal_mesh_from_international,
+                     get_ir_reciprocal_mesh_from_hall_number,
+                     get_symmetry_from_international,
+                     get_pointgroup_rotations,
+                     get_pointgroup_rotations_hall_number,
+                     get_pointgroup_rotations_international)
 
 __version__ = "%d.%d.%d" % get_version()

--- a/src/kpoint.h
+++ b/src/kpoint.h
@@ -91,6 +91,8 @@ size_t kpt_relocate_dense_BZ_grid_address(int bz_grid_address[][3],
                                           const int mesh[3],
                                           SPGCONST double rec_lattice[3][3],
                                           const int is_shift[3]);
+MatINT *kpt_get_unique_rotations(const MatINT * rotations, const int is_time_reversal);
+MatINT *kpt_get_point_group_reciprocal_from_unique(const MatINT * rot_unique);
 MatINT *kpt_get_point_group_reciprocal(const MatINT * rotations,
                                        const int is_time_reversal);
 MatINT *kpt_get_point_group_reciprocal_with_q(const MatINT * rot_reciprocal,

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -370,6 +370,27 @@ static Centering get_centering(double correction_mat[3][3],
 static Centering get_base_center(SPGCONST int transform_mat[3][3]);
 static int get_centering_shifts(double shift[3][3],
                                 const Centering centering);
+								
+int spa_international_number_to_hall_number(const int number){
+	if (number>=0 && number<230)
+		return spacegroup_to_hall_number[number];
+	else
+		return -1;
+}
+
+int spa_international_to_hall_number(const char* itname)
+{
+  SpacegroupType spgtype;
+  for (int i=1; i<531; i++){
+	  spgtype = spgdb_get_spacegroup_type(i);
+	  // now check for matching international table names
+	  if ( 0 == strncmp(itname, spgtype.international, 32)
+		 ||0 == strncmp(itname, spgtype.international_full,20)
+	     ||0 == strncmp(itname, spgtype.international_short,11))
+		 return i;		 
+  }
+  return 0; // no matching strings
+}
 
 
 /* Return spacegroup.number = 0 if failed */

--- a/src/spacegroup.h
+++ b/src/spacegroup.h
@@ -66,6 +66,9 @@ typedef enum {
   R_CENTER,
 } Centering;
 
+int spa_international_number_to_hall_number(const int number);
+int spa_international_to_hall_number(const char* itname);
+
 Spacegroup * spa_search_spacegroup(const Cell * primitive,
                                    const int hall_number,
                                    const double symprec,

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -212,6 +212,28 @@ extern "C" {
                          const int num_atom,
                          const double symprec,
                          const double angle_tolerance);
+						 
+  int spg_get_pointgroup_rotations(int rotation[][3][3],
+                                   const int max_size,
+                                   SPGCONST double lattice[3][3],
+                                   SPGCONST double position[][3],
+                                   const int types[],
+                                   const int num_atom,
+                                   const double symprec,
+                                   const int is_time_reversal);
+  int spgat_get_pointgroup_rotations(int rotation[][3][3],
+                                     const int max_size,
+                                     SPGCONST double lattice[3][3],
+                                     SPGCONST double position[][3],
+                                     const int types[],
+                                     const int num_atom,
+                                     const double symprec,
+                                     const double angle_tolerance,
+                                     const int is_time_reversal);
+  int spg_get_pointgroup_rotations_hall_number(int rotation[][3][3],
+                                               const int max_size,
+                                               const int hall_number,
+                                               const int is_time_reversal);
 
 /* Find symmetry operations with collinear spins on atoms. */
   int spg_get_symmetry_with_collinear_spin(int rotation[][3][3],
@@ -236,6 +258,13 @@ extern "C" {
                                              const int num_atom,
                                              const double symprec,
                                              const double angle_tolerance);
+
+// Space group type (hall number) is searched by International Table name
+// The passed string is checked against "international", "international_full"
+// and "international_short", in that order, for increasing hall number from
+// 1 to 530; short circuiting at the first match. This means that the returned
+// hall number may not be unique for the given string.
+  int spg_get_hall_number_from_international(const char* itname);
 
 /* Space group type (hall_number) is searched from symmetry operations. */
   int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
@@ -420,6 +449,21 @@ extern "C" {
                                           const int types[],
                                           const int num_atom,
                                           const double symprec);
+										  
+int spg_get_ir_reciprocal_mesh_from_hall_number(
+			int grid_address[][3],
+			int ir_mapping_table[],
+			const int mesh[3],
+			const int is_shift[3],
+			const int is_time_reversal,
+			int hall_number);
+size_t spg_get_dense_ir_reciprocal_mesh_from_hall_number(
+			int grid_address[][3],
+			size_t ir_mapping_table[],
+			const int mesh[3],
+			const int is_shift[3],
+			const int is_time_reversal,
+			int hall_number);
 
 /* The irreducible k-points are searched from unique k-point mesh */
 /* grids from real space lattice vectors and rotation matrices of */


### PR DESCRIPTION
In situations where the unit cell is not fully populated but where the correct spacegroup is still known -- e.g., users of [SpinW](https://github.com/spinw/spinw) often omit non-magnetic atoms from their lattice definitions -- it could be useful to have access to spglib's database of symmetry operations or to let it create an irreducible reciprocal grid.
To that end, I've added C and Python functions to access symmetry information by matching a supplied string against one of the three International Table spacegroup strings stored in the `SpacegroupType` database, `international`, `international_long`, or `international_short` to find a (potentially not-unique) Hall number.

I've also added functions to access a spacegroup's pointgroup rotation matrices to enable identification of _which_ rotation (and of which order) is necessary to map points on the reciprocal grid to their equivalent irreducible grid point. With this information one can, e.g., calculate a vector or tensor quantity for each irreducible grid point and transform it to any non-irreducible grid point.
If there's any interest in it, I could add functions to perform the identification inside of spglib, potentially during a call to `*get_ir_reciprocal_mesh` if breaking its API is OK in a future release.

Finally, I have made a small change to `CMakeLists.txt` which should allow for the C library to be built successfully on Windows systems using native Visual Studio compilers.
