### PR TITLE
Reorder arguments of `spg_get_magnetic_spacegroup_type_from_symmetry`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -504,7 +504,7 @@ Return magnetic space-group type information from magnetic symmetry operations.
 ```c
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
     SPGCONST int rotations[][3][3], SPGCONST double translations[][3],
-    const int num_operations, SPGCONST int *time_reversals,
+    SPGCONST int *time_reversals, const int num_operations,
     SPGCONST double lattice[3][3], const double symprec
 );
 ```

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -573,8 +573,8 @@ int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
 
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
     SPGCONST int rotations[][3][3], SPGCONST double translations[][3],
-    SPGCONST int *time_reversals, SPGCONST double lattice[3][3],
-    const int num_operations, const double symprec) {
+    SPGCONST int *time_reversals, const int num_operations,
+    SPGCONST double lattice[3][3], const double symprec) {
     int i;
     MagneticSymmetry *magnetic_symmetry;
     MagneticDataset *msgdata;

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -312,8 +312,8 @@ int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
 
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
     SPGCONST int rotations[][3][3], SPGCONST double translations[][3],
-    SPGCONST int *time_reversals, SPGCONST double lattice[3][3],
-    const int num_operations, const double symprec);
+    SPGCONST int *time_reversals, const int num_operations,
+    SPGCONST double lattice[3][3], const double symprec);
 
 /* Return exact number of symmetry operations. This function may */
 /* be used in advance to allocate memory space for symmetry */

--- a/src/test.c
+++ b/src/test.c
@@ -755,7 +755,7 @@ static int test_spg_get_symmetry_with_site_tensors() {
     }
     SpglibMagneticSpacegroupType msgtype =
         spg_get_magnetic_spacegroup_type_from_symmetry(
-            rotation, translation, time_reversals, lattice, size, 1e-5);
+            rotation, translation, time_reversals, size, lattice, 1e-5);
     assert(msgtype.uni_number == 546);
 
     printf("*** spg_get_symmetry_with_site_tensors (type-III) ***:\n");


### PR DESCRIPTION
Change argument position of `num_operations` to the right behind
time_reversals, because it is more intuitive.