### PR TITLE
Fix a bug in layer groups.

### DIFF
--- a/src/refinement.c
+++ b/src/refinement.c
@@ -970,7 +970,7 @@ static void set_equivalent_atoms_broken_symmetry(int *equiv_atoms_cell,
     } else {
         j = 0;
         for (i = 0; i < 3; i++) {
-            if (i == cell->aperiodic_axis) {
+            if (i != cell->aperiodic_axis) {
                 periodic_axes[j] = i;
                 j++;
             }


### PR DESCRIPTION
I run the layer group detection to all 15000 2D-materials in C2DB. This resulted in 22 Bus errors or segfaults.

Here is a simple script modified from example.c to reproduce the problem.

gcc runlayers.c -I../include -L../_build -O0 -lsymspg -fsanitize=address -static-libasan -ggdb && LD_LIBRARY_PATH=`pwd`/../_build ./a.out

```
#include "spglib.h"
#include <stdio.h>
#include <stdlib.h>
#include <math.h>

static void test_layer_spg_get_dataset(void);
static void show_layer_spg_dataset(double lattice[3][3],
                                   const double origin_shift[3],
                                   double position[][3],
                                   const int num_atom,
                                   const int types[],
                                   const int aperiodic_axis,
                                   const double symprec);

int main(void)
{
  test_layer_spg_get_dataset();
  return 0;
}

static void test_layer_spg_get_dataset(void)
{
  double symprec;
    double origin_shift[3] = { 0.0, 0.0, 0.0};
    int num_atom = 6;

    //double lattice[3][3] = { { 3.6298283346442517, 4.414688373086613e-05, 4.931753153254027e-16 }, { 2.0578765260243217e-05, 6.3189524931635095, 3.0514353036695804e-21 }, { 0.0, 0.0, 16.2670050174248 } };
    double lattice[3][3] = { { 3.6298283346442517, 2.0578765260243217e-05, 0.0 }, { 4.414688373086613e-05, 6.3189524931635095, 0.0 }, { 4.931753153254027e-16, 3.0514353036695804e-21, 16.2670050174248 } };
     int types[] = { 49, 49, 16, 16, 16, 16 };

    double position[][3] = {
{ 0.5000000000011727, 1.9659104439318793e-12, 0.499999999990874 },
{ 3.918861871595479e-13, 0.5000000000025439, 0.499999999990813 },
{ 0.49999671789715555, 0.3331107557679678, 0.4034517768684944 },
{ 0.9999871413290102, 0.16687354536345317, 0.5966360513378329 },
{ 0.5000032821094088, 0.6668892442284696, 0.5965482231161988 },
{ 1.2858669915597997e-05, 0.8331264546340158, 0.4033639486465312 }
 };

    show_layer_spg_dataset(lattice, origin_shift, position, num_atom, types, 2, 0.1);
}

static void show_layer_spg_dataset(double lattice[3][3],
                                   const double origin_shift[3],
                                   double position[][3],
                                   const int num_atom,
                                   const int types[],
                                   const int aperiodic_axis,
                                   const double symprec)
{
  SpglibDataset *dataset;
  char ptsymbol[6];
  int pt_trans_mat[3][3];

  int i, j, size;
  const char *wl = "abcdefghijklmnopqrstuvwxyz";

  for ( i = 0; i < num_atom; i++ ) {
    for ( j = 0; j < 3; j++ ) {
      position[i][j] += origin_shift[j];
    }
  }

  dataset = spg_get_layer_dataset(lattice,
                                  position,
                                  types,
                                  num_atom,
                                  aperiodic_axis,
                                  symprec);

  printf("International: %s (%d)\n", dataset->international_symbol, dataset->spacegroup_number );
  printf("Hall symbol:   %s\n", dataset->hall_symbol );
  spg_get_pointgroup(ptsymbol,
                     pt_trans_mat,
                     dataset->rotations,
                     dataset->n_operations);
  printf("Point group:   %s\n", ptsymbol);
  printf("Transformation matrix:\n");
  for ( i = 0; i < 3; i++ ) {
    printf("%f %f %f\n",
           dataset->transformation_matrix[i][0],
           dataset->transformation_matrix[i][1],
           dataset->transformation_matrix[i][2]);
  }
  printf("Wyckoff letters:\n");
  for ( i = 0; i < dataset->n_atoms; i++ ) {
    printf("%c ", wl[dataset->wyckoffs[i]]);
  }
  printf("\n");
  printf("Equivalent atoms:\n");
  for (i = 0; i < dataset->n_atoms; i++) {
    printf("%d ", dataset->equivalent_atoms[i]);
  }
  printf("\n");

  for (i = 0; i < dataset->n_operations; i++) {
    printf("--- %d ---\n", i + 1);
    for (j = 0; j < 3; j++) {
      printf("%2d %2d %2d\n",
             dataset->rotations[i][j][0],
             dataset->rotations[i][j][1],
             dataset->rotations[i][j][2]);
    }
    printf("%f %f %f\n",
           dataset->translations[i][0],
           dataset->translations[i][1],
           dataset->translations[i][2]);
  }

  spg_free_dataset(dataset);

}

```

I traced the error down to `cel_layer_is_overlap` function, which typically had periodic axes 0, 1, until they were 2 1070703038, and the code crashed. It is quite miraculous that the code worked before, probably due to some stack alignment of previous calls, that the periodic axes happened to be 0 and 1.

This merge request allows calculation for those 22 systems, while keeping all other results the same. However, I am still not sure are the results correct.

There are some more bugs remaining still. *Edit: all of these might be resolved, see comment below.*

1. After changing the periodic axis to first axis from last axis, one material (from all 15000) went from LG 10 to LG 18, otherwise data was reproduced.
periodic axes are hard coded in some places, however, I do not know if this is related 

```
hall_symbol.c:    int periodic_axes[2] = {0, 1};
site_symmetry.c:    int periodic_axes[2] = {0, 1};
site_symmetry.c:    int periodic_axes[2] = {0, 1};
site_symmetry.c:    int periodic_axis[2] = {0, 1};
```

2. There are 191 materials from 15k, where the layer group maps to other spacegroup than is given by get_spacegroup.
(Mapped according to this table) https://arxiv.org/pdf/1306.1280.pdf
Here LG is layergroup, and SG is spacegroup, and mappedsg is mapping of layer group to spacegroup by the table.
https://pastebin.com/sUqCtu4j

Most of them are predicted to be layergroup 35, according to article, spacegroup 35, but predicted to be spacegroup 38.

