### PR TITLE
Implement spg_get_spacegroup_type_from_symmetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,11 @@ repos:
   hooks:
   - id: clang-format
     args: ["-i", "--style=file"]  # Use style set in .clang-format
-    files: ^src/
+    files: |
+      (?x)^(
+        ^src/.+\.(c|h)|
+        ^python/_spglib.c
+      )$
     exclude: src/msg_database.c  # Skip too large file to wait every time
   - id: clang-tidy
     files: ^src/

--- a/doc/api.md
+++ b/doc/api.md
@@ -327,6 +327,7 @@ group operations are stored in ``rotations`` and ``translations``.
 ### ``spg_get_spacegroup_type``
 
 **Changed at version 1.9.4: Some members are added and the member name 'setting' is changed to 'choice'.**
+**Changed at version 2.0: Add 'hall_number' member.**
 
 This function allows to directly access to the space-group-type
 database in spglib (spg_database.c). To specify the space group type
@@ -348,6 +349,7 @@ typedef struct {
     char international[32];
     char schoenflies[7];
     char hall_symbol[17];
+    int hall_number;
     char choice[6];
     char pointgroup_schoenflies[4];
     char pointgroup_international[6];
@@ -359,7 +361,15 @@ typedef struct {
 (api_spg_get_spacegroup_type_from_symmetry)=
 ### `spg_get_spacegroup_type_from_symmetry`
 
+**New at version 2.0**
+
 Return space-group type information from symmetry operations.
+This is the replacement of ``spg_get_hall_number_from_symmetry`` (deprecated at v2.0).
+
+This is expected to work well for the set of symmetry operations whose
+distortion is small. The aim of making this feature is to find
+space-group-type for the set of symmetry operations given by the other
+source than spglib.
 
 ```c
 SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
@@ -367,6 +377,13 @@ SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
     const int num_operations, SPGCONST double lattice[3][3], const double symprec
 );
 ```
+
+The parameter ``lattice`` is used as the distance measure for ``symprec``. If it
+is unknown,
+```
+lattice[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+```
+may be a good choice though ``symprec`` works under this ``lattice``.
 
 
 ## Magnetic symmetry
@@ -640,7 +657,8 @@ This function can be used to obtain all mesh grid points by setting
 ## Deprecated
 ### ``spg_get_hall_number_from_symmetry``
 
-**Deprecated. This function is replaced by {ref}`api_spg_get_spacegroup_type_from_symmetry`.**
+**Deprecated at version 2.0. This function is replaced by
+{ref}`api_spg_get_spacegroup_type_from_symmetry`.**
 
 Return one of ``hall_number`` corresponding to a space-group type of the given
 set of symmetry operations. When multiple ``hall_number`` exist for the

--- a/doc/python-spglib.md
+++ b/doc/python-spglib.md
@@ -442,7 +442,8 @@ When something wrong happened, ``None`` is returned.
 (py_method_get_spacegroup_type)=
 ### ``get_spacegroup_type``
 
-**New at version 1.9.4**
+- **New at version 1.9.4**
+- **`hall_number` member is added at version 2.0.**
 
 ```python
 spacegroup_type = get_spacegroup_type(hall_number)
@@ -462,6 +463,7 @@ international_full
 international
 schoenflies
 hall_symbol
+hall_number
 choice
 pointgroup_schoenflies
 pointgroup_international
@@ -478,11 +480,24 @@ Here ``spacegroup_type['international_short']`` is equivalent to
 
 When something wrong happened, ``None`` is returned.
 
+(py_method_get_spacegroup_type_from_symmetry)=
 ### ``get_spacegroup_type_from_symmetry``
 
-This replaces ``get_hall_number_from_symmetry``, but ``lattice`` is necessary.
+**New at version 2.0**
 
+```python
+spacegroup_type = get_spacegroup_type_from_symmetry(rotations, translations, lattice=None, symprec=1e-5)
+```
 
+Return space-group type information (see {ref}`py_method_get_spacegroup_type`)
+from symmetry operations. This is the replacement of
+``get_hall_number_from_symmetry`` (deprecated at v2.0).
+
+This is expected to work well for the set of symmetry operations whose
+distortion is small. The aim of making this feature is to find space-group-type
+for the set of symmetry operations given by the other source than spglib. The
+parameter ``lattice`` is used as the distance measure for ``symprec``. If this
+is not given, the cubic basis vector whose lengths are one is used.
 
 ## Methods (magnetic symmetry)
 
@@ -722,13 +737,15 @@ An example is shown below:
 ## Method (deprecated)
 ### ``get_hall_number_from_symmetry``
 
-**Deprecated.**
+**Deprecated at version 2.0. This function is replaced by
+{ref}`py_method_get_spacegroup_type_from_symmetry`.**
 
-Return one of ``hall_number`` corresponding to a space-group type of the given set of symmetry operations.
-When multiple ``hall_number`` exist for the space-group type, the smallest one (the first description of the space-group type in International Tables for Crystallography) is chosen.
-The definition of ``hall_number`` is found at
-{ref}`dataset_spg_get_dataset_spacegroup_type` and the corresponding
-space-group-type information is obtained through
+Return one of ``hall_number`` corresponding to a space-group type of the given
+set of symmetry operations. When multiple ``hall_number`` exist for the
+space-group type, the smallest one (the first description of the space-group
+type in International Tables for Crystallography) is chosen. The definition of
+``hall_number`` is found at {ref}`dataset_spg_get_dataset_spacegroup_type` and
+the corresponding space-group-type information is obtained through
 {ref}`py_method_get_spacegroup_type`.
 
 This is expected to work well for the set of symmetry operations whose

--- a/python/_spglib.c
+++ b/python/_spglib.c
@@ -34,9 +34,9 @@
 
 #include <Python.h>
 #include <assert.h>
-#include <stdio.h>
 #include <numpy/arrayobject.h>
 #include <spglib.h>
+#include <stdio.h>
 
 #if (PY_MAJOR_VERSION < 3) && (PY_MINOR_VERSION < 6)
 #define PYUNICODE_FROMSTRING PyString_FromString
@@ -44,1439 +44,1358 @@
 #define PYUNICODE_FROMSTRING PyUnicode_FromString
 #endif
 
-static PyObject * py_get_version(PyObject *self, PyObject *args);
-static PyObject * py_get_dataset(PyObject *self, PyObject *args);
-static PyObject * py_get_magnetic_dataset(PyObject *self, PyObject *args);
-static PyObject * py_get_spacegroup_type(PyObject *self, PyObject *args);
-static PyObject * py_get_magnetic_spacegroup_type(PyObject *self, PyObject *args);
-static PyObject * py_get_pointgroup(PyObject *self, PyObject *args);
-static PyObject * py_standardize_cell(PyObject *self, PyObject *args);
-static PyObject * py_refine_cell(PyObject *self, PyObject *args);
-static PyObject * py_get_symmetry(PyObject *self, PyObject *args);
-static PyObject *
-py_get_symmetry_with_collinear_spin(PyObject *self, PyObject *args);
-static PyObject *
-py_get_symmetry_with_site_tensors(PyObject *self, PyObject *args);
-static PyObject *
-py_get_hall_number_from_symmetry(PyObject *self, PyObject *args);
-static PyObject * py_find_primitive(PyObject *self, PyObject *args);
-static PyObject *
-py_get_grid_point_from_address(PyObject *self, PyObject *args);
-static PyObject * py_get_ir_reciprocal_mesh(PyObject *self, PyObject *args);
-static PyObject *
-py_get_stabilized_reciprocal_mesh(PyObject *self, PyObject *args);
-static PyObject *
-py_get_grid_points_by_rotations(PyObject *self, PyObject *args);
-static PyObject *
-py_get_BZ_grid_points_by_rotations(PyObject *self, PyObject *args);
-static PyObject * py_relocate_BZ_grid_address(PyObject *self, PyObject *args);
-static PyObject * py_get_symmetry_from_database(PyObject *self, PyObject *args);
-static PyObject * py_get_magnetic_symmetry_from_database(PyObject *self, PyObject *args);
-static PyObject * py_delaunay_reduce(PyObject *self, PyObject *args);
-static PyObject * py_niggli_reduce(PyObject *self, PyObject *args);
-static PyObject * py_get_error_message(PyObject *self, PyObject *args);
+static PyObject *py_get_version(PyObject *self, PyObject *args);
+static PyObject *py_get_dataset(PyObject *self, PyObject *args);
+static PyObject *py_get_magnetic_dataset(PyObject *self, PyObject *args);
+static PyObject *py_get_spacegroup_type(PyObject *self, PyObject *args);
+static PyObject *py_get_spacegroup_type_from_symmetry(PyObject *self,
+                                                      PyObject *args);
+static PyObject *py_get_magnetic_spacegroup_type(PyObject *self,
+                                                 PyObject *args);
+static PyObject *py_get_pointgroup(PyObject *self, PyObject *args);
+static PyObject *py_standardize_cell(PyObject *self, PyObject *args);
+static PyObject *py_refine_cell(PyObject *self, PyObject *args);
+static PyObject *py_get_symmetry(PyObject *self, PyObject *args);
+static PyObject *py_get_symmetry_with_collinear_spin(PyObject *self,
+                                                     PyObject *args);
+static PyObject *py_get_symmetry_with_site_tensors(PyObject *self,
+                                                   PyObject *args);
+static PyObject *py_find_primitive(PyObject *self, PyObject *args);
+static PyObject *py_get_grid_point_from_address(PyObject *self, PyObject *args);
+static PyObject *py_get_ir_reciprocal_mesh(PyObject *self, PyObject *args);
+static PyObject *py_get_stabilized_reciprocal_mesh(PyObject *self,
+                                                   PyObject *args);
+static PyObject *py_get_grid_points_by_rotations(PyObject *self,
+                                                 PyObject *args);
+static PyObject *py_get_BZ_grid_points_by_rotations(PyObject *self,
+                                                    PyObject *args);
+static PyObject *py_relocate_BZ_grid_address(PyObject *self, PyObject *args);
+static PyObject *py_get_symmetry_from_database(PyObject *self, PyObject *args);
+static PyObject *py_get_magnetic_symmetry_from_database(PyObject *self,
+                                                        PyObject *args);
+static PyObject *py_delaunay_reduce(PyObject *self, PyObject *args);
+static PyObject *py_niggli_reduce(PyObject *self, PyObject *args);
+static PyObject *py_get_hall_number_from_symmetry(PyObject *self,
+                                                  PyObject *args);
+static PyObject *py_get_error_message(PyObject *self, PyObject *args);
 
 struct module_state {
-  PyObject *error;
+    PyObject *error;
 };
 
 #if PY_MAJOR_VERSION >= 3
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
 #else
 #define GETSTATE(m) (&_state)
 static struct module_state _state;
 #endif
 
-static PyObject *
-error_out(PyObject *m) {
-  struct module_state *st = GETSTATE(m);
-  PyErr_SetString(st->error, "something bad happened");
-  return NULL;
+static PyObject *error_out(PyObject *m) {
+    struct module_state *st = GETSTATE(m);
+    PyErr_SetString(st->error, "something bad happened");
+    return NULL;
 }
 
 static PyMethodDef _spglib_methods[] = {
-  {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
-  {"version", py_get_version, METH_VARARGS, "Spglib version"},
-  {"dataset", py_get_dataset, METH_VARARGS, "Dataset for crystal symmetry"},
-  {"magnetic_dataset", py_get_magnetic_dataset, METH_VARARGS, "Magnetic dataset for crystal symmetry"},
-  {"spacegroup_type", py_get_spacegroup_type, METH_VARARGS, "Space-group type symbols"},
-  {"magnetic_spacegroup_type", py_get_magnetic_spacegroup_type, METH_VARARGS, "Magnetic space-group type symbols"},
-  {"symmetry_from_database", py_get_symmetry_from_database, METH_VARARGS, "Get symmetry operations from database"},
-  {"magnetic_symmetry_from_database", py_get_magnetic_symmetry_from_database, METH_VARARGS,
-   "Get magnetic symmetry operations from database"},
-  {"pointgroup", py_get_pointgroup, METH_VARARGS,
-   "International symbol of pointgroup"},
-  {"standardize_cell", py_standardize_cell, METH_VARARGS, "Standardize cell"},
-  {"refine_cell", py_refine_cell, METH_VARARGS, "Refine cell"},
-  {"symmetry", py_get_symmetry, METH_VARARGS, "Symmetry operations"},
-  {"symmetry_with_collinear_spin", py_get_symmetry_with_collinear_spin,
-   METH_VARARGS, "Symmetry operations with collinear spin magnetic moments"},
-  {"symmetry_with_site_tensors", py_get_symmetry_with_site_tensors,
-   METH_VARARGS, "Symmetry operations with site vectors"},
-  {"hall_number_from_symmetry", py_get_hall_number_from_symmetry,
-   METH_VARARGS, "Space group type is searched from symmetry operations."},
-  {"primitive", py_find_primitive, METH_VARARGS,
-   "Find primitive cell in the input cell"},
-  {"grid_point_from_address", py_get_grid_point_from_address, METH_VARARGS,
-   "Translate grid address to grid point index"},
-  {"ir_reciprocal_mesh", py_get_ir_reciprocal_mesh, METH_VARARGS,
-   "Reciprocal mesh points with map"},
-  {"stabilized_reciprocal_mesh", py_get_stabilized_reciprocal_mesh, METH_VARARGS,
-   "Reciprocal mesh points with map"},
-  {"grid_points_by_rotations", py_get_grid_points_by_rotations, METH_VARARGS,
-   "Rotated grid points are returned"},
-  {"BZ_grid_points_by_rotations", py_get_BZ_grid_points_by_rotations, METH_VARARGS,
-   "Rotated grid points in BZ are returned"},
-  {"BZ_grid_address", py_relocate_BZ_grid_address, METH_VARARGS,
-   "Relocate grid addresses inside Brillouin zone"},
-  {"delaunay_reduce", py_delaunay_reduce, METH_VARARGS, "Delaunay reduction"},
-  {"niggli_reduce", py_niggli_reduce, METH_VARARGS, "Niggli reduction"},
-  {"error_message", py_get_error_message, METH_VARARGS, "Error message"},
+    {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
+    {"version", py_get_version, METH_VARARGS, "Spglib version"},
+    {"dataset", py_get_dataset, METH_VARARGS, "Dataset for crystal symmetry"},
+    {"magnetic_dataset", py_get_magnetic_dataset, METH_VARARGS,
+     "Magnetic dataset for crystal symmetry"},
+    {"spacegroup_type", py_get_spacegroup_type, METH_VARARGS,
+     "Space-group type symbols"},
+    {"spacegroup_type_from_symmetry", py_get_spacegroup_type_from_symmetry,
+     METH_VARARGS, "Space-group type symbols from symmetry operations"},
+    {"magnetic_spacegroup_type", py_get_magnetic_spacegroup_type, METH_VARARGS,
+     "Magnetic space-group type symbols"},
+    {"symmetry_from_database", py_get_symmetry_from_database, METH_VARARGS,
+     "Get symmetry operations from database"},
+    {"magnetic_symmetry_from_database", py_get_magnetic_symmetry_from_database,
+     METH_VARARGS, "Get magnetic symmetry operations from database"},
+    {"pointgroup", py_get_pointgroup, METH_VARARGS,
+     "International symbol of pointgroup"},
+    {"standardize_cell", py_standardize_cell, METH_VARARGS, "Standardize cell"},
+    {"refine_cell", py_refine_cell, METH_VARARGS, "Refine cell"},
+    {"symmetry", py_get_symmetry, METH_VARARGS, "Symmetry operations"},
+    {"symmetry_with_collinear_spin", py_get_symmetry_with_collinear_spin,
+     METH_VARARGS, "Symmetry operations with collinear spin magnetic moments"},
+    {"symmetry_with_site_tensors", py_get_symmetry_with_site_tensors,
+     METH_VARARGS, "Symmetry operations with site vectors"},
+    {"primitive", py_find_primitive, METH_VARARGS,
+     "Find primitive cell in the input cell"},
+    {"grid_point_from_address", py_get_grid_point_from_address, METH_VARARGS,
+     "Translate grid address to grid point index"},
+    {"ir_reciprocal_mesh", py_get_ir_reciprocal_mesh, METH_VARARGS,
+     "Reciprocal mesh points with map"},
+    {"stabilized_reciprocal_mesh", py_get_stabilized_reciprocal_mesh,
+     METH_VARARGS, "Reciprocal mesh points with map"},
+    {"grid_points_by_rotations", py_get_grid_points_by_rotations, METH_VARARGS,
+     "Rotated grid points are returned"},
+    {"BZ_grid_points_by_rotations", py_get_BZ_grid_points_by_rotations,
+     METH_VARARGS, "Rotated grid points in BZ are returned"},
+    {"BZ_grid_address", py_relocate_BZ_grid_address, METH_VARARGS,
+     "Relocate grid addresses inside Brillouin zone"},
+    {"delaunay_reduce", py_delaunay_reduce, METH_VARARGS, "Delaunay reduction"},
+    {"niggli_reduce", py_niggli_reduce, METH_VARARGS, "Niggli reduction"},
+    {"hall_number_from_symmetry", py_get_hall_number_from_symmetry,
+     METH_VARARGS, "Space group type is searched from symmetry operations."},
+    {"error_message", py_get_error_message, METH_VARARGS, "Error message"},
 
-  {NULL, NULL, 0, NULL}
-};
+    {NULL, NULL, 0, NULL}};
 
 #if PY_MAJOR_VERSION >= 3
 
 static int _spglib_traverse(PyObject *m, visitproc visit, void *arg) {
-  Py_VISIT(GETSTATE(m)->error);
-  return 0;
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
 }
 
 static int _spglib_clear(PyObject *m) {
-  Py_CLEAR(GETSTATE(m)->error);
-  return 0;
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
 }
 
-static struct PyModuleDef moduledef = {
-  PyModuleDef_HEAD_INIT,
-  "_spglib",
-  NULL,
-  sizeof(struct module_state),
-  _spglib_methods,
-  NULL,
-  _spglib_traverse,
-  _spglib_clear,
-  NULL
-};
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
+                                       "_spglib",
+                                       NULL,
+                                       sizeof(struct module_state),
+                                       _spglib_methods,
+                                       NULL,
+                                       _spglib_traverse,
+                                       _spglib_clear,
+                                       NULL};
 
 #define INITERROR return NULL
 
-PyObject *
-PyInit__spglib(void)
-
+PyObject *PyInit__spglib(void)
 #else
 #define INITERROR return
 
-  void
-  init_spglib(void)
+void init_spglib(void)
 #endif
 {
-  struct module_state *st;
+    struct module_state *st;
 #if PY_MAJOR_VERSION >= 3
-  PyObject *module = PyModule_Create(&moduledef);
+    PyObject *module = PyModule_Create(&moduledef);
 #else
-  PyObject *module = Py_InitModule("_spglib", _spglib_methods);
+    PyObject *module = Py_InitModule("_spglib", _spglib_methods);
 #endif
 
-  if (module == NULL)
-    INITERROR;
+    if (module == NULL) INITERROR;
 
-  st = GETSTATE(module);
+    st = GETSTATE(module);
 
-  st->error = PyErr_NewException("_spglib.Error", NULL, NULL);
-  if (st->error == NULL) {
-    Py_DECREF(module);
-    INITERROR;
-  }
+    st->error = PyErr_NewException("_spglib.Error", NULL, NULL);
+    if (st->error == NULL) {
+        Py_DECREF(module);
+        INITERROR;
+    }
 
 #if PY_MAJOR_VERSION >= 3
-  return module;
+    return module;
 #endif
 }
 
-static PyObject * py_get_version(PyObject *self, PyObject *args)
-{
-  PyObject *array;
-  int i;
-  int version[3];
+static PyObject *py_get_version(PyObject *self, PyObject *args) {
+    PyObject *array;
+    int i;
+    int version[3];
 
-  if (!PyArg_ParseTuple(args, "")) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
 
-  version[0] = spg_get_major_version();
-  version[1] = spg_get_minor_version();
-  version[2] = spg_get_micro_version();
+    version[0] = spg_get_major_version();
+    version[1] = spg_get_minor_version();
+    version[2] = spg_get_micro_version();
 
-  array = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    PyList_SetItem(array, i, PyLong_FromLong((long)version[i]));
-  }
+    array = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        PyList_SetItem(array, i, PyLong_FromLong((long)version[i]));
+    }
 
-  return array;
+    return array;
 }
 
-static PyObject * py_get_dataset(PyObject *self, PyObject *args)
-{
-  int hall_number;
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_atom_types;
+static PyObject *py_get_dataset(PyObject *self, PyObject *args) {
+    int hall_number;
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_atom_types;
 
-  PyObject *array, *vec, *mat, *rot, *trans, *wyckoffs, *equiv_atoms;
-  PyObject *crystallographic_orbits;
-  PyObject *site_symmetry_symbols, *primitive_lattice, *mapping_to_primitive;
-  PyObject *std_lattice, *std_types, *std_positions, *std_mapping_to_primitive;
+    PyObject *array, *vec, *mat, *rot, *trans, *wyckoffs, *equiv_atoms;
+    PyObject *crystallographic_orbits;
+    PyObject *site_symmetry_symbols, *primitive_lattice, *mapping_to_primitive;
+    PyObject *std_lattice, *std_types, *std_positions,
+        *std_mapping_to_primitive;
 
-  PyObject *std_rotation;
+    PyObject *std_rotation;
 
-  int i, j, k, n;
-  double (*lat)[3];
-  double (*pos)[3];
-  int num_atom, len_list;
-  int* typat;
-  SpglibDataset *dataset;
+    int i, j, k, n;
+    double(*lat)[3];
+    double(*pos)[3];
+    int num_atom, len_list;
+    int *typat;
+    SpglibDataset *dataset;
 
-  if (!PyArg_ParseTuple(args, "OOOidd",
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &hall_number,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
-
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  typat = (int*)PyArray_DATA(py_atom_types);
-
-  if ((dataset = spgat_get_dataset_with_hall_number(lat,
-                                                    pos,
-                                                    typat,
-                                                    num_atom,
-                                                    hall_number,
-                                                    symprec,
-                                                    angle_tolerance)) == NULL) {
-    Py_RETURN_NONE;
-  }
-
-  len_list = 21;
-  array = PyList_New(len_list);
-  n = 0;
-
-  /* Space group number, international symbol, hall symbol */
-  PyList_SetItem(array, n, PyLong_FromLong((long) dataset->spacegroup_number));
-  n++;
-  PyList_SetItem(array, n, PyLong_FromLong((long) dataset->hall_number));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->international_symbol));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->hall_symbol));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->choice));
-  n++;
-
-  /* Transformation matrix */
-  mat = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->transformation_matrix[i][j]));
+    if (!PyArg_ParseTuple(args, "OOOidd", &py_lattice, &py_positions,
+                          &py_atom_types, &hall_number, &symprec,
+                          &angle_tolerance)) {
+        return NULL;
     }
-    PyList_SetItem(mat, i, vec);
-  }
-  PyList_SetItem(array, n, mat);
-  n++;
 
-  /* Origin shift */
-  vec = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    PyList_SetItem(vec, i, PyFloat_FromDouble(dataset->origin_shift[i]));
-  }
-  PyList_SetItem(array, n, vec);
-  n++;
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    typat = (int *)PyArray_DATA(py_atom_types);
 
-  /* Rotation matrices */
-  rot = PyList_New(dataset->n_operations);
-  for (i = 0; i < dataset->n_operations; i++) {
+    if ((dataset = spgat_get_dataset_with_hall_number(
+             lat, pos, typat, num_atom, hall_number, symprec,
+             angle_tolerance)) == NULL) {
+        Py_RETURN_NONE;
+    }
+
+    len_list = 21;
+    array = PyList_New(len_list);
+    n = 0;
+
+    /* Space group number, international symbol, hall symbol */
+    PyList_SetItem(array, n, PyLong_FromLong((long)dataset->spacegroup_number));
+    n++;
+    PyList_SetItem(array, n, PyLong_FromLong((long)dataset->hall_number));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(dataset->international_symbol));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->hall_symbol));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->choice));
+    n++;
+
+    /* Transformation matrix */
     mat = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      vec = PyList_New(3);
-      for (k = 0; k < 3; k++) {
-        PyList_SetItem(vec, k, PyLong_FromLong((long) dataset->rotations[i][j][k]));
-      }
-      PyList_SetItem(mat, j, vec);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j,
+                PyFloat_FromDouble(dataset->transformation_matrix[i][j]));
+        }
+        PyList_SetItem(mat, i, vec);
     }
-    PyList_SetItem(rot, i, mat);
-  }
-  PyList_SetItem(array, n, rot);
-  n++;
+    PyList_SetItem(array, n, mat);
+    n++;
 
-  /* Translation vectors */
-  trans = PyList_New(dataset->n_operations);
-  for (i = 0; i < dataset->n_operations; i++) {
+    /* Origin shift */
     vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->translations[i][j]));
+    for (i = 0; i < 3; i++) {
+        PyList_SetItem(vec, i, PyFloat_FromDouble(dataset->origin_shift[i]));
     }
-    PyList_SetItem(trans, i, vec);
-  }
-  PyList_SetItem(array, n, trans);
-  n++;
+    PyList_SetItem(array, n, vec);
+    n++;
 
-  /* Wyckoff letters, Equivalent atoms */
-  wyckoffs = PyList_New(dataset->n_atoms);
-  site_symmetry_symbols = PyList_New(dataset->n_atoms);
-  crystallographic_orbits = PyList_New(dataset->n_atoms);
-  equiv_atoms = PyList_New(dataset->n_atoms);
-  mapping_to_primitive = PyList_New(dataset->n_atoms);
-  for (i = 0; i < dataset->n_atoms; i++) {
-    PyList_SetItem(wyckoffs, i,
-                   PyLong_FromLong((long) dataset->wyckoffs[i]));
-    PyList_SetItem(site_symmetry_symbols, i,
-                   PYUNICODE_FROMSTRING(dataset->site_symmetry_symbols[i]));
-    PyList_SetItem(equiv_atoms, i,
-                   PyLong_FromLong((long) dataset->equivalent_atoms[i]));
-    PyList_SetItem(crystallographic_orbits, i,
-                   PyLong_FromLong((long) dataset->crystallographic_orbits[i]));
-    PyList_SetItem(mapping_to_primitive, i,
-                   PyLong_FromLong((long) dataset->mapping_to_primitive[i]));
-  }
-  PyList_SetItem(array, n, wyckoffs);
-  n++;
-  PyList_SetItem(array, n, site_symmetry_symbols);
-  n++;
-  PyList_SetItem(array, n, crystallographic_orbits);
-  n++;
-  PyList_SetItem(array, n, equiv_atoms);
-  n++;
-
-  primitive_lattice = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->primitive_lattice[i][j]));
+    /* Rotation matrices */
+    rot = PyList_New(dataset->n_operations);
+    for (i = 0; i < dataset->n_operations; i++) {
+        mat = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            vec = PyList_New(3);
+            for (k = 0; k < 3; k++) {
+                PyList_SetItem(
+                    vec, k, PyLong_FromLong((long)dataset->rotations[i][j][k]));
+            }
+            PyList_SetItem(mat, j, vec);
+        }
+        PyList_SetItem(rot, i, mat);
     }
-    PyList_SetItem(primitive_lattice, i, vec);
-  }
-  PyList_SetItem(array, n, primitive_lattice);
-  n++;
+    PyList_SetItem(array, n, rot);
+    n++;
 
-  PyList_SetItem(array, n, mapping_to_primitive);
-  n++;
-
-  std_lattice = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->std_lattice[i][j]));
+    /* Translation vectors */
+    trans = PyList_New(dataset->n_operations);
+    for (i = 0; i < dataset->n_operations; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->translations[i][j]));
+        }
+        PyList_SetItem(trans, i, vec);
     }
-    PyList_SetItem(std_lattice, i, vec);
-  }
-  PyList_SetItem(array, n, std_lattice);
-  n++;
+    PyList_SetItem(array, n, trans);
+    n++;
 
-  /* Standardized unit cell */
-  std_types = PyList_New(dataset->n_std_atoms);
-  std_positions = PyList_New(dataset->n_std_atoms);
-  std_mapping_to_primitive = PyList_New(dataset->n_std_atoms);
-  for (i = 0; i < dataset->n_std_atoms; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->std_positions[i][j]));
+    /* Wyckoff letters, Equivalent atoms */
+    wyckoffs = PyList_New(dataset->n_atoms);
+    site_symmetry_symbols = PyList_New(dataset->n_atoms);
+    crystallographic_orbits = PyList_New(dataset->n_atoms);
+    equiv_atoms = PyList_New(dataset->n_atoms);
+    mapping_to_primitive = PyList_New(dataset->n_atoms);
+    for (i = 0; i < dataset->n_atoms; i++) {
+        PyList_SetItem(wyckoffs, i,
+                       PyLong_FromLong((long)dataset->wyckoffs[i]));
+        PyList_SetItem(site_symmetry_symbols, i,
+                       PYUNICODE_FROMSTRING(dataset->site_symmetry_symbols[i]));
+        PyList_SetItem(equiv_atoms, i,
+                       PyLong_FromLong((long)dataset->equivalent_atoms[i]));
+        PyList_SetItem(
+            crystallographic_orbits, i,
+            PyLong_FromLong((long)dataset->crystallographic_orbits[i]));
+        PyList_SetItem(mapping_to_primitive, i,
+                       PyLong_FromLong((long)dataset->mapping_to_primitive[i]));
     }
-    PyList_SetItem(std_types, i, PyLong_FromLong((long) dataset->std_types[i]));
-    PyList_SetItem(std_positions, i, vec);
-    PyList_SetItem(std_mapping_to_primitive, i,
-                   PyLong_FromLong((long) dataset->std_mapping_to_primitive[i]));
-  }
-  PyList_SetItem(array, n, std_types);
-  n++;
-  PyList_SetItem(array, n, std_positions);
-  n++;
+    PyList_SetItem(array, n, wyckoffs);
+    n++;
+    PyList_SetItem(array, n, site_symmetry_symbols);
+    n++;
+    PyList_SetItem(array, n, crystallographic_orbits);
+    n++;
+    PyList_SetItem(array, n, equiv_atoms);
+    n++;
 
-  std_rotation = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j,
-                     PyFloat_FromDouble(dataset->std_rotation_matrix[i][j]));
+    primitive_lattice = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j, PyFloat_FromDouble(dataset->primitive_lattice[i][j]));
+        }
+        PyList_SetItem(primitive_lattice, i, vec);
     }
-    PyList_SetItem(std_rotation, i, vec);
-  }
-  PyList_SetItem(array, n, std_rotation);
-  n++;
+    PyList_SetItem(array, n, primitive_lattice);
+    n++;
 
-  PyList_SetItem(array, n, std_mapping_to_primitive);
-  n++;
+    PyList_SetItem(array, n, mapping_to_primitive);
+    n++;
 
-  /* Point group */
-  /* PyList_SetItem(array, n, PyLong_FromLong((long) dataset->pointgroup_number)); */
-  /* n++; */
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->pointgroup_symbol));
-  n++;
+    std_lattice = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->std_lattice[i][j]));
+        }
+        PyList_SetItem(std_lattice, i, vec);
+    }
+    PyList_SetItem(array, n, std_lattice);
+    n++;
 
-  assert(n == len_list);
+    /* Standardized unit cell */
+    std_types = PyList_New(dataset->n_std_atoms);
+    std_positions = PyList_New(dataset->n_std_atoms);
+    std_mapping_to_primitive = PyList_New(dataset->n_std_atoms);
+    for (i = 0; i < dataset->n_std_atoms; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->std_positions[i][j]));
+        }
+        PyList_SetItem(std_types, i,
+                       PyLong_FromLong((long)dataset->std_types[i]));
+        PyList_SetItem(std_positions, i, vec);
+        PyList_SetItem(
+            std_mapping_to_primitive, i,
+            PyLong_FromLong((long)dataset->std_mapping_to_primitive[i]));
+    }
+    PyList_SetItem(array, n, std_types);
+    n++;
+    PyList_SetItem(array, n, std_positions);
+    n++;
 
-  spg_free_dataset(dataset);
+    std_rotation = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j, PyFloat_FromDouble(dataset->std_rotation_matrix[i][j]));
+        }
+        PyList_SetItem(std_rotation, i, vec);
+    }
+    PyList_SetItem(array, n, std_rotation);
+    n++;
 
-  return array;
+    PyList_SetItem(array, n, std_mapping_to_primitive);
+    n++;
+
+    /* Point group */
+    /* PyList_SetItem(array, n, PyLong_FromLong((long)
+     * dataset->pointgroup_number)); */
+    /* n++; */
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(dataset->pointgroup_symbol));
+    n++;
+
+    assert(n == len_list);
+
+    spg_free_dataset(dataset);
+
+    return array;
 }
 
 static PyObject *py_get_magnetic_dataset(PyObject *self, PyObject *args) {
-  int tensor_rank, is_axial;
-  double symprec, angle_tolerance, mag_symprec;
-  PyArrayObject *py_lattice, *py_positions, *py_atom_types, *py_magmoms;
+    int tensor_rank, is_axial;
+    double symprec, angle_tolerance, mag_symprec;
+    PyArrayObject *py_lattice, *py_positions, *py_atom_types, *py_magmoms;
 
-  int num_atom;
-  double (*lat)[3];
-  double (*pos)[3];
-  int *typeat;
-  double *tensors;
-  SpglibMagneticDataset *dataset;
+    int num_atom;
+    double(*lat)[3];
+    double(*pos)[3];
+    int *typeat;
+    double *tensors;
+    SpglibMagneticDataset *dataset;
 
-  PyObject *array, *rot, *trans, *timerev, *equiv_atoms, *mat, *vec;
-  PyObject *std_lattice, *std_types, *std_positions, *std_tensors;
-  PyObject *std_rotation;
-  PyObject *primitive_lattice;
-  int len_list, n, i, j, k, n_tensors;
+    PyObject *array, *rot, *trans, *timerev, *equiv_atoms, *mat, *vec;
+    PyObject *std_lattice, *std_types, *std_positions, *std_tensors;
+    PyObject *std_rotation;
+    PyObject *primitive_lattice;
+    int len_list, n, i, j, k, n_tensors;
 
-  if (!PyArg_ParseTuple(args, "OOOOiiddd",
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &py_magmoms,
-                        &tensor_rank,
-                        &is_axial,
-                        &symprec,
-                        &angle_tolerance,
-                        &mag_symprec)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOOOiiddd", &py_lattice, &py_positions,
+                          &py_atom_types, &py_magmoms, &tensor_rank, &is_axial,
+                          &symprec, &angle_tolerance, &mag_symprec)) {
+        return NULL;
+    }
 
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  typeat = (int *)PyArray_DATA(py_atom_types);
-  tensors = (double *)PyArray_DATA(py_magmoms);
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    typeat = (int *)PyArray_DATA(py_atom_types);
+    tensors = (double *)PyArray_DATA(py_magmoms);
 
-  if ((dataset = spgms_get_magnetic_dataset(
-            lat, pos, typeat, tensors, tensor_rank, num_atom, is_axial,
-            symprec, angle_tolerance, mag_symprec)) ==
-      NULL) {
-    Py_RETURN_NONE;
-  }
+    if ((dataset = spgms_get_magnetic_dataset(
+             lat, pos, typeat, tensors, tensor_rank, num_atom, is_axial,
+             symprec, angle_tolerance, mag_symprec)) == NULL) {
+        Py_RETURN_NONE;
+    }
 
-  len_list = 19;
-  array = PyList_New(len_list);
-  n = 0;
+    len_list = 19;
+    array = PyList_New(len_list);
+    n = 0;
 
-  /* Magnetic space-group type */
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->uni_number));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->msg_type));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->hall_number));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->tensor_rank));
+    /* Magnetic space-group type */
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->uni_number));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->msg_type));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->hall_number));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->tensor_rank));
 
-  /* Magnetic symmetry operations */
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_operations));
+    /* Magnetic symmetry operations */
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_operations));
 
-  /* Rotation */
-  rot = PyList_New(dataset->n_operations);
-  for (i = 0; i < dataset->n_operations; i++) {
+    /* Rotation */
+    rot = PyList_New(dataset->n_operations);
+    for (i = 0; i < dataset->n_operations; i++) {
+        mat = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            vec = PyList_New(3);
+            for (k = 0; k < 3; k++) {
+                PyList_SetItem(
+                    vec, k, PyLong_FromLong((long)dataset->rotations[i][j][k]));
+            }
+            PyList_SetItem(mat, j, vec);
+        }
+        PyList_SetItem(rot, i, mat);
+    }
+    PyList_SetItem(array, n++, rot);
+
+    /* Translation vectors */
+    trans = PyList_New(dataset->n_operations);
+    for (i = 0; i < dataset->n_operations; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->translations[i][j]));
+        }
+        PyList_SetItem(trans, i, vec);
+    }
+    PyList_SetItem(array, n++, trans);
+
+    /* Time reversals */
+    timerev = PyList_New(dataset->n_operations);
+    for (i = 0; i < dataset->n_operations; i++) {
+        PyList_SetItem(timerev, i,
+                       PyLong_FromLong((long)dataset->time_reversals[i]));
+    }
+    PyList_SetItem(array, n++, timerev);
+
+    /* Equivalent atoms */
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_atoms));
+    equiv_atoms = PyList_New(dataset->n_atoms);
+    for (i = 0; i < dataset->n_atoms; i++) {
+        PyList_SetItem(equiv_atoms, i,
+                       PyLong_FromLong((long)dataset->equivalent_atoms[i]));
+    }
+    PyList_SetItem(array, n++, equiv_atoms);
+
+    /* Transformation matrix to standardized setting */
     mat = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      vec = PyList_New(3);
-      for (k = 0; k < 3; k++) {
-        PyList_SetItem(vec, k, PyLong_FromLong((long) dataset->rotations[i][j][k]));
-      }
-      PyList_SetItem(mat, j, vec);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j,
+                PyFloat_FromDouble(dataset->transformation_matrix[i][j]));
+        }
+        PyList_SetItem(mat, i, vec);
     }
-    PyList_SetItem(rot, i, mat);
-  }
-  PyList_SetItem(array, n++, rot);
+    PyList_SetItem(array, n++, mat);
 
-  /* Translation vectors */
-  trans = PyList_New(dataset->n_operations);
-  for (i = 0; i < dataset->n_operations; i++) {
+    /* Origin shift */
     vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->translations[i][j]));
+    for (i = 0; i < 3; i++) {
+        PyList_SetItem(vec, i, PyFloat_FromDouble(dataset->origin_shift[i]));
     }
-    PyList_SetItem(trans, i, vec);
-  }
-  PyList_SetItem(array, n++, trans);
+    PyList_SetItem(array, n++, vec);
 
-  /* Time reversals */
-  timerev = PyList_New(dataset->n_operations);
-  for (i = 0; i < dataset->n_operations; i++) {
-    PyList_SetItem(timerev, i, PyLong_FromLong((long)dataset->time_reversals[i]));
-  }
-  PyList_SetItem(array, n++, timerev);
+    /* Standardized crystal structure */
+    PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_std_atoms));
 
-  /* Equivalent atoms */
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_atoms));
-  equiv_atoms = PyList_New(dataset->n_atoms);
-  for (i = 0; i < dataset->n_atoms; i++) {
-    PyList_SetItem(equiv_atoms, i,
-                   PyLong_FromLong((long) dataset->equivalent_atoms[i]));
-  }
-  PyList_SetItem(array, n++, equiv_atoms);
-
-  /* Transformation matrix to standardized setting */
-  mat = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->transformation_matrix[i][j]));
+    std_lattice = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->std_lattice[i][j]));
+        }
+        PyList_SetItem(std_lattice, i, vec);
     }
-    PyList_SetItem(mat, i, vec);
-  }
-  PyList_SetItem(array, n++, mat);
+    PyList_SetItem(array, n++, std_lattice);
 
-  /* Origin shift */
-  vec = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    PyList_SetItem(vec, i, PyFloat_FromDouble(dataset->origin_shift[i]));
-  }
-  PyList_SetItem(array, n++, vec);
-
-  /* Standardized crystal structure */
-  PyList_SetItem(array, n++, PyLong_FromLong((long)dataset->n_std_atoms));
-
-  std_lattice = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->std_lattice[i][j]));
+    std_types = PyList_New(dataset->n_std_atoms);
+    std_positions = PyList_New(dataset->n_std_atoms);
+    for (i = 0; i < dataset->n_std_atoms; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j,
+                           PyFloat_FromDouble(dataset->std_positions[i][j]));
+        }
+        PyList_SetItem(std_types, i,
+                       PyLong_FromLong((long)dataset->std_types[i]));
+        PyList_SetItem(std_positions, i, vec);
     }
-    PyList_SetItem(std_lattice, i, vec);
-  }
-  PyList_SetItem(array, n++, std_lattice);
+    PyList_SetItem(array, n++, std_types);
+    PyList_SetItem(array, n++, std_positions);
 
-  std_types = PyList_New(dataset->n_std_atoms);
-  std_positions = PyList_New(dataset->n_std_atoms);
-  for (i = 0; i < dataset->n_std_atoms; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->std_positions[i][j]));
+    if (tensor_rank == 0) {
+        n_tensors = dataset->n_std_atoms;
+    } else if (tensor_rank == 1) {
+        n_tensors = 3 * dataset->n_std_atoms;
+    } else {
+        Py_RETURN_NONE;
     }
-    PyList_SetItem(std_types, i, PyLong_FromLong((long) dataset->std_types[i]));
-    PyList_SetItem(std_positions, i, vec);
-  }
-  PyList_SetItem(array, n++, std_types);
-  PyList_SetItem(array, n++, std_positions);
-
-  if (tensor_rank == 0) {
-    n_tensors = dataset->n_std_atoms;
-  } else if (tensor_rank == 1) {
-    n_tensors = 3 * dataset->n_std_atoms;
-  } else {
-    Py_RETURN_NONE;
-  }
-  std_tensors = PyList_New(n_tensors);
-  for (i = 0; i < n_tensors; i++) {
-    PyList_SetItem(std_tensors, i, PyFloat_FromDouble(dataset->std_tensors[i]));
-  }
-  PyList_SetItem(array, n++, std_tensors);
-
-  std_rotation = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j,
-                     PyFloat_FromDouble(dataset->std_rotation_matrix[i][j]));
+    std_tensors = PyList_New(n_tensors);
+    for (i = 0; i < n_tensors; i++) {
+        PyList_SetItem(std_tensors, i,
+                       PyFloat_FromDouble(dataset->std_tensors[i]));
     }
-    PyList_SetItem(std_rotation, i, vec);
-  }
-  PyList_SetItem(array, n++, std_rotation);
+    PyList_SetItem(array, n++, std_tensors);
 
-  /* Intermidiate datum in symmetry search */
-  primitive_lattice = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyFloat_FromDouble(dataset->primitive_lattice[i][j]));
+    std_rotation = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j, PyFloat_FromDouble(dataset->std_rotation_matrix[i][j]));
+        }
+        PyList_SetItem(std_rotation, i, vec);
     }
-    PyList_SetItem(primitive_lattice, i, vec);
-  }
-  PyList_SetItem(array, n++, primitive_lattice);
+    PyList_SetItem(array, n++, std_rotation);
 
-  assert(n == len_list);
-
-  spg_free_magnetic_dataset(dataset);
-
-  return array;
-}
-
-static PyObject * py_get_symmetry_from_database(PyObject *self, PyObject *args)
-{
-  int hall_number;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int num_sym;
-
-  if (!PyArg_ParseTuple(args, "OOi",
-                        &py_rotations,
-                        &py_translations,
-                        &hall_number)) {
-    return NULL;
-  }
-
-  if (PyArray_DIMS(py_rotations)[0] < 192 || PyArray_DIMS(py_translations)[0] < 192) {
-    Py_RETURN_NONE;
-  }
-
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-
-
-  num_sym = spg_get_symmetry_from_database(rot, trans, hall_number);
-
-  return PyLong_FromLong((long) num_sym);
-}
-
-static PyObject * py_get_magnetic_symmetry_from_database(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-  PyArrayObject* py_time_reversals;
-  int uni_number;
-  int hall_number;
-
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int *timerev;
-  int num_sym;
-
-  if (!PyArg_ParseTuple(args, "OOOii",
-                        &py_rotations,
-                        &py_translations,
-                        &py_time_reversals,
-                        &uni_number,
-                        &hall_number)) {
-    return NULL;
-  }
-
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-  timerev = (int*)PyArray_DATA(py_time_reversals);
-
-  num_sym = spg_get_magnetic_symmetry_from_database(rot, trans, timerev, uni_number, hall_number);
-
-  return PyLong_FromLong((long) num_sym);
-}
-
-static PyObject * py_get_spacegroup_type(PyObject *self, PyObject *args)
-{
-  int n, hall_number;
-  PyObject *array;
-  SpglibSpacegroupType spg_type;
-
-  if (!PyArg_ParseTuple(args, "i", &hall_number)) {
-    return NULL;
-  }
-
-  spg_type = spg_get_spacegroup_type(hall_number);
-  if (spg_type.number == 0) {
-    Py_RETURN_NONE;
-  }
-
-  array = PyList_New(11);
-  n = 0;
-  PyList_SetItem(array, n, PyLong_FromLong((long) spg_type.number));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international_short));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international_full));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.schoenflies));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.hall_symbol));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.choice));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.pointgroup_international));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.pointgroup_schoenflies));
-  n++;
-  PyList_SetItem(array, n, PyLong_FromLong((long) spg_type.arithmetic_crystal_class_number));
-  n++;
-  PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.arithmetic_crystal_class_symbol));
-  n++;
-
-  return array;
-}
-
-static PyObject *py_get_magnetic_spacegroup_type(PyObject *self, PyObject *args) {
-  int n, uni_number;
-  PyObject *array;
-  SpglibMagneticSpacegroupType msg_type;
-
-  if (!PyArg_ParseTuple(args, "i", &uni_number)) {
-    return NULL;
-  }
-
-  msg_type = spg_get_magnetic_spacegroup_type(uni_number);
-  if (msg_type.number == 0) {
-    Py_RETURN_NONE;
-  }
-
-  array = PyList_New(6);
-  n = 0;
-  PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.uni_number));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.litvin_number));
-  PyList_SetItem(array, n++, PYUNICODE_FROMSTRING(msg_type.bns_number));
-  PyList_SetItem(array, n++, PYUNICODE_FROMSTRING(msg_type.og_number));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.number));
-  PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.type));
-
-  return array;
-}
-
-static PyObject * py_get_pointgroup(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_rotations;
-
-  int i, j;
-  int trans_mat[3][3];
-  char symbol[6];
-  PyObject* array, * mat, * vec;
-  int(*rot)[3][3];
-  int num_rot;
-  int ptg_num;
-
-  if (! PyArg_ParseTuple(args, "O", &py_rotations)) {
-    return NULL;
-  }
-
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  num_rot = PyArray_DIMS(py_rotations)[0];
-  ptg_num = spg_get_pointgroup(symbol, trans_mat, rot, num_rot);
-
-  /* Transformation matrix */
-  mat = PyList_New(3);
-  for (i = 0; i < 3; i++) {
-    vec = PyList_New(3);
-    for (j = 0; j < 3; j++) {
-      PyList_SetItem(vec, j, PyLong_FromLong((long)trans_mat[i][j]));
+    /* Intermidiate datum in symmetry search */
+    primitive_lattice = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(
+                vec, j, PyFloat_FromDouble(dataset->primitive_lattice[i][j]));
+        }
+        PyList_SetItem(primitive_lattice, i, vec);
     }
-    PyList_SetItem(mat, i, vec);
-  }
+    PyList_SetItem(array, n++, primitive_lattice);
 
-  array = PyList_New(3);
-  PyList_SetItem(array, 0, PYUNICODE_FROMSTRING(symbol));
-  PyList_SetItem(array, 1, PyLong_FromLong((long) ptg_num));
-  PyList_SetItem(array, 2, mat);
+    assert(n == len_list);
 
-  return array;
+    spg_free_magnetic_dataset(dataset);
+
+    return array;
 }
 
-static PyObject * py_standardize_cell(PyObject *self, PyObject *args)
-{
-  int num_atom, to_primitive, no_idealize;
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_atom_types;
+static PyObject *py_get_symmetry_from_database(PyObject *self, PyObject *args) {
+    int hall_number;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
 
-  double (*lat)[3];
-  double (*pos)[3];
-  int* typat;
-  int num_atom_std;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int num_sym;
 
-  if (!PyArg_ParseTuple(args, "OOOiiidd",
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &num_atom,
-                        &to_primitive,
-                        &no_idealize,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOi", &py_rotations, &py_translations,
+                          &hall_number)) {
+        return NULL;
+    }
 
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  typat = (int*)PyArray_DATA(py_atom_types);
+    if (PyArray_DIMS(py_rotations)[0] < 192 ||
+        PyArray_DIMS(py_translations)[0] < 192) {
+        Py_RETURN_NONE;
+    }
 
-  num_atom_std = spgat_standardize_cell(lat,
-                                        pos,
-                                        typat,
-                                        num_atom,
-                                        to_primitive,
-                                        no_idealize,
-                                        symprec,
-                                        angle_tolerance);
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
 
-  return PyLong_FromLong((long) num_atom_std);
+    num_sym = spg_get_symmetry_from_database(rot, trans, hall_number);
+
+    return PyLong_FromLong((long)num_sym);
 }
 
-static PyObject * py_refine_cell(PyObject *self, PyObject *args)
-{
-  int num_atom;
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_atom_types;
+static PyObject *py_get_magnetic_symmetry_from_database(PyObject *self,
+                                                        PyObject *args) {
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+    PyArrayObject *py_time_reversals;
+    int uni_number;
+    int hall_number;
 
-  double (*lat)[3];
-  double (*pos)[3];
-  int* typat;
-  int num_atom_std;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int *timerev;
+    int num_sym;
 
-  if (!PyArg_ParseTuple(args, "OOOidd",
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &num_atom,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOOii", &py_rotations, &py_translations,
+                          &py_time_reversals, &uni_number, &hall_number)) {
+        return NULL;
+    }
 
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  typat = (int*)PyArray_DATA(py_atom_types);
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    timerev = (int *)PyArray_DATA(py_time_reversals);
 
-  num_atom_std = spgat_refine_cell(lat,
-                                   pos,
-                                   typat,
-                                   num_atom,
-                                   symprec,
-                                   angle_tolerance);
+    num_sym = spg_get_magnetic_symmetry_from_database(rot, trans, timerev,
+                                                      uni_number, hall_number);
 
-  return PyLong_FromLong((long) num_atom_std);
+    return PyLong_FromLong((long)num_sym);
 }
 
+static PyObject *py_get_spacegroup_type(PyObject *self, PyObject *args) {
+    int n, hall_number;
+    PyObject *array;
+    SpglibSpacegroupType spg_type;
 
-static PyObject * py_find_primitive(PyObject *self, PyObject *args)
-{
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_atom_types;
+    if (!PyArg_ParseTuple(args, "i", &hall_number)) {
+        return NULL;
+    }
 
-  double (*lat)[3];
-  double (*pos)[3];
-  int num_atom;
-  int* types;
-  int num_atom_prim;
+    spg_type = spg_get_spacegroup_type(hall_number);
+    if (spg_type.number == 0) {
+        Py_RETURN_NONE;
+    }
 
-  if (!PyArg_ParseTuple(args, "OOOdd",
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
+    array = PyList_New(12);
+    n = 0;
+    PyList_SetItem(array, n, PyLong_FromLong((long)spg_type.number));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.international_short));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international_full));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.schoenflies));
+    n++;
+    PyList_SetItem(array, n, PyLong_FromLong((long)spg_type.hall_number));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.hall_symbol));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.choice));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.pointgroup_international));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.pointgroup_schoenflies));
+    n++;
+    PyList_SetItem(
+        array, n,
+        PyLong_FromLong((long)spg_type.arithmetic_crystal_class_number));
+    n++;
+    PyList_SetItem(
+        array, n,
+        PYUNICODE_FROMSTRING(spg_type.arithmetic_crystal_class_symbol));
+    n++;
 
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  types = (int*)PyArray_DATA(py_atom_types);
-
-  num_atom_prim = spgat_find_primitive(lat,
-                                       pos,
-                                       types,
-                                       num_atom,
-                                       symprec,
-                                       angle_tolerance);
-
-  return PyLong_FromLong((long) num_atom_prim);
+    return array;
 }
 
-static PyObject * py_get_symmetry(PyObject *self, PyObject *args)
-{
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-  PyArrayObject* py_atom_types;
+static PyObject *py_get_spacegroup_type_from_symmetry(PyObject *self,
+                                                      PyObject *args) {
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+    PyArrayObject *py_lattice;
+    double symprec;
 
-  double (*lat)[3];
-  double (*pos)[3];
-  int* types;
-  int num_atom;
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int num_sym_from_array_size;
-  int num_sym;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    double(*lat)[3];
+    int num_sym, n;
+    PyObject *array;
+    SpglibSpacegroupType spg_type;
 
-  if (!PyArg_ParseTuple(args, "OOOOOdd",
-                        &py_rotations,
-                        &py_translations,
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOOd", &py_rotations, &py_translations,
+                          &py_lattice, &symprec)) {
+        return NULL;
+    }
 
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  types = (int*)PyArray_DATA(py_atom_types);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-  num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    num_sym = PyArray_DIMS(py_rotations)[0];
 
-  /* num_sym has to be larger than num_sym_from_array_size. */
-  num_sym = spgat_get_symmetry(rot,
-                               trans,
-                               num_sym_from_array_size,
-                               lat,
-                               pos,
-                               types,
-                               num_atom,
-                               symprec,
-                               angle_tolerance);
-  return PyLong_FromLong((long) num_sym);
-}
-
-static PyObject * py_get_symmetry_with_collinear_spin(PyObject *self,
-                                                      PyObject *args)
-{
-  double symprec, angle_tolerance;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-  PyArrayObject* py_atom_types;
-  PyArrayObject* py_magmoms;
-  PyArrayObject* py_equiv_atoms;
-
-  double (*lat)[3];
-  double (*pos)[3];
-  double *spins;
-  int *types;
-  int num_atom;
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int *equiv_atoms;
-  int num_sym_from_array_size;
-  int num_sym;
-
-  if (!PyArg_ParseTuple(args, "OOOOOOOdd",
-                        &py_rotations,
-                        &py_translations,
-                        &py_equiv_atoms,
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &py_magmoms,
-                        &symprec,
-                        &angle_tolerance)) {
-    return NULL;
-  }
-
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  spins = (double*)PyArray_DATA(py_magmoms);
-  types = (int*)PyArray_DATA(py_atom_types);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-  equiv_atoms = (int*)PyArray_DATA(py_equiv_atoms);
-  num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
-
-  /* num_sym has to be larger than num_sym_from_array_size. */
-  num_sym = spgat_get_symmetry_with_collinear_spin(rot,
-                                                   trans,
-                                                   equiv_atoms,
-                                                   num_sym_from_array_size,
-                                                   lat,
-                                                   pos,
-                                                   types,
-                                                   spins,
-                                                   num_atom,
-                                                   symprec,
-                                                   angle_tolerance);
-  return PyLong_FromLong((long) num_sym);
-}
-
-
-static PyObject * py_get_symmetry_with_site_tensors(PyObject *self,
-                                                    PyObject *args)
-{
-  double symprec, angle_tolerance, mag_symprec;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-  PyArrayObject* py_atom_types;
-  PyArrayObject* py_tensors;
-  PyArrayObject* py_equiv_atoms;
-  PyArrayObject* py_primitive_lattice;
-  PyArrayObject* py_spin_flips;
-
-  int with_time_reversal, is_axial;
-
-  double (*lat)[3];
-  double (*pos)[3];
-  double *tensors;
-  int *types;
-  int num_atom;
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int *equiv_atoms;
-  double (*primitive_lattice)[3];
-  int *spin_flips;
-  int num_sym_from_array_size;
-  int num_sym;
-  int tensor_rank;
-
-  if (!PyArg_ParseTuple(args, "OOOOOOOOOiiddd",
-                        &py_rotations,
-                        &py_translations,
-                        &py_equiv_atoms,
-                        &py_primitive_lattice,
-                        &py_spin_flips,
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &py_tensors,
-                        &with_time_reversal,
-                        &is_axial,
-                        &symprec,
-                        &angle_tolerance,
-                        &mag_symprec)) {
-    return NULL;
-  }
-
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  tensors = (double*)PyArray_DATA(py_tensors);
-  types = (int*)PyArray_DATA(py_atom_types);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-  equiv_atoms = (int*)PyArray_DATA(py_equiv_atoms);
-  primitive_lattice = (double(*)[3])PyArray_DATA(py_primitive_lattice);
-  num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
-  tensor_rank = PyArray_NDIM(py_tensors) - 1;
-  if (tensor_rank == 0 || tensor_rank == 1) {
-    spin_flips = (int*)PyArray_DATA(py_spin_flips);
-  } else {
-    spin_flips = NULL;
-  }
-
-  /* num_sym has to be larger than num_sym_from_array_size. */
-  num_sym = spgms_get_symmetry_with_site_tensors(rot,
-                                                 trans,
-                                                 equiv_atoms,
-                                                 primitive_lattice,
-                                                 spin_flips,
-                                                 num_sym_from_array_size,
-                                                 lat,
-                                                 pos,
-                                                 types,
-                                                 tensors,
-                                                 tensor_rank,
-                                                 num_atom,
-                                                 with_time_reversal,
-                                                 is_axial,
-                                                 symprec,
-                                                 angle_tolerance,
-                                                 mag_symprec);
-  return PyLong_FromLong((long) num_sym);
-}
-
-static PyObject *
-py_get_hall_number_from_symmetry(PyObject *self, PyObject *args)
-{
-  double symprec;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_translations;
-
-  int (*rot)[3][3];
-  double (*trans)[3];
-  int num_sym;
-  int hall_number;
-
-  if (!PyArg_ParseTuple(args, "OOd",
-                        &py_rotations,
-                        &py_translations,
-                        &symprec)) {
-    return NULL;
-  }
-
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  trans = (double(*)[3])PyArray_DATA(py_translations);
-  num_sym = PyArray_DIMS(py_rotations)[0];
-
-  hall_number = spg_get_hall_number_from_symmetry(rot,
-                                              trans,
-                                              num_sym,
-                                              symprec);
-
-  return PyLong_FromLong((long) hall_number);
-}
-
-static PyObject * py_get_grid_point_from_address(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_grid_address;
-  PyArrayObject* py_mesh;
-
-  int* grid_address;
-  int* mesh;
-  size_t gp;
-
-  if (!PyArg_ParseTuple(args, "OO",
-                        &py_grid_address,
-                        &py_mesh)) {
-    return NULL;
-  }
-
-  grid_address = (int*)PyArray_DATA(py_grid_address);
-  mesh = (int*)PyArray_DATA(py_mesh);
-
-  gp = spg_get_dense_grid_point_from_address(grid_address, mesh);
-
-  return PyLong_FromSize_t(gp);
-}
-
-static PyObject * py_get_ir_reciprocal_mesh(PyObject *self, PyObject *args)
-{
-  double symprec;
-  PyArrayObject* py_grid_address;
-  PyArrayObject* py_grid_mapping_table;
-  PyArrayObject* py_mesh;
-  PyArrayObject* py_is_shift;
-  int is_time_reversal;
-  PyArrayObject* py_lattice;
-  PyArrayObject* py_positions;
-  PyArrayObject* py_atom_types;
-
-  double (*lat)[3];
-  double (*pos)[3];
-  int* types;
-  int* mesh;
-  int* is_shift;
-  int num_atom;
-  int (*grid_address)[3];
-  int *grid_mapping_table_int;
-  size_t *grid_mapping_table_size_t;
-  int num_ir_int;
-  size_t num_ir_size_t;
-
-  if (!PyArg_ParseTuple(args, "OOOOiOOOd",
-                        &py_grid_address,
-                        &py_grid_mapping_table,
-                        &py_mesh,
-                        &py_is_shift,
-                        &is_time_reversal,
-                        &py_lattice,
-                        &py_positions,
-                        &py_atom_types,
-                        &symprec)) {
-    return NULL;
-  }
-
-  lat = (double(*)[3])PyArray_DATA(py_lattice);
-  pos = (double(*)[3])PyArray_DATA(py_positions);
-  types = (int*)PyArray_DATA(py_atom_types);
-  mesh = (int*)PyArray_DATA(py_mesh);
-  is_shift = (int*)PyArray_DATA(py_is_shift);
-  num_atom = PyArray_DIMS(py_positions)[0];
-  grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
-  if (PyArray_TYPE(py_grid_mapping_table) == NPY_UINTP) {
-    grid_mapping_table_size_t = (size_t*)PyArray_DATA(py_grid_mapping_table);
-    num_ir_size_t = spg_get_dense_ir_reciprocal_mesh(grid_address,
-                                                     grid_mapping_table_size_t,
-                                                     mesh,
-                                                     is_shift,
-                                                     is_time_reversal,
-                                                     lat,
-                                                     pos,
-                                                     types,
-                                                     num_atom,
+    spg_type = spg_get_spacegroup_type_from_symmetry(rot, trans, num_sym, lat,
                                                      symprec);
-    return PyLong_FromSize_t(num_ir_size_t);
-  }
-  if (PyArray_TYPE(py_grid_mapping_table) == NPY_INT) {
-    grid_mapping_table_int = (int*)PyArray_DATA(py_grid_mapping_table);
+    if (spg_type.number == 0) {
+        Py_RETURN_NONE;
+    }
+
+    array = PyList_New(12);
+    n = 0;
+    PyList_SetItem(array, n, PyLong_FromLong((long)spg_type.number));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.international_short));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international_full));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.international));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.schoenflies));
+    n++;
+    PyList_SetItem(array, n, PyLong_FromLong((long)spg_type.hall_number));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.hall_symbol));
+    n++;
+    PyList_SetItem(array, n, PYUNICODE_FROMSTRING(spg_type.choice));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.pointgroup_international));
+    n++;
+    PyList_SetItem(array, n,
+                   PYUNICODE_FROMSTRING(spg_type.pointgroup_schoenflies));
+    n++;
+    PyList_SetItem(
+        array, n,
+        PyLong_FromLong((long)spg_type.arithmetic_crystal_class_number));
+    n++;
+    PyList_SetItem(
+        array, n,
+        PYUNICODE_FROMSTRING(spg_type.arithmetic_crystal_class_symbol));
+    n++;
+
+    return array;
+}
+
+static PyObject *py_get_magnetic_spacegroup_type(PyObject *self,
+                                                 PyObject *args) {
+    int n, uni_number;
+    PyObject *array;
+    SpglibMagneticSpacegroupType msg_type;
+
+    if (!PyArg_ParseTuple(args, "i", &uni_number)) {
+        return NULL;
+    }
+
+    msg_type = spg_get_magnetic_spacegroup_type(uni_number);
+    if (msg_type.number == 0) {
+        Py_RETURN_NONE;
+    }
+
+    array = PyList_New(6);
+    n = 0;
+    PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.uni_number));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.litvin_number));
+    PyList_SetItem(array, n++, PYUNICODE_FROMSTRING(msg_type.bns_number));
+    PyList_SetItem(array, n++, PYUNICODE_FROMSTRING(msg_type.og_number));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.number));
+    PyList_SetItem(array, n++, PyLong_FromLong((long)msg_type.type));
+
+    return array;
+}
+
+static PyObject *py_get_pointgroup(PyObject *self, PyObject *args) {
+    PyArrayObject *py_rotations;
+
+    int i, j;
+    int trans_mat[3][3];
+    char symbol[6];
+    PyObject *array, *mat, *vec;
+    int(*rot)[3][3];
+    int num_rot;
+    int ptg_num;
+
+    if (!PyArg_ParseTuple(args, "O", &py_rotations)) {
+        return NULL;
+    }
+
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    num_rot = PyArray_DIMS(py_rotations)[0];
+    ptg_num = spg_get_pointgroup(symbol, trans_mat, rot, num_rot);
+
+    /* Transformation matrix */
+    mat = PyList_New(3);
+    for (i = 0; i < 3; i++) {
+        vec = PyList_New(3);
+        for (j = 0; j < 3; j++) {
+            PyList_SetItem(vec, j, PyLong_FromLong((long)trans_mat[i][j]));
+        }
+        PyList_SetItem(mat, i, vec);
+    }
+
+    array = PyList_New(3);
+    PyList_SetItem(array, 0, PYUNICODE_FROMSTRING(symbol));
+    PyList_SetItem(array, 1, PyLong_FromLong((long)ptg_num));
+    PyList_SetItem(array, 2, mat);
+
+    return array;
+}
+
+static PyObject *py_standardize_cell(PyObject *self, PyObject *args) {
+    int num_atom, to_primitive, no_idealize;
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_atom_types;
+
+    double(*lat)[3];
+    double(*pos)[3];
+    int *typat;
+    int num_atom_std;
+
+    if (!PyArg_ParseTuple(args, "OOOiiidd", &py_lattice, &py_positions,
+                          &py_atom_types, &num_atom, &to_primitive,
+                          &no_idealize, &symprec, &angle_tolerance)) {
+        return NULL;
+    }
+
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    typat = (int *)PyArray_DATA(py_atom_types);
+
+    num_atom_std =
+        spgat_standardize_cell(lat, pos, typat, num_atom, to_primitive,
+                               no_idealize, symprec, angle_tolerance);
+
+    return PyLong_FromLong((long)num_atom_std);
+}
+
+static PyObject *py_refine_cell(PyObject *self, PyObject *args) {
+    int num_atom;
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_atom_types;
+
+    double(*lat)[3];
+    double(*pos)[3];
+    int *typat;
+    int num_atom_std;
+
+    if (!PyArg_ParseTuple(args, "OOOidd", &py_lattice, &py_positions,
+                          &py_atom_types, &num_atom, &symprec,
+                          &angle_tolerance)) {
+        return NULL;
+    }
+
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    typat = (int *)PyArray_DATA(py_atom_types);
+
+    num_atom_std =
+        spgat_refine_cell(lat, pos, typat, num_atom, symprec, angle_tolerance);
+
+    return PyLong_FromLong((long)num_atom_std);
+}
+
+static PyObject *py_find_primitive(PyObject *self, PyObject *args) {
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_atom_types;
+
+    double(*lat)[3];
+    double(*pos)[3];
+    int num_atom;
+    int *types;
+    int num_atom_prim;
+
+    if (!PyArg_ParseTuple(args, "OOOdd", &py_lattice, &py_positions,
+                          &py_atom_types, &symprec, &angle_tolerance)) {
+        return NULL;
+    }
+
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    types = (int *)PyArray_DATA(py_atom_types);
+
+    num_atom_prim = spgat_find_primitive(lat, pos, types, num_atom, symprec,
+                                         angle_tolerance);
+
+    return PyLong_FromLong((long)num_atom_prim);
+}
+
+static PyObject *py_get_symmetry(PyObject *self, PyObject *args) {
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+    PyArrayObject *py_atom_types;
+
+    double(*lat)[3];
+    double(*pos)[3];
+    int *types;
+    int num_atom;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int num_sym_from_array_size;
+    int num_sym;
+
+    if (!PyArg_ParseTuple(args, "OOOOOdd", &py_rotations, &py_translations,
+                          &py_lattice, &py_positions, &py_atom_types, &symprec,
+                          &angle_tolerance)) {
+        return NULL;
+    }
+
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    types = (int *)PyArray_DATA(py_atom_types);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
+
     /* num_sym has to be larger than num_sym_from_array_size. */
-    num_ir_int = spg_get_ir_reciprocal_mesh(grid_address,
-                                            grid_mapping_table_int,
-                                            mesh,
-                                            is_shift,
-                                            is_time_reversal,
-                                            lat,
-                                            pos,
-                                            types,
-                                            num_atom,
-                                            symprec);
-    return PyLong_FromLong((long) num_ir_int);
-  }
-
-  Py_RETURN_NONE;
+    num_sym = spgat_get_symmetry(rot, trans, num_sym_from_array_size, lat, pos,
+                                 types, num_atom, symprec, angle_tolerance);
+    return PyLong_FromLong((long)num_sym);
 }
 
-static PyObject *
-py_get_stabilized_reciprocal_mesh(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_grid_address;
-  PyArrayObject* py_grid_mapping_table;
-  PyArrayObject* py_mesh;
-  PyArrayObject* py_is_shift;
-  int is_time_reversal;
-  PyArrayObject* py_rotations;
-  PyArrayObject* py_qpoints;
+static PyObject *py_get_symmetry_with_collinear_spin(PyObject *self,
+                                                     PyObject *args) {
+    double symprec, angle_tolerance;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+    PyArrayObject *py_atom_types;
+    PyArrayObject *py_magmoms;
+    PyArrayObject *py_equiv_atoms;
 
-  int (*grid_address)[3];
-  int* mesh;
-  int* is_shift;
-  int (*rot)[3][3];
-  int num_rot;
-  double (*q)[3];
-  int num_q;
+    double(*lat)[3];
+    double(*pos)[3];
+    double *spins;
+    int *types;
+    int num_atom;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int *equiv_atoms;
+    int num_sym_from_array_size;
+    int num_sym;
 
-  int *grid_mapping_table_int;
-  size_t *grid_mapping_table_size_t;
-  int num_ir_int;
-  size_t num_ir_size_t;
+    if (!PyArg_ParseTuple(args, "OOOOOOOdd", &py_rotations, &py_translations,
+                          &py_equiv_atoms, &py_lattice, &py_positions,
+                          &py_atom_types, &py_magmoms, &symprec,
+                          &angle_tolerance)) {
+        return NULL;
+    }
 
-  if (!PyArg_ParseTuple(args, "OOOOiOO",
-                        &py_grid_address,
-                        &py_grid_mapping_table,
-                        &py_mesh,
-                        &py_is_shift,
-                        &is_time_reversal,
-                        &py_rotations,
-                        &py_qpoints)) {
-    return NULL;
-  }
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    spins = (double *)PyArray_DATA(py_magmoms);
+    types = (int *)PyArray_DATA(py_atom_types);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    equiv_atoms = (int *)PyArray_DATA(py_equiv_atoms);
+    num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
 
-  grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
-  mesh = (int*)PyArray_DATA(py_mesh);
-  is_shift = (int*)PyArray_DATA(py_is_shift);
-  rot = (int(*)[3][3])PyArray_DATA(py_rotations);
-  num_rot = PyArray_DIMS(py_rotations)[0];
-  q = (double(*)[3])PyArray_DATA(py_qpoints);
-  num_q = PyArray_DIMS(py_qpoints)[0];
-
-  if (PyArray_TYPE(py_grid_mapping_table) == NPY_UINTP) {
-    grid_mapping_table_size_t = (size_t*)PyArray_DATA(py_grid_mapping_table);
-    num_ir_size_t =
-      spg_get_dense_stabilized_reciprocal_mesh(grid_address,
-                                               grid_mapping_table_size_t,
-                                               mesh,
-                                               is_shift,
-                                               is_time_reversal,
-                                               num_rot,
-                                               rot,
-                                               num_q,
-                                               q);
-    return PyLong_FromSize_t(num_ir_size_t);
-  }
-  if (PyArray_TYPE(py_grid_mapping_table) == NPY_INT) {
-    grid_mapping_table_int = (int*)PyArray_DATA(py_grid_mapping_table);
-    num_ir_int = spg_get_stabilized_reciprocal_mesh(grid_address,
-                                                    grid_mapping_table_int,
-                                                    mesh,
-                                                    is_shift,
-                                                    is_time_reversal,
-                                                    num_rot,
-                                                    rot,
-                                                    num_q,
-                                                    q);
-    return PyLong_FromLong((long) num_ir_int);
-  }
-
-  Py_RETURN_NONE;
+    /* num_sym has to be larger than num_sym_from_array_size. */
+    num_sym = spgat_get_symmetry_with_collinear_spin(
+        rot, trans, equiv_atoms, num_sym_from_array_size, lat, pos, types,
+        spins, num_atom, symprec, angle_tolerance);
+    return PyLong_FromLong((long)num_sym);
 }
 
-static PyObject *
-py_get_grid_points_by_rotations(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_rot_grid_points;
-  PyArrayObject* py_address_orig;
-  PyArrayObject* py_rot_reciprocal;
-  PyArrayObject* py_mesh;
-  PyArrayObject* py_is_shift;
+static PyObject *py_get_symmetry_with_site_tensors(PyObject *self,
+                                                   PyObject *args) {
+    double symprec, angle_tolerance, mag_symprec;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+    PyArrayObject *py_atom_types;
+    PyArrayObject *py_tensors;
+    PyArrayObject *py_equiv_atoms;
+    PyArrayObject *py_primitive_lattice;
+    PyArrayObject *py_spin_flips;
 
-  size_t *rot_grid_points;
-  int *address_orig;
-  int (*rot_reciprocal)[3][3];
-  int num_rot;
-  int* mesh;
-  int* is_shift;
+    int with_time_reversal, is_axial;
 
-  if (!PyArg_ParseTuple(args, "OOOOO",
-                        &py_rot_grid_points,
-                        &py_address_orig,
-                        &py_rot_reciprocal,
-                        &py_mesh,
-                        &py_is_shift)) {
-    return NULL;
-  }
+    double(*lat)[3];
+    double(*pos)[3];
+    double *tensors;
+    int *types;
+    int num_atom;
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int *equiv_atoms;
+    double(*primitive_lattice)[3];
+    int *spin_flips;
+    int num_sym_from_array_size;
+    int num_sym;
+    int tensor_rank;
 
-  rot_grid_points = (size_t*)PyArray_DATA(py_rot_grid_points);
-  address_orig = (int*)PyArray_DATA(py_address_orig);
-  rot_reciprocal = (int(*)[3][3])PyArray_DATA(py_rot_reciprocal);
-  num_rot = PyArray_DIMS(py_rot_reciprocal)[0];
-  mesh = (int*)PyArray_DATA(py_mesh);
-  is_shift = (int*)PyArray_DATA(py_is_shift);
+    if (!PyArg_ParseTuple(
+            args, "OOOOOOOOOiiddd", &py_rotations, &py_translations,
+            &py_equiv_atoms, &py_primitive_lattice, &py_spin_flips, &py_lattice,
+            &py_positions, &py_atom_types, &py_tensors, &with_time_reversal,
+            &is_axial, &symprec, &angle_tolerance, &mag_symprec)) {
+        return NULL;
+    }
 
-  spg_get_dense_grid_points_by_rotations(rot_grid_points,
-                                         address_orig,
-                                         num_rot,
-                                         rot_reciprocal,
-                                         mesh,
-                                         is_shift);
-  Py_RETURN_NONE;
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    tensors = (double *)PyArray_DATA(py_tensors);
+    types = (int *)PyArray_DATA(py_atom_types);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    equiv_atoms = (int *)PyArray_DATA(py_equiv_atoms);
+    primitive_lattice = (double(*)[3])PyArray_DATA(py_primitive_lattice);
+    num_sym_from_array_size = PyArray_DIMS(py_rotations)[0];
+    tensor_rank = PyArray_NDIM(py_tensors) - 1;
+    if (tensor_rank == 0 || tensor_rank == 1) {
+        spin_flips = (int *)PyArray_DATA(py_spin_flips);
+    } else {
+        spin_flips = NULL;
+    }
+
+    /* num_sym has to be larger than num_sym_from_array_size. */
+    num_sym = spgms_get_symmetry_with_site_tensors(
+        rot, trans, equiv_atoms, primitive_lattice, spin_flips,
+        num_sym_from_array_size, lat, pos, types, tensors, tensor_rank,
+        num_atom, with_time_reversal, is_axial, symprec, angle_tolerance,
+        mag_symprec);
+    return PyLong_FromLong((long)num_sym);
 }
 
-static PyObject *
-py_get_BZ_grid_points_by_rotations(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_rot_grid_points;
-  PyArrayObject* py_address_orig;
-  PyArrayObject* py_rot_reciprocal;
-  PyArrayObject* py_mesh;
-  PyArrayObject* py_is_shift;
-  PyArrayObject* py_bz_map;
+static PyObject *py_get_grid_point_from_address(PyObject *self,
+                                                PyObject *args) {
+    PyArrayObject *py_grid_address;
+    PyArrayObject *py_mesh;
 
-  size_t *rot_grid_points;
-  int *address_orig;
-  int (*rot_reciprocal)[3][3];
-  int num_rot;
-  int* mesh;
-  int* is_shift;
-  size_t* bz_map;
+    int *grid_address;
+    int *mesh;
+    size_t gp;
 
-  if (!PyArg_ParseTuple(args, "OOOOOO",
-                        &py_rot_grid_points,
-                        &py_address_orig,
-                        &py_rot_reciprocal,
-                        &py_mesh,
-                        &py_is_shift,
-                        &py_bz_map)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OO", &py_grid_address, &py_mesh)) {
+        return NULL;
+    }
 
-  rot_grid_points = (size_t*)PyArray_DATA(py_rot_grid_points);
-  address_orig = (int*)PyArray_DATA(py_address_orig);
-  rot_reciprocal = (int(*)[3][3])PyArray_DATA(py_rot_reciprocal);
-  num_rot = PyArray_DIMS(py_rot_reciprocal)[0];
-  mesh = (int*)PyArray_DATA(py_mesh);
-  is_shift = (int*)PyArray_DATA(py_is_shift);
-  bz_map = (size_t*)PyArray_DATA(py_bz_map);
+    grid_address = (int *)PyArray_DATA(py_grid_address);
+    mesh = (int *)PyArray_DATA(py_mesh);
 
-  spg_get_dense_BZ_grid_points_by_rotations(rot_grid_points,
-                                            address_orig,
-                                            num_rot,
-                                            rot_reciprocal,
-                                            mesh,
-                                            is_shift,
-                                            bz_map);
-  Py_RETURN_NONE;
+    gp = spg_get_dense_grid_point_from_address(grid_address, mesh);
+
+    return PyLong_FromSize_t(gp);
 }
 
-static PyObject * py_relocate_BZ_grid_address(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_bz_grid_address;
-  PyArrayObject* py_bz_map;
-  PyArrayObject* py_grid_address;
-  PyArrayObject* py_mesh;
-  PyArrayObject* py_is_shift;
-  PyArrayObject* py_reciprocal_lattice;
+static PyObject *py_get_ir_reciprocal_mesh(PyObject *self, PyObject *args) {
+    double symprec;
+    PyArrayObject *py_grid_address;
+    PyArrayObject *py_grid_mapping_table;
+    PyArrayObject *py_mesh;
+    PyArrayObject *py_is_shift;
+    int is_time_reversal;
+    PyArrayObject *py_lattice;
+    PyArrayObject *py_positions;
+    PyArrayObject *py_atom_types;
 
-  int (*bz_grid_address)[3];
-  size_t *bz_map;
-  int (*grid_address)[3];
-  int* mesh;
-  int* is_shift;
-  double (*reciprocal_lattice)[3];
-  size_t num_ir_gp;
+    double(*lat)[3];
+    double(*pos)[3];
+    int *types;
+    int *mesh;
+    int *is_shift;
+    int num_atom;
+    int(*grid_address)[3];
+    int *grid_mapping_table_int;
+    size_t *grid_mapping_table_size_t;
+    int num_ir_int;
+    size_t num_ir_size_t;
 
-  if (!PyArg_ParseTuple(args, "OOOOOO",
-                        &py_bz_grid_address,
-                        &py_bz_map,
-                        &py_grid_address,
-                        &py_mesh,
-                        &py_reciprocal_lattice,
-                        &py_is_shift)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOOOiOOOd", &py_grid_address,
+                          &py_grid_mapping_table, &py_mesh, &py_is_shift,
+                          &is_time_reversal, &py_lattice, &py_positions,
+                          &py_atom_types, &symprec)) {
+        return NULL;
+    }
 
-  bz_grid_address = (int(*)[3])PyArray_DATA(py_bz_grid_address);
-  bz_map = (size_t*)PyArray_DATA(py_bz_map);
-  grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
-  mesh = (int*)PyArray_DATA(py_mesh);
-  is_shift = (int*)PyArray_DATA(py_is_shift);
-  reciprocal_lattice = (double(*)[3])PyArray_DATA(py_reciprocal_lattice);
+    lat = (double(*)[3])PyArray_DATA(py_lattice);
+    pos = (double(*)[3])PyArray_DATA(py_positions);
+    types = (int *)PyArray_DATA(py_atom_types);
+    mesh = (int *)PyArray_DATA(py_mesh);
+    is_shift = (int *)PyArray_DATA(py_is_shift);
+    num_atom = PyArray_DIMS(py_positions)[0];
+    grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
+    if (PyArray_TYPE(py_grid_mapping_table) == NPY_UINTP) {
+        grid_mapping_table_size_t =
+            (size_t *)PyArray_DATA(py_grid_mapping_table);
+        num_ir_size_t = spg_get_dense_ir_reciprocal_mesh(
+            grid_address, grid_mapping_table_size_t, mesh, is_shift,
+            is_time_reversal, lat, pos, types, num_atom, symprec);
+        return PyLong_FromSize_t(num_ir_size_t);
+    }
+    if (PyArray_TYPE(py_grid_mapping_table) == NPY_INT) {
+        grid_mapping_table_int = (int *)PyArray_DATA(py_grid_mapping_table);
+        /* num_sym has to be larger than num_sym_from_array_size. */
+        num_ir_int = spg_get_ir_reciprocal_mesh(
+            grid_address, grid_mapping_table_int, mesh, is_shift,
+            is_time_reversal, lat, pos, types, num_atom, symprec);
+        return PyLong_FromLong((long)num_ir_int);
+    }
 
-  num_ir_gp = spg_relocate_dense_BZ_grid_address(bz_grid_address,
-                                                 bz_map,
-                                                 grid_address,
-                                                 mesh,
-                                                 reciprocal_lattice,
-                                                 is_shift);
-
-  return PyLong_FromSize_t(num_ir_gp);
+    Py_RETURN_NONE;
 }
 
-static PyObject * py_delaunay_reduce(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_lattice;
-  double symprec;
+static PyObject *py_get_stabilized_reciprocal_mesh(PyObject *self,
+                                                   PyObject *args) {
+    PyArrayObject *py_grid_address;
+    PyArrayObject *py_grid_mapping_table;
+    PyArrayObject *py_mesh;
+    PyArrayObject *py_is_shift;
+    int is_time_reversal;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_qpoints;
 
-  double (*lattice)[3];
-  int result;
+    int(*grid_address)[3];
+    int *mesh;
+    int *is_shift;
+    int(*rot)[3][3];
+    int num_rot;
+    double(*q)[3];
+    int num_q;
 
-  if (!PyArg_ParseTuple(args, "Od", &py_lattice, &symprec)) {
-    return NULL;
-  }
+    int *grid_mapping_table_int;
+    size_t *grid_mapping_table_size_t;
+    int num_ir_int;
+    size_t num_ir_size_t;
 
-  lattice = (double(*)[3])PyArray_DATA(py_lattice);
+    if (!PyArg_ParseTuple(args, "OOOOiOO", &py_grid_address,
+                          &py_grid_mapping_table, &py_mesh, &py_is_shift,
+                          &is_time_reversal, &py_rotations, &py_qpoints)) {
+        return NULL;
+    }
 
-  result = spg_delaunay_reduce(lattice, symprec);
+    grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
+    mesh = (int *)PyArray_DATA(py_mesh);
+    is_shift = (int *)PyArray_DATA(py_is_shift);
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    num_rot = PyArray_DIMS(py_rotations)[0];
+    q = (double(*)[3])PyArray_DATA(py_qpoints);
+    num_q = PyArray_DIMS(py_qpoints)[0];
 
-  return PyLong_FromLong((long) result);
+    if (PyArray_TYPE(py_grid_mapping_table) == NPY_UINTP) {
+        grid_mapping_table_size_t =
+            (size_t *)PyArray_DATA(py_grid_mapping_table);
+        num_ir_size_t = spg_get_dense_stabilized_reciprocal_mesh(
+            grid_address, grid_mapping_table_size_t, mesh, is_shift,
+            is_time_reversal, num_rot, rot, num_q, q);
+        return PyLong_FromSize_t(num_ir_size_t);
+    }
+    if (PyArray_TYPE(py_grid_mapping_table) == NPY_INT) {
+        grid_mapping_table_int = (int *)PyArray_DATA(py_grid_mapping_table);
+        num_ir_int = spg_get_stabilized_reciprocal_mesh(
+            grid_address, grid_mapping_table_int, mesh, is_shift,
+            is_time_reversal, num_rot, rot, num_q, q);
+        return PyLong_FromLong((long)num_ir_int);
+    }
+
+    Py_RETURN_NONE;
 }
 
-static PyObject * py_niggli_reduce(PyObject *self, PyObject *args)
-{
-  PyArrayObject* py_lattice;
-  double eps;
+static PyObject *py_get_grid_points_by_rotations(PyObject *self,
+                                                 PyObject *args) {
+    PyArrayObject *py_rot_grid_points;
+    PyArrayObject *py_address_orig;
+    PyArrayObject *py_rot_reciprocal;
+    PyArrayObject *py_mesh;
+    PyArrayObject *py_is_shift;
 
-  double (*lattice)[3];
-  int result;
+    size_t *rot_grid_points;
+    int *address_orig;
+    int(*rot_reciprocal)[3][3];
+    int num_rot;
+    int *mesh;
+    int *is_shift;
 
-  if (!PyArg_ParseTuple(args, "Od", &py_lattice, &eps)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args, "OOOOO", &py_rot_grid_points, &py_address_orig,
+                          &py_rot_reciprocal, &py_mesh, &py_is_shift)) {
+        return NULL;
+    }
 
-  lattice = (double(*)[3])PyArray_DATA(py_lattice);
+    rot_grid_points = (size_t *)PyArray_DATA(py_rot_grid_points);
+    address_orig = (int *)PyArray_DATA(py_address_orig);
+    rot_reciprocal = (int(*)[3][3])PyArray_DATA(py_rot_reciprocal);
+    num_rot = PyArray_DIMS(py_rot_reciprocal)[0];
+    mesh = (int *)PyArray_DATA(py_mesh);
+    is_shift = (int *)PyArray_DATA(py_is_shift);
 
-  result = spg_niggli_reduce(lattice, eps);
-
-  return PyLong_FromLong((long) result);
+    spg_get_dense_grid_points_by_rotations(
+        rot_grid_points, address_orig, num_rot, rot_reciprocal, mesh, is_shift);
+    Py_RETURN_NONE;
 }
 
-static PyObject * py_get_error_message(PyObject *self, PyObject *args)
-{
-  SpglibError error;
+static PyObject *py_get_BZ_grid_points_by_rotations(PyObject *self,
+                                                    PyObject *args) {
+    PyArrayObject *py_rot_grid_points;
+    PyArrayObject *py_address_orig;
+    PyArrayObject *py_rot_reciprocal;
+    PyArrayObject *py_mesh;
+    PyArrayObject *py_is_shift;
+    PyArrayObject *py_bz_map;
 
-  if (!PyArg_ParseTuple(args, "")) {
-    return NULL;
-  }
+    size_t *rot_grid_points;
+    int *address_orig;
+    int(*rot_reciprocal)[3][3];
+    int num_rot;
+    int *mesh;
+    int *is_shift;
+    size_t *bz_map;
 
-  error = spg_get_error_code();
+    if (!PyArg_ParseTuple(args, "OOOOOO", &py_rot_grid_points, &py_address_orig,
+                          &py_rot_reciprocal, &py_mesh, &py_is_shift,
+                          &py_bz_map)) {
+        return NULL;
+    }
 
-  return PYUNICODE_FROMSTRING(spg_get_error_message(error));
+    rot_grid_points = (size_t *)PyArray_DATA(py_rot_grid_points);
+    address_orig = (int *)PyArray_DATA(py_address_orig);
+    rot_reciprocal = (int(*)[3][3])PyArray_DATA(py_rot_reciprocal);
+    num_rot = PyArray_DIMS(py_rot_reciprocal)[0];
+    mesh = (int *)PyArray_DATA(py_mesh);
+    is_shift = (int *)PyArray_DATA(py_is_shift);
+    bz_map = (size_t *)PyArray_DATA(py_bz_map);
+
+    spg_get_dense_BZ_grid_points_by_rotations(rot_grid_points, address_orig,
+                                              num_rot, rot_reciprocal, mesh,
+                                              is_shift, bz_map);
+    Py_RETURN_NONE;
+}
+
+static PyObject *py_relocate_BZ_grid_address(PyObject *self, PyObject *args) {
+    PyArrayObject *py_bz_grid_address;
+    PyArrayObject *py_bz_map;
+    PyArrayObject *py_grid_address;
+    PyArrayObject *py_mesh;
+    PyArrayObject *py_is_shift;
+    PyArrayObject *py_reciprocal_lattice;
+
+    int(*bz_grid_address)[3];
+    size_t *bz_map;
+    int(*grid_address)[3];
+    int *mesh;
+    int *is_shift;
+    double(*reciprocal_lattice)[3];
+    size_t num_ir_gp;
+
+    if (!PyArg_ParseTuple(args, "OOOOOO", &py_bz_grid_address, &py_bz_map,
+                          &py_grid_address, &py_mesh, &py_reciprocal_lattice,
+                          &py_is_shift)) {
+        return NULL;
+    }
+
+    bz_grid_address = (int(*)[3])PyArray_DATA(py_bz_grid_address);
+    bz_map = (size_t *)PyArray_DATA(py_bz_map);
+    grid_address = (int(*)[3])PyArray_DATA(py_grid_address);
+    mesh = (int *)PyArray_DATA(py_mesh);
+    is_shift = (int *)PyArray_DATA(py_is_shift);
+    reciprocal_lattice = (double(*)[3])PyArray_DATA(py_reciprocal_lattice);
+
+    num_ir_gp = spg_relocate_dense_BZ_grid_address(
+        bz_grid_address, bz_map, grid_address, mesh, reciprocal_lattice,
+        is_shift);
+
+    return PyLong_FromSize_t(num_ir_gp);
+}
+
+static PyObject *py_delaunay_reduce(PyObject *self, PyObject *args) {
+    PyArrayObject *py_lattice;
+    double symprec;
+
+    double(*lattice)[3];
+    int result;
+
+    if (!PyArg_ParseTuple(args, "Od", &py_lattice, &symprec)) {
+        return NULL;
+    }
+
+    lattice = (double(*)[3])PyArray_DATA(py_lattice);
+
+    result = spg_delaunay_reduce(lattice, symprec);
+
+    return PyLong_FromLong((long)result);
+}
+
+static PyObject *py_niggli_reduce(PyObject *self, PyObject *args) {
+    PyArrayObject *py_lattice;
+    double eps;
+
+    double(*lattice)[3];
+    int result;
+
+    if (!PyArg_ParseTuple(args, "Od", &py_lattice, &eps)) {
+        return NULL;
+    }
+
+    lattice = (double(*)[3])PyArray_DATA(py_lattice);
+
+    result = spg_niggli_reduce(lattice, eps);
+
+    return PyLong_FromLong((long)result);
+}
+
+/* Deprecated at v2.0 */
+static PyObject *py_get_hall_number_from_symmetry(PyObject *self,
+                                                  PyObject *args) {
+    double symprec;
+    PyArrayObject *py_rotations;
+    PyArrayObject *py_translations;
+
+    int(*rot)[3][3];
+    double(*trans)[3];
+    int num_sym;
+    int hall_number;
+
+    if (!PyArg_ParseTuple(args, "OOd", &py_rotations, &py_translations,
+                          &symprec)) {
+        return NULL;
+    }
+
+    rot = (int(*)[3][3])PyArray_DATA(py_rotations);
+    trans = (double(*)[3])PyArray_DATA(py_translations);
+    num_sym = PyArray_DIMS(py_rotations)[0];
+
+    hall_number =
+        spg_get_hall_number_from_symmetry(rot, trans, num_sym, symprec);
+
+    return PyLong_FromLong((long)hall_number);
+}
+
+static PyObject *py_get_error_message(PyObject *self, PyObject *args) {
+    SpglibError error;
+
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+
+    error = spg_get_error_code();
+
+    return PYUNICODE_FROMSTRING(spg_get_error_message(error));
 }

--- a/python/spglib/__init__.py
+++ b/python/spglib/__init__.py
@@ -50,6 +50,7 @@ from .spglib import (  # noqa: F401
     get_pointgroup,
     get_spacegroup,
     get_spacegroup_type,
+    get_spacegroup_type_from_symmetry,
     get_stabilized_reciprocal_mesh,
     get_symmetry,
     get_symmetry_dataset,

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -34,7 +34,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import warnings
-from typing import Dict, Optional
 
 import numpy as np
 
@@ -745,7 +744,7 @@ def get_spacegroup_type(hall_number):
 
 def get_spacegroup_type_from_symmetry(
     rotations, translations, lattice=None, symprec=1e-5
-) -> Optional[Dict]:
+):
     """Space group type information is obtained from a set of symmetry operations.
 
     Parameters

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import warnings
+from typing import Dict, Optional
 
 import numpy as np
 
@@ -303,61 +304,96 @@ def get_magnetic_symmetry(
 def get_symmetry_dataset(cell, symprec=1e-5, angle_tolerance=-1.0, hall_number=0):
     """Search symmetry dataset from an input cell.
 
-    Args:
-        cell, symprec, angle_tolerance:
-            See the docstring of get_symmetry.
-        hall_number: If a serial number of Hall symbol (>0) is given,
-                     the database corresponding to the Hall symbol is made.
+    Parameters
+    ----------
+    cell, symprec, angle_tolerance:
+        See the docstring of get_symmetry.
+    hall_number : int
+        If a serial number of Hall symbol (>0) is given, the database
+        corresponding to the Hall symbol is made.
 
-    Return:
-        A dictionary is returned. Dictionary keys:
-            number (int): International space group number
-            international (str): International symbol
-            hall (str): Hall symbol
-            choice (str): Centring, origin, basis vector setting
-            transformation_matrix (3x3 float):
-                Transformation matrix from input lattice to standardized
-                lattice:
-                    L^original = L^standardized * Tmat
-            origin shift (3 float):
-                Origin shift from standardized to input origin
-            rotations (3x3 int), translations (float vector):
-                Rotation matrices and translation vectors. Space group
-                operations are obtained by
-                [(r,t) for r, t in zip(rotations, translations)]
-            wyckoffs (n char): Wyckoff letters corresponding to the space
-                group type.
-            site_symmetry_symbols: Site symmetry symbols corresponding to the
-                space group type.
-            equivalent_atoms (n int): Symmetrically equivalent atoms, where
-                'symmetrically' means found symmetry operations. In spglib,
-                symmetry operations are given for the input cell. When a
-                non-primitive cell is inputted and the lattice made by the
-                non-primitive basis vectors breaks its point group,
-                the found symmetry operations may not correspond to the
-                crystallographic space group type.
-            crystallographic_orbits (n int): Symmetrically equivalent atoms,
-                where 'symmetrically' means the space group operations
-                corresponding to the space group type. This is very similar to
-                ``equivalent_atoms``. See the difference explained in
-                ``equivalent_atoms``
-            Primitive cell:
-                primitive_lattice (3x3 float, row vectors):
-                    Shape of cell by these basis vectors may not be nice.
-                mapping_to_primitive (n int):
-                    Atom index mapping from original cell to primitive cell
-            Idealized standardized unit cell:
-                std_lattice (3x3 float, row vectors),
-                std_positions (Nx3 float), std_types (N int)
-            std_rotation_matrix:
-                Rigid rotation matrix to rotate from standardized basis
-                vectors to idealized standardized basis vectors
-                    L^idealized = R * L^standardized
-            std_mapping_to_primitive (m int):
-                std_positions index mapping to those of primitive cell atoms
-            pointgroup (str): Pointgroup symbol
+    Returns
+    -------
+    dict or None
+        If it fails, None is returned. Otherwise a dictionary is returned.
+        Dictionary keys are as follows:
 
-        If it fails, None is returned.
+        number : int
+            International space group number.
+        international : str
+            International symbol.
+        hall : str
+            Hall symbol.
+        choice : str
+            Centring, origin, basis vector setting.
+        transformation_matrix : ndarray
+            Transformation matrix from input lattice to standardized lattice:
+                L^original = L^standardized * Tmat.
+            shape=(3, 3), order='C', dtype='double'
+        origin shift : ndarray
+            Origin shift from standardized to input origin.
+            shape=(3,), dtype='double'
+        rotations : ndarray
+            Matrix (rotation) parts of space group operations. Space group
+            operations are obtained by [(r,t) for r, t in zip(rotations,
+            translations)].
+            shape=(n_operations, 3, 3), order='C', dtype='intc'
+        translations : ndarray
+            Vector (translation) parts of space group operations. Space group
+            operations are obtained by [(r,t) for r, t in zip(rotations,
+            translations)].
+            shape=(n_operations, 3), order='C', dtype='double'
+        wyckoffs : list of str
+            Wyckoff letters corresponding to the space group type.
+        site_symmetry_symbols : list of str
+            Site symmetry symbols corresponding to the space group type.
+        equivalent_atoms : ndarray
+            Symmetrically equivalent atoms, where 'symmetrically' means found
+            symmetry operations. In spglib, symmetry operations are given for
+            the input cell. When a non-primitive cell is inputted and the
+            lattice made by the non-primitive basis vectors breaks its point
+            group, the found symmetry operations may not correspond to the
+            crystallographic space group type.
+            shape=(n_atoms,), dtype='intc'
+        crystallographic_orbits : ndarray
+            Symmetrically equivalent atoms, where 'symmetrically' means the
+            space group operations corresponding to the space group type. This
+            is very similar to ``equivalent_atoms``. See the difference
+            explained in ``equivalent_atoms``
+            shape=(n_atoms,), dtype='intc'
+        Primitive cell :
+            primitive_lattice : ndarray
+                Basis vectors a, b, c of a primitive cell in row vectors. This
+                is the primitive cell found inside spglib before applying
+                standardization. Therefore, the values are distorted with
+                respect to found space group type.
+                shape=(3, 3), order='C', dtype='double'
+            mapping_to_primitive : ndarray
+                Atom index mapping from original cell to the primitive cell of
+                ``primitive_lattice``.
+                shape=(n_atoms), dtype='intc'
+        Idealized standardized unit cell :
+            std_lattice : ndarray
+                Basis vectors a, b, c of a standardized cell in row vectors.
+                shape=(3, 3), order='C', dtype='double'
+            std_positions : ndarray
+                Positions of atoms in the standardized cell in fractional
+                coordinates.
+                shape=(n_atoms, 3), order='C', dtype='double'
+            std_types : ndarray
+                Identity numbers of atoms in the standarzied cell.
+                shape=(n_atoms,), dtype='intc'
+        std_rotation_matrix : ndarray
+            Rigid rotation matrix to rotate from standardized basis vectors to
+            idealized standardized basis vectors. Orthonormalized.
+                L^idealized = R * L^standardized.
+            shape=(3, 3), order='C', dtype='double'
+        std_mapping_to_primitive :
+            ``std_positions`` index mapping to those of atoms of the primitive
+            cell in the standardized cell.
+            dtype='intc'
+        pointgroup : str
+            Pointgroup symbol.
 
     """
     _set_no_error()
@@ -455,69 +491,73 @@ def get_magnetic_symmetry_dataset(
 ):
     """Search magnetic symmetry dataset from an input cell.
 
-    Args:
-        cell, is_axial, symprec, angle_tolerance, mag_symprec:
-            See the docstring of get_magnetic_symmetry.
+    Parameters
+    ----------
+    cell, is_axial, symprec, angle_tolerance, mag_symprec:
+        See the docstring of get_magnetic_symmetry.
 
-    Return:
-        A dictionary is returned. Dictionary keys:
-            Magnetic space-group type
-                uni_number: int
-                    UNI number between 1 to 1651
-                msg_type: int
-                    Magnetic space groups (MSG) is classified by its family space
-                    group (FSG) and maximal space subgroup (XSG). FSG is a non-magnetic
-                    space group obtained by ignoring time-reversal term in MSG. XSG is
-                    a space group obtained by picking out non time-reversal operations
-                    in MSG.
+    Returns
+    -------
+    dict or None
+        If it fails, None is returned. Otherwise a dictionary is returned.
+        Dictionary keys are as follows:
 
-                    msg_type==1 (type-I): MSG, XSG, FSG are all isomorphic.
-                    msg_type==2 (type-II): XSG and FSG are isomorphic, and MSG is
-                                           generated from XSG and pure time reversal
-                                           operations.
-                    msg_type==3 (type-III): XSG is a proper subgroup of MSG with
-                                            isomorphic translational subgroups.
-                    msg_type==4 (type-IV): XSG is a proper subgroup of MSG with
-                                           isomorphic point group.
-                hall_number: int
-                    For type-I, II, III, Hall number of FSG; for type-IV, that of XSG
-                tensor_rank: int
-            Magnetic symmetry operations
-                n_operations: int
-                rotations: array, (n_operations, 3, 3)
-                    Rotation (matrix) parts of symmetry operations
-                translations: array, (n_operations, 3)
-                    Translation (vector) parts of symmetry operations
-                time_reversals: array, (n_operations, )
-                    Time reversal part of magnetic symmetry operations.
-                    True indicates time reversal operation, and False indicates
-                    an ordinary operation.
-            Equivalent atoms
-                n_atoms: int
-                equivalent_atoms: array
-                    See the docstring of get_symmetry_dataset
-            Transformation to standardized setting
-                transformation_matrix: array, (3, 3)
-                    Transformation matrix from input lattice to standardized
-                origin_shift: array, (3, )
-                    Origin shift from standardized to input origin
-            Standardized crystal structure
-                n_std_atoms: int
-                    Number of atoms in standardized unit cell
-                std_lattice: array, (3, 3)
-                    Row-wise lattice vectors
-                std_types: array, (n_std_atoms, )
-                std_positions: array, (n_std_atoms, 3)
-                std_tensors: array
-                    (n_std_atoms, ) for collinear magnetic moments.
-                    (n_std_atoms, 3) for vector non-collinear magnetic moments.
-                std_rotation_matrix
-                    Rigid rotation matrix to rotate from standardized basis
-                    vectors to idealized standardized basis vectors
-            Intermediate data in symmetry search
-                primitive_lattice: array, (3, 3)
+        Magnetic space-group type
+            uni_number: int
+                UNI number between 1 to 1651
+            msg_type: int
+                Magnetic space groups (MSG) is classified by its family space
+                group (FSG) and maximal space subgroup (XSG). FSG is a non-magnetic
+                space group obtained by ignoring time-reversal term in MSG. XSG is
+                a space group obtained by picking out non time-reversal operations
+                in MSG.
 
-        If it fails, None is returned.
+                msg_type==1 (type-I): MSG, XSG, FSG are all isomorphic.
+                msg_type==2 (type-II): XSG and FSG are isomorphic, and MSG is
+                                        generated from XSG and pure time reversal
+                                        operations.
+                msg_type==3 (type-III): XSG is a proper subgroup of MSG with
+                                        isomorphic translational subgroups.
+                msg_type==4 (type-IV): XSG is a proper subgroup of MSG with
+                                        isomorphic point group.
+            hall_number: int
+                For type-I, II, III, Hall number of FSG; for type-IV, that of XSG
+            tensor_rank: int
+        Magnetic symmetry operations
+            n_operations: int
+            rotations: array, (n_operations, 3, 3)
+                Rotation (matrix) parts of symmetry operations
+            translations: array, (n_operations, 3)
+                Translation (vector) parts of symmetry operations
+            time_reversals: array, (n_operations, )
+                Time reversal part of magnetic symmetry operations.
+                True indicates time reversal operation, and False indicates
+                an ordinary operation.
+        Equivalent atoms
+            n_atoms: int
+            equivalent_atoms: array
+                See the docstring of get_symmetry_dataset
+        Transformation to standardized setting
+            transformation_matrix: array, (3, 3)
+                Transformation matrix from input lattice to standardized
+            origin_shift: array, (3, )
+                Origin shift from standardized to input origin
+        Standardized crystal structure
+            n_std_atoms: int
+                Number of atoms in standardized unit cell
+            std_lattice: array, (3, 3)
+                Row-wise lattice vectors
+            std_types: array, (n_std_atoms, )
+            std_positions: array, (n_std_atoms, 3)
+            std_tensors: array
+                (n_std_atoms, ) for collinear magnetic moments.
+                (n_std_atoms, 3) for vector non-collinear magnetic moments.
+            std_rotation_matrix
+                Rigid rotation matrix to rotate from standardized basis
+                vectors to idealized standardized basis vectors
+        Intermediate data in symmetry search
+            primitive_lattice: array, (3, 3)
+
     """
     _set_no_error()
 
@@ -617,6 +657,7 @@ def get_spacegroup(cell, symprec=1e-5, angle_tolerance=-1.0, symbol_type=0):
     """Return space group in international table symbol and number as a string.
 
     If it fails, None is returned.
+
     """
     _set_no_error()
 
@@ -633,21 +674,45 @@ def get_spacegroup(cell, symprec=1e-5, angle_tolerance=-1.0, symbol_type=0):
         return "%s (%d)" % (spg_type["international_short"], dataset["number"])
 
 
-def get_hall_number_from_symmetry(rotations, translations, symprec=1e-5):
-    """Hall number is obtained from a set of symmetry operations.
-
-    If it fails, None is returned.
-    """
-    r = np.array(rotations, dtype="intc", order="C")
-    t = np.array(translations, dtype="double", order="C")
-    hall_number = spg.hall_number_from_symmetry(r, t, symprec)
-    return hall_number
-
-
 def get_spacegroup_type(hall_number):
     """Translate Hall number to space group type information.
 
-    If it fails, None is returned.
+    Parameters
+    ----------
+    hall_number : int
+        Hall symbol ID.
+
+    Returns
+    -------
+    dict or None
+        If it fails, None is returned. Otherwise a dictionary is returned.
+        Dictionary keys are as follows:
+
+        number : int
+            International space group number
+        international_short : str
+            International short symbol.
+        international_full : str
+            International full symbol.
+        international : str
+            International symbol.
+        schoenflies : str
+            Schoenflies symbol.
+        hall_number : int
+            Hall symbol ID number.
+        hall_symbol : str
+            Hall symbol.
+        choice : str
+            Centring, origin, basis vector setting.
+        pointgroup_international :
+            International symbol of crystallographic point group.
+        pointgroup_schoenflies :
+            Schoenflies symbol of crystallographic point group.
+        arithmetic_crystal_class_number : int
+            Arithmetic crystal class number
+        arithmetic_crystal_class_symbol : str
+            Arithmetic crystal class symbol.
+
     """
     _set_no_error()
 
@@ -657,6 +722,7 @@ def get_spacegroup_type(hall_number):
         "international_full",
         "international",
         "schoenflies",
+        "hall_number",
         "hall_symbol",
         "choice",
         "pointgroup_international",
@@ -670,7 +736,94 @@ def get_spacegroup_type(hall_number):
     if spg_type_list is not None:
         spg_type = dict(zip(keys, spg_type_list))
         for key in spg_type:
-            if key != "number" and key != "arithmetic_crystal_class_number":
+            if key not in ("number", "hall_number", "arithmetic_crystal_class_number"):
+                spg_type[key] = spg_type[key].strip()
+        return spg_type
+    else:
+        return None
+
+
+def get_spacegroup_type_from_symmetry(
+    rotations, translations, lattice=None, symprec=1e-5
+) -> Optional[Dict]:
+    """Space group type information is obtained from a set of symmetry operations.
+
+    Parameters
+    ----------
+    rotations : array_like
+        Matrix parts of space group operations.
+        shape=(n_operations, 3, 3), order='C', dtype='intc'
+    translations : array_like
+        Vector parts of space group operations.
+        shape=(n_operations, 3), order='C', dtype='double'
+    lattice : array_like, optional
+        Basis vectors a, b, c given in row vectors. This is used as the measure of
+        distance. Default is None, which gives unit matrix.
+        shape=(3, 3), order='C', dtype='double'
+
+    Returns
+    -------
+    dict or None
+        If it fails, None is returned. Otherwise a dictionary is returned.
+        Dictionary keys are as follows:
+
+        number : int
+            International space group number
+        international_short : str
+            International short symbol.
+        international_full : str
+            International full symbol.
+        international : str
+            International symbol.
+        schoenflies : str
+            Schoenflies symbol.
+        hall_number : int
+            Hall symbol ID number.
+        hall_symbol : str
+            Hall symbol.
+        choice : str
+            Centring, origin, basis vector setting.
+        pointgroup_international :
+            International symbol of crystallographic point group.
+        pointgroup_schoenflies :
+            Schoenflies symbol of crystallographic point group.
+        arithmetic_crystal_class_number : int
+            Arithmetic crystal class number
+        arithmetic_crystal_class_symbol : str
+            Arithmetic crystal class symbol.
+
+    """
+    r = np.array(rotations, dtype="intc", order="C")
+    t = np.array(translations, dtype="double", order="C")
+    if lattice is None:
+        _lattice = np.eye(3, dtype="double", order="C")
+    else:
+        _lattice = np.array(lattice, dtype="double", order="C")
+
+    _set_no_error()
+
+    keys = (
+        "number",
+        "international_short",
+        "international_full",
+        "international",
+        "schoenflies",
+        "hall_number",
+        "hall_symbol",
+        "choice",
+        "pointgroup_international",
+        "pointgroup_schoenflies",
+        "arithmetic_crystal_class_number",
+        "arithmetic_crystal_class_symbol",
+    )
+
+    spg_type_list = spg.spacegroup_type_from_symmetry(r, t, _lattice, symprec)
+    _set_error_message()
+
+    if spg_type_list is not None:
+        spg_type = dict(zip(keys, spg_type_list))
+        for key in spg_type:
+            if key not in ("number", "hall_number", "arithmetic_crystal_class_number"):
                 spg_type[key] = spg_type[key].strip()
         return spg_type
     else:
@@ -681,6 +834,7 @@ def get_magnetic_spacegroup_type(uni_number):
     """Translate UNI number to magnetic space group type information.
 
     If it fails, return None
+
     """
     _set_no_error()
 
@@ -741,6 +895,7 @@ def get_pointgroup(rotations):
     30  "432  "
     31  "-43m "
     32  "m-3m "
+
     """
     _set_no_error()
 
@@ -755,19 +910,21 @@ def standardize_cell(
 ):
     """Return standardized cell.
 
-    Args:
-        cell, symprec, angle_tolerance:
-            See the docstring of get_symmetry.
-        to_primitive:
-            bool: If True, the standardized primitive cell is created.
-        no_idealize:
-            bool: If True,  it is disabled to idealize lengths and angles of
-                  basis vectors and positions of atoms according to crystal
-                  symmetry.
-    Return:
-        The standardized unit cell or primitive cell is returned by a tuple of
-        (lattice, positions, numbers).
-        If it fails, None is returned.
+    Parameters
+    ----------
+    cell, symprec, angle_tolerance:
+        See the docstring of get_symmetry.
+    to_primitive : bool
+        If True, the standardized primitive cell is created.
+    no_idealize : bool
+        If True, it is disabled to idealize lengths and angles of basis vectors
+        and positions of atoms according to crystal symmetry.
+
+    Returns
+    -------
+    The standardized unit cell or primitive cell is returned by a tuple of
+    (lattice, positions, numbers). If it fails, None is returned.
+
     """
     _set_no_error()
 
@@ -1364,3 +1521,23 @@ def _set_error_message():
 
 def _set_no_error():
     spglib_error.message = "no error"
+
+
+def get_hall_number_from_symmetry(rotations, translations, symprec=1e-5):
+    """Hall number is obtained from a set of symmetry operations.
+
+    Deprecated at v2.0.
+
+    If it fails, None is returned.
+
+    """
+    warnings.warn(
+        "get_hall_number_from_symmetry() is deprecated. "
+        "Use get_spacegroup_type_from_symmetry() instead.",
+        DeprecationWarning,
+    )
+
+    r = np.array(rotations, dtype="intc", order="C")
+    t = np.array(translations, dtype="double", order="C")
+    hall_number = spg.hall_number_from_symmetry(r, t, symprec)
+    return hall_number

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,253 @@
+"""Pytest configuration."""
+from io import StringIO
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+import numpy as np
+import pytest
+
+_dirnames = (
+    "cubic",
+    "hexagonal",
+    "monoclinic",
+    "orthorhombic",
+    "tetragonal",
+    "triclinic",
+    "trigonal",
+    "distorted",
+    "virtual_structure",
+)
+
+_data_dir = Path(__file__).parent.absolute() / "data"
+
+
+@pytest.fixture(scope="session")
+def dirnames() -> Tuple:
+    """Return test directory names."""
+    return (_data_dir / d for d in _dirnames)
+
+
+@pytest.fixture(scope="session")
+def all_filenames() -> List:
+    """Return all filenames in test directories."""
+    all_filenames = []
+    for d in (_data_dir / _d for _d in _dirnames):
+        all_filenames += [d / fname for fname in d.iterdir()]
+    return all_filenames
+
+
+@pytest.fixture(scope="session")
+def read_vasp() -> Callable:
+    """Return function to read POSCAR."""
+
+    def _read_vasp(filename):
+        with open(filename) as f:
+            lines = f.readlines()
+            return _get_cell(lines)
+        return None
+
+    return _read_vasp
+
+
+def read_vasp_from_strings(strings):
+    return _get_cell(StringIO(strings).readlines())
+
+
+def _get_cell(lines):
+    line1 = [x for x in lines[0].split()]
+    if _is_exist_symbols(line1):
+        symbols = line1
+    else:
+        symbols = None
+
+    scale = float(lines[1])
+
+    lattice = []
+    for i in range(2, 5):
+        lattice.append([float(x) for x in lines[i].split()[:3]])
+    lattice = np.array(lattice) * scale
+
+    try:
+        num_atoms = np.array([int(x) for x in lines[5].split()])
+        line_at = 6
+    except ValueError:
+        symbols = [x for x in lines[5].split()]
+        num_atoms = np.array([int(x) for x in lines[6].split()])
+        line_at = 7
+
+    numbers = _expand_symbols(num_atoms, symbols)
+
+    if lines[line_at][0].lower() == "s":
+        line_at += 1
+
+    is_cartesian = False
+    if lines[line_at][0].lower() == "c" or lines[line_at][0].lower() == "k":
+        is_cartesian = True
+
+    line_at += 1
+
+    positions = []
+    for i in range(line_at, line_at + num_atoms.sum()):
+        positions.append([float(x) for x in lines[i].split()[:3]])
+
+    if is_cartesian:
+        positions = np.dot(positions, np.linalg.inv(lattice))
+
+    return (lattice, positions, numbers)
+
+
+def _expand_symbols(num_atoms, symbols=None):
+    expanded_symbols = []
+    is_symbols = True
+    if symbols is None:
+        is_symbols = False
+    else:
+        if len(symbols) != len(num_atoms):
+            is_symbols = False
+        else:
+            for s in symbols:
+                if s not in symbol_map:
+                    is_symbols = False
+                    break
+
+    if is_symbols:
+        for s, num in zip(symbols, num_atoms):
+            expanded_symbols += [
+                symbol_map[s],
+            ] * num
+    else:
+        for i, num in enumerate(num_atoms):
+            expanded_symbols += [
+                i + 1,
+            ] * num
+
+    return expanded_symbols
+
+
+def _is_exist_symbols(symbols):
+    for s in symbols:
+        if not (s in symbol_map):
+            return False
+    return True
+
+
+symbol_map = {
+    "H": 1,
+    "He": 2,
+    "Li": 3,
+    "Be": 4,
+    "B": 5,
+    "C": 6,
+    "N": 7,
+    "O": 8,
+    "F": 9,
+    "Ne": 10,
+    "Na": 11,
+    "Mg": 12,
+    "Al": 13,
+    "Si": 14,
+    "P": 15,
+    "S": 16,
+    "Cl": 17,
+    "Ar": 18,
+    "K": 19,
+    "Ca": 20,
+    "Sc": 21,
+    "Ti": 22,
+    "V": 23,
+    "Cr": 24,
+    "Mn": 25,
+    "Fe": 26,
+    "Co": 27,
+    "Ni": 28,
+    "Cu": 29,
+    "Zn": 30,
+    "Ga": 31,
+    "Ge": 32,
+    "As": 33,
+    "Se": 34,
+    "Br": 35,
+    "Kr": 36,
+    "Rb": 37,
+    "Sr": 38,
+    "Y": 39,
+    "Zr": 40,
+    "Nb": 41,
+    "Mo": 42,
+    "Tc": 43,
+    "Ru": 44,
+    "Rh": 45,
+    "Pd": 46,
+    "Ag": 47,
+    "Cd": 48,
+    "In": 49,
+    "Sn": 50,
+    "Sb": 51,
+    "Te": 52,
+    "I": 53,
+    "Xe": 54,
+    "Cs": 55,
+    "Ba": 56,
+    "La": 57,
+    "Ce": 58,
+    "Pr": 59,
+    "Nd": 60,
+    "Pm": 61,
+    "Sm": 62,
+    "Eu": 63,
+    "Gd": 64,
+    "Tb": 65,
+    "Dy": 66,
+    "Ho": 67,
+    "Er": 68,
+    "Tm": 69,
+    "Yb": 70,
+    "Lu": 71,
+    "Hf": 72,
+    "Ta": 73,
+    "W": 74,
+    "Re": 75,
+    "Os": 76,
+    "Ir": 77,
+    "Pt": 78,
+    "Au": 79,
+    "Hg": 80,
+    "Tl": 81,
+    "Pb": 82,
+    "Bi": 83,
+    "Po": 84,
+    "At": 85,
+    "Rn": 86,
+    "Fr": 87,
+    "Ra": 88,
+    "Ac": 89,
+    "Th": 90,
+    "Pa": 91,
+    "U": 92,
+    "Np": 93,
+    "Pu": 94,
+    "Am": 95,
+    "Cm": 96,
+    "Bk": 97,
+    "Cf": 98,
+    "Es": 99,
+    "Fm": 100,
+    "Md": 101,
+    "No": 102,
+    "Lr": 103,
+    "Rf": 104,
+    "Db": 105,
+    "Sg": 106,
+    "Bh": 107,
+    "Hs": 108,
+    "Mt": 109,
+    "Ds": 110,
+    "Rg": 111,
+    "Cn": 112,
+    "Nh": 113,
+    "Fl": 114,
+    "Mc": 115,
+    "Lv": 116,
+    "Ts": 117,
+    "Og": 118,
+}

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,7 +1,8 @@
 """Pytest configuration."""
-from io import StringIO
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Callable, List, Tuple
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -22,13 +23,13 @@ _data_dir = Path(__file__).parent.absolute() / "data"
 
 
 @pytest.fixture(scope="session")
-def dirnames() -> Tuple:
+def dirnames() -> list[Path]:
     """Return test directory names."""
-    return (_data_dir / d for d in _dirnames)
+    return [_data_dir / d for d in _dirnames]
 
 
 @pytest.fixture(scope="session")
-def all_filenames() -> List:
+def all_filenames() -> list:
     """Return all filenames in test directories."""
     all_filenames = []
     for d in (_data_dir / _d for _d in _dirnames):
@@ -44,13 +45,12 @@ def read_vasp() -> Callable:
         with open(filename) as f:
             lines = f.readlines()
             return _get_cell(lines)
-        return None
 
     return _read_vasp
 
 
-def read_vasp_from_strings(strings):
-    return _get_cell(StringIO(strings).readlines())
+# def read_vasp_from_strings(strings):
+#     return _get_cell(StringIO(strings).readlines())
 
 
 def _get_cell(lines):

--- a/python/test/test_hall_number_from_symmetry.py
+++ b/python/test/test_hall_number_from_symmetry.py
@@ -1,63 +1,49 @@
-import os
-import unittest
+"""Test of get_hall_number_from_symmetry."""
+from __future__ import annotations
 
-from test_spglib import dirnames
-from vasp import read_vasp
+import os
+from pathlib import Path
+from typing import Callable
+
+import pytest
 
 from spglib import get_hall_number_from_symmetry, get_symmetry_dataset
 
 data_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-class TestGetHallNumberFromSymmetry(unittest.TestCase):
-    def setUp(self):
-        self._filenames = []
-        for d in dirnames:
-            dirname = os.path.join(data_dir, "data", d)
-            filenames = os.listdir(dirname)
-            self._filenames += [os.path.join(dirname, fname) for fname in filenames]
-
-    def tearDown(self):
-        pass
-
-    def test_get_hall_number_from_symmetry(self):
-        for fname in self._filenames:
-            cell = read_vasp(fname)
-            if "distorted" in fname:
-                dataset = get_symmetry_dataset(cell, symprec=1e-1)
-                hall_number = get_hall_number_from_symmetry(
-                    dataset["rotations"], dataset["translations"], symprec=1e-1
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_get_hall_number_from_symmetry(all_filenames: list[Path], read_vasp: Callable):
+    """Test get_hall_number_from_symmetry."""
+    for fname in all_filenames:
+        cell = read_vasp(fname)
+        if "distorted" in str(fname):
+            dataset = get_symmetry_dataset(cell, symprec=1e-1)
+            hall_number = get_hall_number_from_symmetry(
+                dataset["rotations"], dataset["translations"], symprec=1e-1
+            )
+            if hall_number != dataset["hall_number"]:
+                print("%d != %d in %s" % (hall_number, dataset["hall_number"], fname))
+                ref_cell = (
+                    dataset["std_lattice"],
+                    dataset["std_positions"],
+                    dataset["std_types"],
                 )
-                if hall_number != dataset["hall_number"]:
-                    print(
-                        "%d != %d in %s" % (hall_number, dataset["hall_number"], fname)
-                    )
-                    ref_cell = (
-                        dataset["std_lattice"],
-                        dataset["std_positions"],
-                        dataset["std_types"],
-                    )
-                    dataset = get_symmetry_dataset(ref_cell, symprec=1e-5)
-                    hall_number = get_hall_number_from_symmetry(
-                        dataset["rotations"], dataset["translations"], symprec=1e-5
-                    )
-                    print(
-                        "Using refined cell: %d, %d in %s"
-                        % (hall_number, dataset["hall_number"], fname)
-                    )
-            else:
-                dataset = get_symmetry_dataset(cell, symprec=1e-5)
+                dataset = get_symmetry_dataset(ref_cell, symprec=1e-5)
                 hall_number = get_hall_number_from_symmetry(
                     dataset["rotations"], dataset["translations"], symprec=1e-5
                 )
-            self.assertEqual(
-                hall_number,
-                dataset["hall_number"],
-                msg=("%d != %d in %s" % (hall_number, dataset["hall_number"], fname)),
+                print(
+                    "Using refined cell: %d, %d in %s"
+                    % (hall_number, dataset["hall_number"], fname)
+                )
+        else:
+            dataset = get_symmetry_dataset(cell, symprec=1e-5)
+            hall_number = get_hall_number_from_symmetry(
+                dataset["rotations"], dataset["translations"], symprec=1e-5
             )
-
-
-if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestGetHallNumberFromSymmetry)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    # unittest.main()
+        assert hall_number == dataset["hall_number"], "%d != %d in %s" % (
+            hall_number,
+            dataset["hall_number"],
+            fname,
+        )

--- a/python/test/test_spacegrouop_type_from_symmetry.py
+++ b/python/test/test_spacegrouop_type_from_symmetry.py
@@ -1,0 +1,61 @@
+"""Test of spacegroup_type_from_symmetry."""
+import os
+from pathlib import Path
+from typing import Callable, List
+
+from spglib import (
+    get_spacegroup_type,
+    get_spacegroup_type_from_symmetry,
+    get_symmetry_dataset,
+)
+
+data_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_spacegroup_type_from_symmetry(all_filenames: List[Path], read_vasp: Callable):
+    """Test spacegroup_type_from_symmetry."""
+    for fname in all_filenames:
+        cell = read_vasp(fname)
+        if "distorted" in str(fname):
+            dataset = get_symmetry_dataset(cell, symprec=1e-1)
+            spgtype = get_spacegroup_type_from_symmetry(
+                dataset["rotations"],
+                dataset["translations"],
+                lattice=cell[0],
+                symprec=1e-1,
+            )
+            if spgtype["number"] != dataset["number"]:
+                print("%d != %d in %s" % (spgtype["number"], dataset["number"], fname))
+                ref_cell = (
+                    dataset["std_lattice"],
+                    dataset["std_positions"],
+                    dataset["std_types"],
+                )
+                dataset = get_symmetry_dataset(ref_cell, symprec=1e-5)
+                spgtype = get_spacegroup_type_from_symmetry(
+                    dataset["rotations"],
+                    dataset["translations"],
+                    lattice=cell[0],
+                    symprec=1e-5,
+                )
+                print(
+                    "Using refined cell: %d, %d in %s"
+                    % (spgtype["number"], dataset["number"], fname)
+                )
+        else:
+            dataset = get_symmetry_dataset(cell, symprec=1e-5)
+            spgtype = get_spacegroup_type_from_symmetry(
+                dataset["rotations"],
+                dataset["translations"],
+                lattice=cell[0],
+                symprec=1e-5,
+            )
+
+        assert spgtype["number"] == dataset["number"], "%d != %d in %s" % (
+            spgtype["number"],
+            dataset["number"],
+            fname,
+        )
+        spgtype_ref = get_spacegroup_type(dataset["hall_number"])
+        for key in spgtype:
+            assert spgtype[key] == spgtype_ref[key]

--- a/python/test/test_spacegrouop_type_from_symmetry.py
+++ b/python/test/test_spacegrouop_type_from_symmetry.py
@@ -1,7 +1,9 @@
 """Test of spacegroup_type_from_symmetry."""
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 
@@ -16,7 +18,7 @@ data_dir = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.mark.parametrize("lattice_None", [True, False])
 def test_spacegroup_type_from_symmetry(
-    all_filenames: List[Path], read_vasp: Callable, lattice_None: bool
+    all_filenames: list[Path], read_vasp: Callable, lattice_None: bool
 ):
     """Test spacegroup_type_from_symmetry."""
     for fname in all_filenames:

--- a/python/test/test_spacegrouop_type_from_symmetry.py
+++ b/python/test/test_spacegrouop_type_from_symmetry.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 from typing import Callable, List
 
+import pytest
+
 from spglib import (
     get_spacegroup_type,
     get_spacegroup_type_from_symmetry,
@@ -12,16 +14,23 @@ from spglib import (
 data_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_spacegroup_type_from_symmetry(all_filenames: List[Path], read_vasp: Callable):
+@pytest.mark.parametrize("lattice_None", [True, False])
+def test_spacegroup_type_from_symmetry(
+    all_filenames: List[Path], read_vasp: Callable, lattice_None: bool
+):
     """Test spacegroup_type_from_symmetry."""
     for fname in all_filenames:
         cell = read_vasp(fname)
+        if lattice_None:
+            lattice = None
+        else:
+            lattice = cell[0]
         if "distorted" in str(fname):
             dataset = get_symmetry_dataset(cell, symprec=1e-1)
             spgtype = get_spacegroup_type_from_symmetry(
                 dataset["rotations"],
                 dataset["translations"],
-                lattice=cell[0],
+                lattice=lattice,
                 symprec=1e-1,
             )
             if spgtype["number"] != dataset["number"]:
@@ -35,7 +44,7 @@ def test_spacegroup_type_from_symmetry(all_filenames: List[Path], read_vasp: Cal
                 spgtype = get_spacegroup_type_from_symmetry(
                     dataset["rotations"],
                     dataset["translations"],
-                    lattice=cell[0],
+                    lattice=lattice,
                     symprec=1e-5,
                 )
                 print(
@@ -47,7 +56,7 @@ def test_spacegroup_type_from_symmetry(all_filenames: List[Path], read_vasp: Cal
             spgtype = get_spacegroup_type_from_symmetry(
                 dataset["rotations"],
                 dataset["translations"],
-                lattice=cell[0],
+                lattice=lattice,
                 symprec=1e-5,
             )
 

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -536,6 +536,7 @@ static Symmetry *get_space_group_with_magnetic_symmetry(
     int i, num_sym_msg, num_sym, is_type2;
     Symmetry *sym, *prim_sym;
     int identity[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+    double unit_lat[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
     double tmat[3][3], inv_tmat[3][3];
 
     sym = NULL;
@@ -581,8 +582,8 @@ static Symmetry *get_space_group_with_magnetic_symmetry(
 
     /* (a, b, c) = (a_prim, b_prim, c_prim) @ tmat */
     prim_sym = prm_get_primitive_symmetry(tmat, sym, symprec);
-
-    *spacegroup = spa_search_spacegroup_with_symmetry(prim_sym, symprec);
+    *spacegroup =
+        spa_search_spacegroup_with_symmetry(prim_sym, unit_lat, symprec);
     /* refine bravais_lattice and origin_shift */
     ref_find_similar_bravais_lattice(*spacegroup, symprec);
     /* At this point, let P = spacegroup->bravais_lattice, p =

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -251,7 +251,7 @@ int prm_get_primitive_lattice_vectors(double prim_lattice[3][3],
 /* Return NULL if failed */
 static Primitive *get_primitive(const Cell *cell, const double symprec,
                                 const double angle_tolerance) {
-    int i, attempt;
+    int attempt;
     double tolerance;
     Primitive *primitive;
     VecDBL *pure_trans;

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -518,6 +518,7 @@ Spacegroup *spa_search_spacegroup(const Primitive *primitive,
 /* Return NULL if failed */
 /* Assume symmetry is transformed in primitive cell. */
 Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
+                                                SPGCONST double prim_lat[3][3],
                                                 const double symprec) {
     int i, hall_number;
     Spacegroup *spacegroup;
@@ -531,7 +532,7 @@ Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
     if ((primitive->cell = cel_alloc_cell(1, NOSPIN)) == NULL) {
         return 0;
     }
-    mat_copy_matrix_d3(primitive->cell->lattice, identity);
+    mat_copy_matrix_d3(primitive->cell->lattice, prim_lat);
     for (i = 0; i < 3; i++) {
         primitive->cell->position[0][i] = 0;
     }

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -520,7 +520,7 @@ Spacegroup *spa_search_spacegroup(const Primitive *primitive,
 Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
                                                 SPGCONST double prim_lat[3][3],
                                                 const double symprec) {
-    int i, hall_number;
+    int i;
     Spacegroup *spacegroup;
     Primitive *primitive;
 

--- a/src/spacegroup.h
+++ b/src/spacegroup.h
@@ -70,6 +70,7 @@ Spacegroup *spa_search_spacegroup(const Primitive *primitive,
                                   const int hall_number, const double symprec,
                                   const double angle_tolerance);
 Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
+                                                SPGCONST double prim_lat[3][3],
                                                 const double symprec);
 Cell *spa_transform_to_primitive(int *mapping_table, const Cell *cell,
                                  SPGCONST double trans_mat[3][3],

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -2313,6 +2313,7 @@ SpglibSpacegroupType get_spacegroup_type(const int hall_number) {
     char arth_symbol[7];
 
     spglibtype.number = 0;
+    spglibtype.hall_number = 0;
     strcpy(spglibtype.schoenflies, "");
     strcpy(spglibtype.hall_symbol, "");
     strcpy(spglibtype.choice, "");
@@ -2327,6 +2328,7 @@ SpglibSpacegroupType get_spacegroup_type(const int hall_number) {
     if (0 < hall_number && hall_number < 531) {
         spgtype = spgdb_get_spacegroup_type(hall_number);
         spglibtype.number = spgtype.number;
+        spglibtype.hall_number = hall_number;
         memcpy(spglibtype.schoenflies, spgtype.schoenflies, 7);
         memcpy(spglibtype.hall_symbol, spgtype.hall_symbol, 17);
         memcpy(spglibtype.choice, spgtype.choice, 6);
@@ -2355,7 +2357,6 @@ static int get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
     Symmetry *prim_symmetry;
     Spacegroup *spacegroup;
     double t_mat[3][3], t_mat_inv[3][3], prim_lat[3][3];
-    SpglibSpacegroupType spglibtype;
 
     symmetry = NULL;
     prim_symmetry = NULL;

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -304,11 +304,26 @@ int spgms_get_symmetry_with_site_tensors(
     const double symprec, const double angle_tolerance,
     const double mag_symprec);
 
+/* Deprecated at v2.0 */
 /* Space group type (hall_number) is searched from symmetry operations. */
 int spg_get_hall_number_from_symmetry(SPGCONST int rotation[][3][3],
                                       SPGCONST double translation[][3],
                                       const int num_operations,
                                       const double symprec);
+/**
+ * @brief Search space group type from symmetry operations
+ *
+ * @param rotation Matrix parts of space group operations
+ * @param translation Vector parts of space grouop operations
+ * @param num_operations Number of space group operations
+ * @param lattice Basis vectors given as column vectors
+ * @param symprec
+ * @return SpglibSpacegroupType
+ */
+SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
+    SPGCONST int rotation[][3][3], SPGCONST double translation[][3],
+    const int num_operations, SPGCONST double lattice[3][3],
+    const double symprec);
 
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
     SPGCONST int rotations[][3][3], SPGCONST double translations[][3],
@@ -362,14 +377,16 @@ int spg_get_symmetry_from_database(int rotations[192][3][3],
                                    const int hall_number);
 
 /* This is unstable feature under active development! */
-/* Magnetic space-group operations in built-in database are accessed by UNI */
-/* number, which is defined as number from 1 to 1651. Optionally alternative */
+/* Magnetic space-group operations in built-in database are accessed by UNI
+ */
+/* number, which is defined as number from 1 to 1651. Optionally alternative
+ */
 /* settings can be specified with hall_number. For type-I, type-II, and */
-/* type-III magnetic space groups, hall_number changes settings in family space
- * group. */
+/* type-III magnetic space groups, hall_number changes settings in family
+ * space group. */
 /* For type-IV, hall_number changes settings in maximal space group. */
-/* When hall_number = 0, the smallest hall number corresponding to uni_number is
- * used. */
+/* When hall_number = 0, the smallest hall number corresponding to
+ * uni_number is used. */
 int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
                                             double translations[384][3],
                                             int time_reversals[384],
@@ -381,7 +398,8 @@ int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
 SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number);
 
 /* This is unstable feature under active development! */
-/* Magnetic space-group type information is accessed by index of UNI symbol. */
+/* Magnetic space-group type information is accessed by index of UNI symbol.
+ */
 /* The index is defined as number from 1 to 1651. */
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type(
     const int uni_number);
@@ -398,7 +416,8 @@ int spgat_standardize_cell(double lattice[3][3], double position[][3],
 
 /* This is a wrapper of spg_standardize_cell. */
 /* A primitive cell is found from an input cell. */
-/* Be careful that ``lattice``, ``position``, and ``types`` are overwritten. */
+/* Be careful that ``lattice``, ``position``, and ``types`` are overwritten.
+ */
 /* ``num_atom`` is returned as return value. */
 /* When any primitive cell is not found, 0 is returned. */
 int spg_find_primitive(double lattice[3][3], double position[][3], int types[],
@@ -487,7 +506,8 @@ size_t spg_get_dense_stabilized_reciprocal_mesh(
     SPGCONST double qpoints[][3]);
 
 /* Rotation operations in reciprocal space ``rot_reciprocal`` are applied */
-/* to a grid address ``address_orig`` and resulting grid points are stored in */
+/* to a grid address ``address_orig`` and resulting grid points are stored
+ * in */
 /* ``rot_grid_points``. Return 0 if failed. */
 void spg_get_grid_points_by_rotations(int rot_grid_points[],
                                       const int address_orig[3],

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -142,6 +142,7 @@ typedef struct {
     char international_full[20];
     char international[32];
     char schoenflies[7];
+    int hall_number;
     char hall_symbol[17];
     char choice[6];
     char pointgroup_international[6];


### PR DESCRIPTION
`spg_get_spacegroup_type_from_symmetry` is implemented to replace `spg_get_hall_number_from_symmetry` that is deprecated at v2.0.

- [x] C-API
- [x] test.c
- [x] Python-API
- [x] pytest