### PR TITLE
Return time reversal operations for scalar and vectors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
   - id: clang-format
     args: ["-i", "--style=file"]  # Use style set in .clang-format
     files: ^src/
+    exclude: src/msg_database.c  # Skip too large file to wait every time
   - id: clang-tidy
     files: ^src/
   # - id: oclint

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,8 @@ This directory contains python-sphinx documentation source.
 
 ## How to compile
 
-```
+```shell
+pip install sphinx sphinx-bootstrap-theme
 make html
 ```
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -96,3 +96,11 @@ Spglib project acknowledges Paweł T. Jochym for deployment and packaging, Yusuk
 Seto for the Crystallographic database, Jingheng Fu for layer group
 implementation, Dimitar Pashov for the Fortran interface, and many other
 contributors.
+
+Developer Documentation
+-----------------------
+
+.. toctree::
+  :maxdepth: 1
+
+  Magnetic space group <magnetic_spacegroup>

--- a/doc/magnetic_spacegroup.rst
+++ b/doc/magnetic_spacegroup.rst
@@ -1,0 +1,237 @@
+Magnetic Space group (MSG)
+==========================
+
+.. contents::
+
+Definition
+----------
+
+A **magnetic space group** :math:`\mathcal{M}` is a subgroup of direct product of space group :math:`\mathcal{G}` and :math:`\mathbb{Z}_{2} \simeq \{1, 1' \}`.
+
+A **family space group** (FSG) :math:`\mathcal{F}(\mathcal{M})` is a non-magnetic space group obtained by ignoring primes in operations,
+
+.. math::
+    \mathcal{F}(\mathcal{M}) = \left\{ (\mathbf{R}, \mathbf{v}) \mid (\mathbf{R}, \mathbf{v}) \in \mathcal{M} \vee (\mathbf{R}, \mathbf{v})1' \in \mathcal{M} \right\}.
+
+A **maximal space subgroup** (XSG) :math:`\mathcal{D}(\mathcal{M})` is a space group obtained by removing primed operations,
+
+.. math::
+    \mathcal{D}(\mathcal{M}) = \left\{ (\mathbf{R}, \mathbf{v}) \mid (\mathbf{R}, \mathbf{v}) \in \mathcal{M} \right\}.
+
+Magnetic space groups are classified to the following four types:
+
+- (type-I) :math:`\mathcal{M} \simeq \mathcal{F}(\mathcal{M}) \simeq \mathcal{D}(\mathcal{M})`.
+- (type-II) :math:`\mathcal{M} \simeq \mathcal{F}(\mathcal{M}) \times \{1, 1'\}, \mathcal{F}(\mathcal{M}) \simeq \mathcal{D}(\mathcal{M})`.
+- (type-III)
+  :math:`\mathcal{D}(\mathcal{M})` is a translationengleiche subgroup of index two of :math:`\mathcal{F}(\mathcal{M})`.
+
+  .. math::
+    \mathcal{M} \simeq \mathcal{D}(\mathcal{M}) \sqcup (\mathcal{F}(\mathcal{M}) \backslash \mathcal{D}(\mathcal{M})) 1'
+
+- (type-IV)
+  :math:`\mathcal{D}(\mathcal{M})` is a klessengleichesubgroup of index two of :math:`\mathcal{F}(\mathcal{M})`.
+
+  .. math::
+    \mathcal{M} \simeq \mathcal{D}(\mathcal{M}) \sqcup (\mathcal{F}(\mathcal{M}) \backslash \mathcal{D}(\mathcal{M})) 1'
+
+.. list-table:: Number of (3-dimensional) magnetic space groups
+    :header-rows: 1
+
+    * - type-I
+      - type-II
+      - type-III
+      - type-IV
+      - Total
+    * - 230
+      - 230
+      - 674
+      - 517
+      - 1651
+
+For type-I, II, III MSG, both OG and BNS symbols use a setting of :math:`\mathcal{F}(\mathcal{M})`.
+For type-IV MSG, OG symbols use a setting of :math:`\mathcal{F}(\mathcal{M})` and BNS symbols use that of :math:`\mathcal{D}(\mathcal{M})`.
+
+Action of MSG operations
+------------------------
+
+In general, we can arbitrarily choose how MSG operation acts on objects as long as it satisfies the definition of left actions.
+Here are the examples of objects and actions on them:
+
+* Collinear magnetic moment :math:`m_{z}` without spin-orbit coupling
+
+.. math::
+    (\mathbf{R}, \mathbf{v}) \circ m_{z} &= m_{z} \\
+    1' \circ m_{z} &= -m_{z}
+
+* Magnetic moment :math:`\mathbf{m}`
+
+.. math::
+    (\mathbf{R}, \mathbf{v}) \circ \mathbf{m} &= (\mathrm{det} \mathbf{R}) \mathbf{R} \mathbf{m} \\
+    1' \circ \mathbf{m} &= -\mathbf{m}
+
+* Grain boundary made of "black" and "white" crystals
+
+.. math::
+    (\mathbf{R}, \mathbf{v}) \circ (\mathbf{r}, \mathrm{black}) &= ( \mathbf{R}\mathbf{r} + \mathbf{v}, \mathrm{black} ) \\
+    (\mathbf{R}, \mathbf{v}) \circ (\mathbf{r}, \mathrm{white}) &= ( \mathbf{R}\mathbf{r} + \mathbf{v}, \mathrm{white} ) \\
+    1' \circ (\mathbf{r}, \mathrm{black}) &= (\mathbf{r}, \mathrm{white}) \\
+    1' \circ (\mathbf{r}, \mathrm{white}) &= (\mathbf{r}, \mathrm{black}) \\
+
+MSG detection for crystal structure
+-----------------------------------
+
+Formally, :code:`cell` consists of
+
+- column-wise lattice matrix :math:`\mathbf{A}`
+- fractional coordinates :math:`\mathbf{X}`
+- atomic types :math:`\mathbf{T}`
+- magmoms :math:`\mathbf{M}`
+
+SG corresponds to the following equivalence relation (implemented in :code:`cel_is_overlap_with_same_type`) as :math:`\mathcal{S} := \mathrm{Stab}_{\mathrm{E}(3)} \, (\mathbf{X}, \mathbf{T}) / \sim_{\mathcal{S}}`,
+
+.. math::
+    (X_{i}, T_{i}) \sim_{\mathcal{S}} (X_{j}, T_{j})
+    \overset{\mathrm{def}}{\iff}
+    \exists g \in \mathrm{E}(3) \, s.t. \,  g \circ X_{i} = X_{j} \,\mathrm{and}\,  T_{i} = T_{j}.
+
+XSG corresponds to the following equivalence relation as :math:`\mathcal{D} := \mathrm{Stab}_{ \mathcal{S} } \, (\mathbf{X}, \mathbf{T}, \mathbf{M}) / \sim_{\mathcal{D}}`,
+
+.. math::
+    (X_{i}, T_{i}, M_{i}) \sim_{\mathcal{D}} (X_{j}, T_{j}, M_{j})
+    \overset{\mathrm{def}}{\iff}
+    \exists g \in \mathcal{S} \, s.t. \, g \circ M_{i} = M_{j}.
+
+MSG corresponds to the following equivalence relation as :math:`\mathcal{M} = \mathrm{Stab}_{ \mathcal{S} \times \{ 1, 1' \} } \, (\mathbf{X}, \mathbf{T}, \mathbf{M}) / \sim_{\mathcal{M}}`
+
+.. math::
+    (X_{i}, T_{i}, M_{i}) \sim_{\mathcal{M}} (X_{j}, T_{j}, M_{j})
+    \overset{\mathrm{def}}{\iff}
+    \exists g\theta \in \mathcal{S} \times \{ 1, 1' \} \, s.t. \, g \theta \circ M_{i} = M_{j}
+
+:math:`\mathcal{S}` may not be index-two supergroup of :math:`\mathcal{D}` because the former ignores magmom configurations.
+Thus, we compute FSG via MSG as :math:`\mathcal{F} := \mathcal{M}  / \{ 1, 1' \}`.
+
+Procedure to detect MSG operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In actual implementation in :code:`spn_get_operations_with_site_tensors`, the following steps two, three, and four are performed at the same time.
+
+#. Compute SG :math:`\mathcal{S}` by just ignoring magmoms.
+#. Compute XSG :math:`\mathcal{D}` by checking :math:`g \circ M_{i} = M_{g \circ i}` one by one for :math:`g \in \mathcal{S}`.
+#. Compute MSG :math:`\mathcal{M}` by checking :math:`g \theta \circ M_{i} = M_{g \circ i}` one by one for :math:`g \theta \in \mathcal{S} \times \{ 1, 1' \}`.
+#. Compute FSG :math:`\mathcal{F}` by ignoring primes in :math:`\mathcal{M}`
+
+In :code:`spgat_get_symmetry_with_site_tensors`, :code:`sym_nonspin` corresponds to :math:`\mathcal{S}`.
+Then, :code:`spn_get_operations_with_site_tensors` computes :math:`\mathcal{M}` under the following actions:
+
+- :code:`tensor_rank=0`
+    - :code:`is_magnetic=true`: :math:`1' \circ m = -m, (\mathbf{R}, \mathbf{v}) \circ m = m`
+    - :code:`is_magnetic=false`: :math:`1' \circ m_{z} = m_{z}, (\mathbf{R}, \mathbf{v}) \circ m = m`
+- :code:`tensor_rank=1` (currently only support axial vector)
+    - :code:`is_magnetic=true`: :math:`1' \circ \mathbf{m} = -\mathbf{m}, (\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = (\mathrm{det} \mathbf{R}) \mathbf{R} \mathbf{m}`
+    - :code:`is_magnetic=false`: :math:`1' \circ \mathbf{m} = \mathbf{m}, (\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = (\mathrm{det} \mathbf{R}) \mathbf{R} \mathbf{m}`
+
+
+Procedure to standardize MSG setting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:code:`spglib.c:get_magnetic_dataset`
+
+#. Determine type of MSG
+    - When :math:`[\mathcal{F}:\mathcal{D}] = 1`
+        - :math:`[\mathcal{M}:\mathcal{F}] = 1` -> Type-I
+        - :math:`[\mathcal{M}:\mathcal{F}] = 2` -> Type-II
+    - When :math:`[\mathcal{F}:\mathcal{D}] = 2`
+        - Find a coset decomposition :math:`\mathcal{M} = \mathcal{D} \sqcup g \mathcal{D}`
+        - :math:`g` is not translation -> Type-III
+        - :math:`g` is translation -> Type-IV
+#. Choose reference setting
+    - Type-I, II, III -> Hall symbol of :math:`\mathcal{F}`
+    - Type-IV -> Hall symbol of :math:`\mathcal{D}`
+#. Compare :math:`\mathcal{M}` with MSGs in database after applying a transformation to the Hall symbol's setting
+#. Standardize cell
+
+Transformation of space group :math:`\mathcal{G}`
+-------------------------------------------------
+
+We denote a primitive lattice as :math:`L_{\mathrm{prim}}` and a conventional lattice as :math:`L_{\mathrm{conv}}`.
+Here the centering vectors correspond to :math:`L_{\mathrm{conv}} / L_{\mathrm{prim}}`.
+For example, trigonal space groups with hexagonal cell (obverse) give
+
+.. math::
+    L_{\mathrm{conv}} / L_{\mathrm{prim}} =
+    \left\{
+        (0, 0, 0),
+        (2/3, 1/3, 1/3),
+        (1/3, 2/3, 2/3)
+    \right\}.
+
+We write translation group formed by :math:`L_{\mathrm{prim}}` as :math:`\mathcal{T}_{\mathrm{prim}}`, and translation group formed by :math:`L_{\mathrm{conv}}` as :math:`\mathcal{T}_{\mathrm{conv}}`.
+Space group :math:`\mathcal{G}` can be written by finite factor group :math:`\mathcal{G} / \mathcal{T}_{\mathrm{conv}}` and the centerings:
+
+.. math::
+    \mathcal{G} / \mathcal{T}_{\mathrm{prim}}
+    =
+    \left\{
+        (\mathbf{I}, \mathbf{c}) (\mathbf{W}, \mathbf{w})
+        \mid
+        (\mathbf{W}, \mathbf{w}) \in \mathcal{G} / \mathcal{T}_{\mathrm{conv}},
+        \mathbf{c} \in L_{\mathrm{conv}} / L_{\mathrm{prim}}
+    \right\}
+
+
+Consider a transformation matrix :math:`\mathbf{P}` (corresponds to :code:`Spacegroup.bravais_lattice`) and origin shift :math:`\mathbf{p}` (corresponds to :code:`Spacegroup.origin_shift`).
+This transformation convert the factor group :math:`\mathcal{G} / \mathcal{T}_{\mathrm{conv}}` to
+
+.. math::
+    \left\{
+        (\mathbf{P}, \mathbf{p}) (\mathbf{W}, \mathbf{w}) (\mathbf{P}, \mathbf{p})^{-1}
+        \mid
+        (\mathbf{W}, \mathbf{w}) \in \mathcal{G} / \mathcal{T}_{\mathrm{conv}}
+    \right\}
+
+If the conventional lattice is properly chosen, each operation in :math:`\mathcal{G} / \mathcal{T}_{\mathrm{conv}}` has a unique linear part.
+Then, the above transformed factor group has the same order as :math:`\mathcal{G} / \mathcal{T}_{\mathrm{conv}}`.
+
+The centering vectors are transformed as
+
+.. math::
+    \left\{
+        \mathbf{P} (\mathbf{c} + \mathbf{n}) \, \mathrm{mod}\, 1
+        \mid
+        \mathbf{c} \in L_{\mathrm{conv}} / L_{\mathrm{prim}}, \mathbf{n} \in \mathbb{Z}^{3}
+    \right\}.
+
+When :math:`|\det \mathbf{P}| = 1`, the transformed centering vectors give the same conventional lattice.
+When :math:`|\det \mathbf{P}| > 1`, some centering vectors become duplicated.
+When :math:`|\det \mathbf{P}| < 1`, we need to additionally find lattice points.
+We can confirm the range of :math:`\mathbf{n}` to :math:`[0, d)^{3}`, where :math:`d` is maximum denominator of :math:`\mathbf{P}`.
+
+Transformation of magnetic space group :math:`\mathcal{M}`
+----------------------------------------------------------
+
+We need care for anti-translation.
+
+.. math::
+    \mathcal{M}
+        &= \mathcal{D} \sqcup g \mathcal{D} \\
+    \mathcal{M} / \mathcal{T}_{\mathrm{prim}}(\mathcal{M})
+        &=
+        \langle g \rangle
+        \cdot ( \mathcal{T}_{\mathrm{conv}}(\mathcal{M}) / \mathcal{T}_{\mathrm{prim}}(\mathcal{M}) )
+        \cdot ( \mathcal{M} / \langle g \rangle / \mathcal{T}_{\mathrm{conv}}(\mathcal{M}) ) \\
+        &=
+        \langle g \rangle
+        \cdot ( \mathcal{T}_{\mathrm{conv}}(\mathcal{M}) / \mathcal{T}_{\mathrm{prim}}(\mathcal{M}) )
+        \cdot ( \mathcal{D} / \mathcal{T}_{\mathrm{conv}}(\mathcal{M}) ) \\
+
+Each element in factor group :math:`\mathcal{D} / \mathcal{T}_{\mathrm{conv}}(\mathcal{D})` has a unique linear part.
+
+References
+----------
+
+[Lit14] D. B. Litvin, Magnetic Group Tables 1-, 2- and 3-Dimensional Magnetic Subperiodic Groups and Magnetic Space Groups (IUCr, 2014).
+
+[SC22] Harold T. Stokes and Branton J. Campbell, [ISO-MAG Table of Magnetic Space Groups](https://stokes.byu.edu/iso/magneticspacegroups.php).
+
+[GPKRC21] J. González-Platas, N. A. Katcho and J. Rodríguez-Carvajal, J. Appl. Crystallogr. 54, 1, 338-342 (2021).

--- a/python/_spglib.c
+++ b/python/_spglib.c
@@ -878,7 +878,7 @@ static PyObject * py_get_symmetry_with_site_tensors(PyObject *self,
   primitive_lattice = (double(*)[3])PyArray_DATA(py_primitive_lattice);
   num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
   tensor_rank = PyArray_NDIM(py_tensors) - 1;
-  if (tensor_rank == 0) {
+  if (tensor_rank == 0 || tensor_rank == 1) {
     spin_flips = (int*)PyArray_DATA(py_spin_flips);
   } else {
     spin_flips = NULL;

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -108,7 +108,7 @@ def get_symmetry(cell,
         'translations' : ndarray
             Translation (vector) parts of symmetry operations
             shape=(num_operations, 3), dtype='double'
-        'time_reversals': ndarray (exists when is_magnetic=True)
+        'time_reversals': ndarray (exists when the optional data is given)
             Time reversal part of magnetic symmetry operations.
             True indicates time reversal operation, and False indicates
             an ordinary operation.

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -108,6 +108,11 @@ def get_symmetry(cell,
         'translations' : ndarray
             Translation (vector) parts of symmetry operations
             shape=(num_operations, 3), dtype='double'
+        'time_reversals': ndarray (exists when is_magnetic=True)
+            Time reversal part of magnetic symmetry operations.
+            True indicates time reversal operation, and False indicates
+            an ordinary operation.
+            shape=(num_operations, ), dtype='bool_'
         'equivalent_atoms' : ndarray
             shape=(num_atoms, ), dtype='intc'
 
@@ -118,28 +123,30 @@ def get_symmetry(cell,
     if lattice is None:
         return None
 
-    # Get symmetry operations without on-site tensors (i.e. normal crystal)
-    dataset = get_symmetry_dataset(cell,
-                                   symprec=symprec,
-                                   angle_tolerance=angle_tolerance)
-    if dataset is None:
-        return None
-
     if magmoms is None:
+        # Get symmetry operations without on-site tensors (i.e. normal crystal)
+        dataset = get_symmetry_dataset(cell,
+                                       symprec=symprec,
+                                       angle_tolerance=angle_tolerance)
+        if dataset is None:
+            return None
+
         return {'rotations': dataset['rotations'],
                 'translations': dataset['translations'],
                 'equivalent_atoms': dataset['equivalent_atoms']}
     else:
-        rotations = dataset['rotations']
-        translations = dataset['translations']
+        max_size = len(positions) * 96
+        rotations = np.zeros((max_size, 3, 3), dtype='intc', order='C')
+        translations = np.zeros((max_size, 3), dtype='double', order='C')
         equivalent_atoms = np.zeros(len(magmoms), dtype='intc')
         primitive_lattice = np.zeros((3, 3), dtype='double', order='C')
         # (magmoms.ndim - 1) has to be equal to the rank of physical
         # tensors, e.g., ndim=1 for collinear, ndim=2 for non-collinear.
-        if magmoms.ndim == 1:
-            spin_flips = np.zeros(len(rotations), dtype='intc')
+        if magmoms.ndim == 1 or magmoms.ndim == 2:
+            spin_flips = np.zeros(max_size, dtype='intc')
         else:
             spin_flips = None
+
         num_sym = spg.symmetry_with_site_tensors(rotations,
                                                  translations,
                                                  equivalent_atoms,
@@ -157,10 +164,14 @@ def get_symmetry(cell,
         if num_sym == 0:
             return None
         else:
+            spin_flips = np.array(spin_flips[:num_sym], dtype='intc', order='C')
+            # True for time reversal operation, False for ordinary operation
+            time_reversals = (spin_flips == -1)
             return {'rotations': np.array(rotations[:num_sym],
                                           dtype='intc', order='C'),
                     'translations': np.array(translations[:num_sym],
                                              dtype='double', order='C'),
+                    'time_reversals': time_reversals,
                     'equivalent_atoms': equivalent_atoms,
                     'primitive_lattice': primitive_lattice}
 

--- a/python/test/test_site_tensors.py
+++ b/python/test/test_site_tensors.py
@@ -12,16 +12,94 @@ class TestGetOperationsWithSiteTensors(unittest.TestCase):
         magmoms = [[0, 0, 1]]
         self._cell_Ni = (lattice, positions, numbers, magmoms)
 
+        # CrCl2, adapted from Example 1 in Tutorial-MAXMAGN:
+        # http://webbdcrista1.ehu.es/cryst/tutorials/Tutorial-MAXMAGN.pdf
+        lattice = [
+            [6.8257, 0, 0],
+            [0, 6.2139, 0],
+            [0, 0, 3.4947],
+        ]
+        positions = [
+            # Cr (2a), site symmetry: < -x,-y,-z; -x,-y,z >
+            [0, 0, 0],
+            [0.5, 0.5, 0.5],
+            # Cl (4g)
+            [0.3586, 0.2893, 0],
+            [-0.3586, -0.2893, 0],
+            [-0.3586 + 0.5, 0.2893 + 0.5, 0.5],
+            [0.3586 + 0.5, -0.2893 + 0.5, 0.5],
+        ]
+        numbers = [1, 1, 2, 2, 2, 2]
+        self._cell_CrCl2 = (lattice, positions, numbers)
+
     def tearDown(self):
         pass
 
     def test_get_symmetry_non_collinear(self):
-        sym = get_symmetry(self._cell_Ni)
+        sym = get_symmetry(self._cell_Ni, is_magnetic=False)
         self.assertEqual(8, len(sym['rotations']))
         np.testing.assert_equal(sym['equivalent_atoms'], [0])
 
+        # type-II magnetic space group
+        sym2 = get_symmetry(self._cell_Ni)
+        self.assertEqual(16, len(sym2['rotations']))
+        self.assertEqual(16, len(sym2['translations']))
+        self.assertEqual(16, len(sym2['time_reversals']))
+
     def test_get_symmetry_vectors(self):
-        pass
+        # Space group without magnetic moments
+        # Pnnm (58), "-P 2 2n" (hall_number=275)
+        # Generators: -x,-y,-z; -x,-y,z; -x+1/2,y+1/2,-z+1/2
+        sym = get_symmetry(self._cell_CrCl2)
+        self.assertEqual(8, len(sym['rotations']))
+
+        # Type-I magnetic space group (MSG)
+        magmoms1 = [
+            [0, 0, 1],
+            [0, 0, -1],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+        sym1 = get_symmetry(self._cell_CrCl2 + (magmoms1, ))
+        self.assertTrue(np.allclose(sym1['time_reversals'], False))
+        self.assertTrue(np.allclose(sym1['rotations'], sym['rotations']))
+        self.assertTrue(np.allclose(sym1['translations'], sym['translations']))
+
+        # Type-II MSG
+        # 58.394, -P 2 2n 1'
+        magmoms2 = [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+        sym2 = get_symmetry(self._cell_CrCl2 + (magmoms2, ))
+        self.assertEqual(len(sym2['rotations']), 16)
+        self.assertEqual(np.sum(sym2['time_reversals']), 8)
+
+        sym2_gray = get_symmetry(self._cell_CrCl2 + (magmoms2, ), is_magnetic=False)
+        self.assertTrue(np.allclose(sym2_gray['rotations'], sym['rotations']))
+        self.assertTrue(np.allclose(sym2_gray['translations'], sym['translations']))
+
+        # Type-III MSG
+        # 58.397: -P 2 2n'
+        # Generators: -x,-y,-z; -x,-y,z; -x+1/2,y+1/2,-z+1/2'
+        magmoms3 = [
+            [0, 0, 1],
+            [0, 0, 1],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+        sym3 = get_symmetry(self._cell_CrCl2 + (magmoms3, ))
+        self.assertTrue(np.allclose(sym3['rotations'], sym['rotations']))
+        self.assertTrue(np.allclose(sym3['translations'], sym['translations']))
+        self.assertTrue(np.sum(sym3['time_reversals']), 4)
 
 
 if __name__ == '__main__':

--- a/python/test/test_site_tensors.py
+++ b/python/test/test_site_tensors.py
@@ -101,6 +101,21 @@ class TestGetOperationsWithSiteTensors(unittest.TestCase):
         self.assertTrue(np.allclose(sym3['translations'], sym['translations']))
         self.assertTrue(np.sum(sym3['time_reversals']), 4)
 
+        # Type-IV MSG
+        # https://github.com/spglib/spglib/issues/150
+        # -P 2 2 -> -P 2 2 1c' (47.254)
+        lat = [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+        pos = [[0., 0., 0.], [0., 0., 0.5]]
+        num = [0, 0]
+        magmom = [[0., 0., 1.], [0., 0., -1.]]
+        sym_gray = get_symmetry((lat, pos, num))
+        sym4 = get_symmetry((lat, pos, num, magmom))
+        self.assertTrue(np.allclose(sym_gray['rotations'], sym4['rotations']))
+        self.assertTrue(np.allclose(sym_gray['translations'], sym4['translations']))
+        self.assertTrue(sym4['time_reversals'].shape[0], 16)
+        self.assertTrue(np.sum(sym4['time_reversals']), 8)
+        self.assertTrue(np.allclose(sym4['primitive_lattice'], lat))
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(

--- a/python/test/test_site_tensors.py
+++ b/python/test/test_site_tensors.py
@@ -40,7 +40,7 @@ class TestGetOperationsWithSiteTensors(unittest.TestCase):
         self.assertEqual(8, len(sym['rotations']))
         np.testing.assert_equal(sym['equivalent_atoms'], [0])
 
-        # type-II magnetic space group
+        # type-III magnetic space group
         sym2 = get_symmetry(self._cell_Ni)
         self.assertEqual(16, len(sym2['rotations']))
         self.assertEqual(16, len(sym2['translations']))

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -474,7 +474,7 @@ static int is_equivalent_lattice(double tmat[3][3], const int allow_flip,
                                  SPGCONST double orig_lattice[3][3],
                                  const double symprec);
 
-/* Return spacegroup.number = 0 if failed */
+/* Return NULL if failed */
 Spacegroup *spa_search_spacegroup(const Primitive *primitive,
                                   const int hall_number, const double symprec,
                                   const double angle_tolerance) {
@@ -515,9 +515,9 @@ Spacegroup *spa_search_spacegroup(const Primitive *primitive,
     return spacegroup;
 }
 
-/* Return 0 if failed */
-int spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
-                                        const double symprec) {
+/* Return NULL if failed */
+Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
+                                                const double symprec) {
     int i, hall_number;
     Spacegroup *spacegroup;
     Primitive *primitive;
@@ -539,14 +539,7 @@ int spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
     prm_free_primitive(primitive);
     primitive = NULL;
 
-    if (spacegroup != NULL) {
-        hall_number = spacegroup->hall_number;
-        free(spacegroup);
-        spacegroup = NULL;
-        return hall_number;
-    } else {
-        return 0;
-    }
+    return spacegroup;
 }
 
 /* Return NULL if failed */

--- a/src/spacegroup.h
+++ b/src/spacegroup.h
@@ -69,8 +69,8 @@ typedef enum {
 Spacegroup *spa_search_spacegroup(const Primitive *primitive,
                                   const int hall_number, const double symprec,
                                   const double angle_tolerance);
-int spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
-                                        const double symprec);
+Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
+                                                const double symprec);
 Cell *spa_transform_to_primitive(int *mapping_table, const Cell *cell,
                                  SPGCONST double trans_mat[3][3],
                                  const Centering centering,

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -409,9 +409,11 @@ int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
     int i, hall_number;
     Symmetry *symmetry;
     Symmetry *prim_symmetry;
+    Spacegroup *spacegroup;
 
     symmetry = NULL;
     prim_symmetry = NULL;
+    spacegroup = NULL;
     hall_number = 0;
 
     if ((symmetry = sym_alloc_symmetry(max_size)) == NULL) {
@@ -431,16 +433,20 @@ int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
         return 0;
     }
 
-    hall_number = spa_search_spacegroup_with_symmetry(prim_symmetry, symprec);
+    spacegroup = spa_search_spacegroup_with_symmetry(prim_symmetry, symprec);
 
-    if (hall_number) {
+    if (spacegroup) {
+        hall_number = spacegroup->hall_number;
         spglib_error_code = SPGLIB_SUCCESS;
     } else {
+        hall_number = 0;
         spglib_error_code = SPGERR_SPACEGROUP_SEARCH_FAILED;
     }
 
     sym_free_symmetry(prim_symmetry);
     prim_symmetry = NULL;
+    free(spacegroup);
+    spacegroup = NULL;
 
     return hall_number;
 }

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -231,18 +231,16 @@ int spgat_get_symmetry_with_collinear_spin(
 
 /* Return 0 if failed */
 /* ``rotation`` and ``translation`` are used as input and output. */
-/* ``num_operations`` is the number of the symmetry operations of */
-/* input. */
 int spg_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int num_operations,
+    double primitive_lattice[3][3], int *spin_flips, const int max_size,
     SPGCONST double lattice[3][3], SPGCONST double position[][3],
     const int types[], const double *tensors, const int tensor_rank,
     const int num_atom, const int is_magnetic, const double symprec);
 
 int spgat_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int num_operations,
+    double primitive_lattice[3][3], int *spin_flips, const int max_size,
     SPGCONST double lattice[3][3], SPGCONST double position[][3],
     const int types[], const double *tensors, const int tensor_rank,
     const int num_atom, const int is_magnetic, const double symprec,

--- a/src/spin.h
+++ b/src/spin.h
@@ -39,10 +39,9 @@
 #include "mathfunc.h"
 #include "symmetry.h"
 
-Symmetry *spn_get_operations_with_site_tensors(
-    int equiv_atoms[], double prim_lattice[3][3], int *spin_flips,
-    const Symmetry *sym_nonspin, const Cell *cell, const double *tensors,
-    const int tensor_rank, const int is_magnetic, const double symprec,
-    const double angle_tolerance);
+MagneticSymmetry *spn_get_operations_with_site_tensors(
+    int equiv_atoms[], double prim_lattice[3][3], const Symmetry *sym_nonspin,
+    const Cell *cell, const double *tensors, const int tensor_rank,
+    const int is_magnetic, const double symprec, const double angle_tolerance);
 
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -738,7 +738,7 @@ static int test_spg_get_symmetry_with_site_tensors() {
     /* Find equivalent_atoms, primitive_lattice, spin_flips */
     size = spg_get_symmetry_with_site_tensors(
         rotation, translation, equivalent_atoms, primitive_lattice, spin_flips,
-        size, lattice, position, types, tensors, 1, num_atom, 1, 1e-5);
+        max_size, lattice, position, types, tensors, 1, num_atom, 1, 1e-5);
     assert(size == 8);
 
     printf("*** spg_get_symmetry_with_site_tensors (type-III) ***:\n");

--- a/src/test.c
+++ b/src/test.c
@@ -733,10 +733,6 @@ static int test_spg_get_symmetry_with_site_tensors() {
     translation = (double(*)[3])malloc(sizeof(double[3]) * max_size);
     spin_flips = (int *)malloc(sizeof(int *) * max_size);
 
-    /* Find rotations and translations */
-    size = spg_get_symmetry(rotation, translation, max_size, lattice, position,
-                            types, num_atom, 1e-5);
-
     /* Find equivalent_atoms, primitive_lattice, spin_flips */
     size = spg_get_symmetry_with_site_tensors(
         rotation, translation, equivalent_atoms, primitive_lattice, spin_flips,

--- a/src/test.c
+++ b/src/test.c
@@ -118,6 +118,8 @@ static int test_spg_get_hall_number_from_symmetry(void) {
             retval = 1;
         }
     }
+    /* Im-3m (229) */
+    assert(hall_number == 529);
 
     if (dataset) {
         spg_free_dataset(dataset);

--- a/src/test.c
+++ b/src/test.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -7,6 +8,7 @@
 
 static int test_spg_get_symmetry(void);
 static int test_spg_get_symmetry_with_collinear_spin(void);
+static int test_spg_get_symmetry_with_site_tensors(void);
 static int test_spg_get_multiplicity(void);
 static int test_spg_find_primitive_BCC(void);
 static int test_spg_find_primitive_corundum(void);
@@ -48,6 +50,7 @@ int main(void) {
                             test_spg_get_multiplicity,
                             test_spg_get_symmetry,
                             test_spg_get_symmetry_with_collinear_spin,
+                            test_spg_get_symmetry_with_site_tensors,
                             test_spg_get_international,
                             test_spg_get_schoenflies,
                             test_spg_get_spacegroup_type,
@@ -663,6 +666,103 @@ end:
     translation = NULL;
 
     return retval;
+}
+
+static int test_spg_get_symmetry_with_site_tensors() {
+    /* MAGNDATA #0.1: LaMnO3 */
+    /* BNS: Pn'ma' (62.448), MHall: -P 2ac' 2n' (509) */
+    int max_size, size, i, j;
+    double lattice[][3] = {{5.7461, 0, 0}, {0, 7.6637, 0}, {0, 0, 5.5333}};
+    /* clang-format off */
+    double position[][3] = {
+        {0.051300, 0.250000, 0.990500}, /* La */
+        {0.948700, 0.750000, 0.009500},
+        {0.551300, 0.250000, 0.509500},
+        {0.448700, 0.750000, 0.490500},
+        {0.000000, 0.000000, 0.500000}, /* Mn */
+        {0.000000, 0.500000, 0.500000},
+        {0.500000, 0.500000, 0.000000},
+        {0.500000, 0.000000, 0.000000},
+        {0.484900, 0.250000, 0.077700}, /* O1 */
+        {0.515100, 0.750000, 0.922300},
+        {0.984900, 0.250000, 0.422300},
+        {0.015100, 0.750000, 0.577700},
+        {0.308500, 0.040800, 0.722700}, /* O2 */
+        {0.691500, 0.540800, 0.277300},
+        {0.691500, 0.959200, 0.277300},
+        {0.308500, 0.459200, 0.722700},
+        {0.808500, 0.459200, 0.777300},
+        {0.191500, 0.959200, 0.222700},
+        {0.191500, 0.540800, 0.222700},
+        {0.808500, 0.040800, 0.777300},
+    };
+    int types[] = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+    double tensors[] = {
+        0, 0, 0, /* La */
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        3.87, 0, 0, /* Mn */
+        -3.87, 0, 0,
+        -3.87, 0, 0,
+        3.87, 0, 0,
+        0, 0, 0, /* O1 */
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0, /* O2 */
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
+    };
+    /* clang-format on */
+    int num_atom = 20;
+
+    int equivalent_atoms[20];
+    double primitive_lattice[3][3];
+    int(*rotation)[3][3];
+    double(*translation)[3];
+    int *spin_flips;
+
+    max_size = num_atom * 96;
+    rotation = (int(*)[3][3])malloc(sizeof(int[3][3]) * max_size);
+    translation = (double(*)[3])malloc(sizeof(double[3]) * max_size);
+    spin_flips = (int *)malloc(sizeof(int *) * max_size);
+
+    /* Find rotations and translations */
+    size = spg_get_symmetry(rotation, translation, max_size, lattice, position,
+                            types, num_atom, 1e-5);
+
+    /* Find equivalent_atoms, primitive_lattice, spin_flips */
+    size = spg_get_symmetry_with_site_tensors(
+        rotation, translation, equivalent_atoms, primitive_lattice, spin_flips,
+        size, lattice, position, types, tensors, 1, num_atom, 1, 1e-5);
+    assert(size == 8);
+
+    printf("*** spg_get_symmetry_with_site_tensors (type-III) ***:\n");
+    for (i = 0; i < size; i++) {
+        printf("--- %d ---\n", i + 1);
+        for (j = 0; j < 3; j++) {
+            printf("%2d %2d %2d\n", rotation[i][j][0], rotation[i][j][1],
+                   rotation[i][j][2]);
+        }
+        printf("%f %f %f\n", translation[i][0], translation[i][1],
+               translation[i][2]);
+        printf("%d\n", spin_flips[i]);
+    }
+
+    free(rotation);
+    rotation = NULL;
+    free(translation);
+    translation = NULL;
+    free(spin_flips);
+    spin_flips = NULL;
+
+    return 0;
 }
 
 static int test_spg_get_dataset(void) {


### PR DESCRIPTION
This is the second PR for supporting magnetic space groups (MSG) in spglib.

- In the python interface, `get_symmetry` with magmoms ≠ None, now returns the `time_reversals` array. True for time-reversal operations, and False for ordinary operations.
- The functions in `spin.c` are fixed and refactored. Now Type-II MSG, which has same-spatial-part operations like g1 and g1’, can be handled.
- Adding an implementation note for MSG detection (`doc/magnetic_spacegroup.rst`). But, I am not sure where to put it.
- Currently, `symprec` is used to compare magmoms. It will be more flexible to add a tolerance parameter for them like magmom_tolerance.

Related: https://github.com/spglib/spglib/issues/150