### PR TITLE
Skip to determine time-reversal part for non-overlapped operations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,9 @@ If spglib returns different results by changing `symprec`, `angle_tolerance`, or
 <!-- A clear and concise description of what you expected to happen. -->
 
 ## Environment
- 
-- Python version: 
-- Spglib's version: 
+
+- Python version:
+- Spglib's version:
 
 ## Additional context
 

--- a/doc/magnetic_symmetry_flags.md
+++ b/doc/magnetic_symmetry_flags.md
@@ -30,10 +30,10 @@
 - `tensor_rank=1`
     - `with_time_reversal=true`: {math}`1' \circ \mathbf{m} = -\mathbf{m}`
         - `is_axial=true`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = (\mathrm{det} \mathbf{R}) \mathbf{R} \mathbf{m}`
-        - `is_axial=true`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = \mathbf{R} \mathbf{m}`
+        - `is_axial=false`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = \mathbf{R} \mathbf{m}`
     - `with_time_reversal=false`: {math}`1' \circ \mathbf{m} = \mathbf{m}`
         - `is_axial=true`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = (\mathrm{det} \mathbf{R}) \mathbf{R} \mathbf{m}`
-        - `is_axial=true`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = \mathbf{R} \mathbf{m}`
+        - `is_axial=false`: {math}`(\mathbf{R}, \mathbf{v}) \circ \mathbf{m} = \mathbf{R} \mathbf{m}`
 
 <!-- ### Correspondence
 

--- a/src/overlap.c
+++ b/src/overlap.c
@@ -641,7 +641,7 @@ static int check_total_overlap_for_sorted(
     search_start = 0;
     for (i_orig = 0; i_orig < num_pos; i_orig++) {
         /* Permanently skip positions filled near the beginning. */
-        while (found[search_start]) {
+        while ((search_start < num_pos) && found[search_start]) {
             search_start++;
         }
 

--- a/src/spin.c
+++ b/src/spin.c
@@ -408,8 +408,12 @@ static MagneticSymmetry *get_operations(
                 }
             }
             if (k == cell->size) {
-                /* Unreachable here! */
-                return NULL;
+                // Unreachable here in theory, but we rarely fail to overlap
+                // atoms possibly due to too high symprec. In that case, skip
+                // the symmetry operation.
+                debug_print("Failed to overlap atom-%d by operation-%d\n", j, i);
+                found = 0;
+                break;
             }
 
             // Skip if relevant tensors are zeros because they have nothing to


### PR DESCRIPTION
Fixes: https://github.com/spglib/spglib/issues/194

Time-reversal parts are searched after determining linear and
translation parts of symmetry operations by `get_dataset`. It
is impossible in theory but we rarely fail to overlap atoms
possibly due to too high symprec. In that case, skip the
symmetry operation.

@atztogo In some edge cases with high `symprec`, a symmetry operation in `DataContainer->exact_structure->Symmetry` does not follow `symprec` (on the other hand, the not-refined operation follows `symprec`).
In the current implementation for MSG search, permutations of sites are computed from `DataContainer->exact_structure->symmetry`. Then, the segmentation fault in https://github.com/spglib/spglib/issues/194 was caused.
This PR just skips such a suspicious operation and does not change space-group search codes.
So, I will merge this if there are no concerns.

Not addressed in this PR, but I think adding permutation information in `DataContainer` will be better (e.g. ``int *DataContainer->exact_structure->permutations``).