### PR TITLE
Fix shebang in python/examples/example.py (evn -> env)

### DIFF
--- a/python/examples/example.py
+++ b/python/examples/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/evn python
+#!/usr/bin/env python
 
 import sys
 import spglib


### PR DESCRIPTION
There seems to be a typo in the shebang of python/examples/example.py (evn -> env).