### PR TITLE
Fix dead links

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -287,7 +287,7 @@ or cell choice), ``spg_get_dataset_with_hall_number`` is used.
 where ``hall_number`` is used to specify the choice. The possible
 choices and those serial numbers are found at `list of space groups
 (Seto's web site)
-<http://pmsl.planet.sci.kobe-u.ac.jp/~seto/?page_id=37&lang=en>`_.
+<https://yseto.net/?page_id=29>`_.
 The crystal structure has to possess the space-group type of the Hall
 symbol. If the symmetry search fails or the specified ``hall_number``
 is not in the list of Hall symbols for the space group type of the

--- a/doc/dataset.rst
+++ b/doc/dataset.rst
@@ -58,7 +58,7 @@ Crystallography (ITA).
 
 The serial number from 1 to 530 which are found at `list of space
 groups (Seto's web site)
-<http://pmsl.planet.sci.kobe-u.ac.jp/~seto/?page_id=37&lang=en>`_. Be
+<https://yseto.net/?page_id=29>`_. Be
 sure that this is not a standard crystallographic definition as far as
 the author of spglib knows.
 

--- a/doc/python-spglib.rst
+++ b/doc/python-spglib.rst
@@ -388,7 +388,7 @@ The arguments are:
   option (i.e., in the case of ``hall_number=0``), always the first one
   (the smallest serial number corresponding to the space-group-type in
   `list of space groups (Seto's web site)
-  <http://pmsl.planet.sci.kobe-u.ac.jp/~seto/?page_id=37&lang=en>`_)
+  <https://yseto.net/?page_id=29>`_)
   among possible choices and settings is chosen as default. This
   argument is useful when the other choice (or setting) is expected to
   be hooked. This affects to the obtained values of ``international``,


### PR DESCRIPTION
Dr. Seto's page for Hall symbols seems to be moved. 