### PR TITLE
Clarify primitive setting choice

### DIFF
--- a/doc/definition.rst
+++ b/doc/definition.rst
@@ -348,7 +348,7 @@ as follows:
 
 The choice of transformation matrix is a matter of convention. The transformation
 matrices above transform from a conventional ITA basis to the primitive
-setting adopted in the reference work of Cracknell, Davies, Love, and Miller
+setting adopted in the reference work of Cracknell, Davies, Miller, and Love
 (CDML). Other primitive setting choices exist: of note, the CDML choice is not
 the primitive setting choice made in the International Tables of Crystallography.
 


### PR DESCRIPTION
The primitive setting choice described in the documentation is consistent with the CDML primitive setting choice, as can be confirmed e.g. by comparison with [Table 2 of this paper](https://doi.org/10.1107/S205327331303091X) [which give (P⁻¹)ᵀ] or by comparison with Tables 1.5.4.1 and 1.5.4.2 of the International Table of Crystallography, Vol. B, 2nd edition.

I figured it might be helpful to explicate this (e.g., so users can see if the setting is compatible with settings used by other libraries or reference works).