### PR TITLE
Install spglib pkgconfig into LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,5 +132,5 @@ endif()
 configure_file(spglib.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/spglib.pc)
 install(
   FILES  ${CMAKE_CURRENT_BINARY_DIR}/spglib.pc
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig
   COMPONENT pkgconfig)

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -25,5 +25,5 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.mod DESTINATION ${CMAKE_INS
 configure_file(spglib_f08.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.pc)
 install(
 	FILES  ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.pc
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
+	DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig
 	COMPONENT pkgconfig)

--- a/fortran/spglib_f08.pc.cmake
+++ b/fortran/spglib_f08.pc.cmake
@@ -2,5 +2,5 @@ Name: ${PROJECT_NAME}
 Description: The spglib f08 library
 depends: spglib
 Version: ${PROJECT_VERSION}
-Libs: -L${CMAKE_INSTALL_PREFIX}/lib -lspglib_f08
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include -I${CMAKE_INSTALL_PREFIX}/lib
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -lspglib_f08
+Cflags: -I${CMAKE_INSTALL_PREFIX}/include -I${CMAKE_INSTALL_FULL_LIBDIR}

--- a/spglib.pc.cmake
+++ b/spglib.pc.cmake
@@ -1,5 +1,5 @@
 Name: ${PROJECT_NAME}
 Description: The spglib library
 Version: ${PROJECT_VERSION}
-Libs: -L${CMAKE_INSTALL_PREFIX}/lib -lsymspg
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -lsymspg
 Cflags: -I${CMAKE_INSTALL_PREFIX}/include


### PR DESCRIPTION
The pkgconfig file is architecture specific, so it needs
to be installed into libdir/pkgconfig. On Red Hat/SUSE
like distributions libdir is actually $prefix/lib64 on
64bit platforms.

Signed-off-by: Dirk Müller <dirk@dmllr.de>