### PR TITLE
Fix include-path problem in testing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,17 +42,12 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# Include src/spglib.h
-include_directories(${PROJECT_SOURCE_DIR}/../src)
-# Include test/utils.h
-include_directories(${PROJECT_SOURCE_DIR})
+# Include src/spglib.h and test/utils.h
+include_directories("${PROJECT_SOURCE_DIR}/../src" "${PROJECT_SOURCE_DIR}")
 
-# Source code
+# Static library
 file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/../src/*.c)
-list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/../src/test.c)
-
-# Shared library
-add_library(symspg SHARED ${SOURCES})
+add_library(symspg STATIC ${SOURCES})
 
 # Fetch GoogleTest
 include(FetchContent)


### PR DESCRIPTION
Fixes https://github.com/spglib/spglib/issues/182.

When spglib.h appears several times in directoies specified by -I, -iquote,
-isystem, or -idirafter, older spglib.h may be chosen (especially when
installing spglib and C compiler via conda). To fix the inconsistency,
use static library of `symspg.so` for testing. Then, src/spglib.h is
searched first since it locates the same directory as other src/*.c
files.

@atztogo I've reproduced the test failures when installing compilers and spglib via Conda. 
Can you check this PR and, if it works, merge it?