### PR TITLE
Add setup.cfg for python interface

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,7 @@
+[options]
+package_dir=
+    =.
+packages=find:
+
+[options.packages.find]
+where=.


### PR DESCRIPTION
I hope adding this `setup.cfg` is harmless for normal cases.

I add `setup.cfg` to cure my VSCode that can not resolve import spglib from other code by `Go to Definition` when using pip editable install. This may be due to my specific case: I setup my python environment by conda (conda-forge), but for developing codes in python and installing them by `pip install -e .`. Those codes work but the codes installed in this way could not be recognized by VSCode. This didn't happen before. I finally found this was fixed (maybe just by luck) by putting `setup.cfg`. Probably this is related to modern `pip` (https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/). I don't understand this theoretically but do empirically.