### PR TITLE
Fix possible segmentation fault in `get_magnetic_dataset`

### DIFF
--- a/src/spglib.c
+++ b/src/spglib.c
@@ -1316,6 +1316,7 @@ finalize:
     if (spglib_error_code == SPGLIB_SUCCESS) {
         return dataset;
     } else {
+        spg_free_magnetic_dataset(dataset);
         return NULL;
     }
 }
@@ -1779,9 +1780,15 @@ static MagneticSymmetry *get_symmetry_with_site_tensors(
     spg_free_dataset(dataset);
     dataset = NULL;
 
-    magnetic_symmetry = spn_get_operations_with_site_tensors(
-        &equiv_atoms, permutations, primitive_lattice, sym_nonspin, cell,
-        with_time_reversal, is_axial, symprec, angle_tolerance, mag_symprec);
+    if ((magnetic_symmetry = spn_get_operations_with_site_tensors(
+             &equiv_atoms, permutations, primitive_lattice, sym_nonspin, cell,
+             with_time_reversal, is_axial, symprec, angle_tolerance,
+             mag_symprec)) == NULL) {
+        sym_free_symmetry(sym_nonspin);
+        sym_nonspin = NULL;
+        goto err;
+    }
+
     /* Set equivalent_atoms */
     for (i = 0; i < cell->size; i++) {
         equivalent_atoms[i] = equiv_atoms[i];

--- a/src/spin.c
+++ b/src/spin.c
@@ -411,7 +411,8 @@ static MagneticSymmetry *get_operations(
                 // Unreachable here in theory, but we rarely fail to overlap
                 // atoms possibly due to too high symprec. In that case, skip
                 // the symmetry operation.
-                debug_print("Failed to overlap atom-%d by operation-%d\n", j, i);
+                debug_print("Failed to overlap atom-%d by operation-%d\n", j,
+                            i);
                 found = 0;
                 break;
             }
@@ -562,9 +563,9 @@ err:
     return NULL;
 }
 
-/* Return permutation tables `permutations` such that the p-th operation */
-/* in `magnetic_symmetry` maps site-`i` to site-`permutations[p * cell->size +
- * i]`. */
+// Return permutation tables `permutations` such that the p-th operation
+// in `magnetic_symmetry` maps site-`i` to site-`permutations[p * cell->size +
+// * i]`. If failed, return NULL.
 static int *get_symmetry_permutations(const MagneticSymmetry *magnetic_symmetry,
                                       const Cell *cell,
                                       const int with_time_reversal,
@@ -659,7 +660,7 @@ static int *get_symmetry_permutations(const MagneticSymmetry *magnetic_symmetry,
     return permutations;
 }
 
-/* Return equivalent_atoms */
+// Return equivalent_atoms. If failed, return NULL.
 static int *get_orbits(const int *permutations, const int num_sym,
                        const int num_atoms) {
     int s, i;


### PR DESCRIPTION
Because we cannot assume magnetic symmetry search is always successful, this commit fixes gracefully to return NULL for such a difficult situation with possibly too high symprec and mag_symprec.