### PR TITLE
Rename periodic_niggli_reduce to niggli_reduce_periodic

### DIFF
--- a/python/test/test_niggli_delaunay.py
+++ b/python/test/test_niggli_delaunay.py
@@ -1,129 +1,124 @@
-import os
-import unittest
+"""Tests of delaunay_reduce and niggli_reduce."""
+from pathlib import Path
 
 import numpy as np
 
 from spglib import delaunay_reduce, niggli_reduce
 
-data_dir = os.path.dirname(os.path.abspath(__file__))
+cwd = Path(__file__).parent
 
 
-def get_lattice_parameters(lattice):
+def _get_lattice_parameters(lattice):
     return np.sqrt(np.dot(lattice, lattice.T).diagonal())
 
 
-def get_angles(lattice):
-    a, b, c = get_lattice_parameters(lattice)
+def _get_angles(lattice):
+    a, b, c = _get_lattice_parameters(lattice)
     alpha = np.arccos(np.vdot(lattice[1, :], lattice[2, :]) / b / c)
     beta = np.arccos(np.vdot(lattice[2, :], lattice[0, :]) / c / a)
     gamma = np.arccos(np.vdot(lattice[0, :], lattice[1, :]) / a / b)
     return np.array([alpha, beta, gamma]) / np.pi * 180
 
 
-class TestNiggliDelaunay(unittest.TestCase):
-    def setUp(self):
-        self._input_lattices = self._read_file(os.path.join(data_dir, "lattices.dat"))
-        self._niggli_lattices = self._read_file(
-            os.path.join(data_dir, "niggli_lattices.dat")
+def _reduce(input_lattices, func, ref_data):
+    for i, (input_lattice, reference_lattice) in enumerate(
+        zip(input_lattices, ref_data)
+    ):
+        reduced_lattice = func(input_lattice)
+        # self._show_lattice(i, reduced_lattice)
+        assert np.allclose(
+            [np.linalg.det(input_lattice)], [np.linalg.det(reduced_lattice)]
         )
-        self._delaunay_lattices = self._read_file(
-            os.path.join(data_dir, "delaunay_lattices.dat")
+        T = np.dot(np.linalg.inv(reference_lattice.T), input_lattice.T)
+        assert np.allclose(T, np.rint(T))
+        assert np.allclose(
+            _metric_tensor(reduced_lattice),
+            _metric_tensor(reference_lattice),
+        ), "\n".join(
+            [
+                "# %d" % (i + 1),
+                "Input lattice",
+                "%s" % input_lattice,
+                " angles: %s" % np.array(_get_angles(input_lattice)),
+                "Reduced lattice in reference data",
+                "%s" % reference_lattice,
+                " angles: %s" % np.array(_get_angles(reference_lattice)),
+                "Reduced lattice",
+                "%s" % reduced_lattice,
+                " angles: %s" % np.array(_get_angles(reduced_lattice)),
+                _str_lattice(reduced_lattice),
+            ]
         )
 
-    def tearDown(self):
-        pass
 
-    def test_niggli_angles(self):
-        for i, reference_lattice in enumerate(self._niggli_lattices):
-            angles = np.array(get_angles(reference_lattice))
-            self.assertTrue(
-                (angles > 90 - 1e-3).all() or (angles < 90 + 1e-3).all(),
-                msg=("%d %s" % (i + 1, angles)),
-            )
-
-    def test_niggli_reduce(self):
-        self._reduce(niggli_reduce, self._niggli_lattices)
-
-    def test_delaunay_reduce(self):
-        self._reduce(delaunay_reduce, self._delaunay_lattices)
-
-    def _reduce(self, func, ref_data):
-        for i, (input_lattice, reference_lattice) in enumerate(
-            zip(self._input_lattices, ref_data)
-        ):
-            reduced_lattice = func(input_lattice)
-            # self._show_lattice(i, reduced_lattice)
-            self.assertTrue(
-                np.allclose(
-                    [np.linalg.det(input_lattice)], [np.linalg.det(reduced_lattice)]
-                )
-            )
-            T = np.dot(np.linalg.inv(reference_lattice.T), input_lattice.T)
-            self.assertTrue(np.allclose(T, np.rint(T)))
-            self.assertTrue(
-                np.allclose(
-                    self._metric_tensor(reduced_lattice),
-                    self._metric_tensor(reference_lattice),
-                ),
-                msg="\n".join(
-                    [
-                        "# %d" % (i + 1),
-                        "Input lattice",
-                        "%s" % input_lattice,
-                        " angles: %s" % np.array(get_angles(input_lattice)),
-                        "Reduced lattice in reference data",
-                        "%s" % reference_lattice,
-                        " angles: %s" % np.array(get_angles(reference_lattice)),
-                        "Reduced lattice",
-                        "%s" % reduced_lattice,
-                        " angles: %s" % np.array(get_angles(reduced_lattice)),
-                        self._str_lattice(reduced_lattice),
-                    ]
-                ),
-            )
-
-    def _read_file(self, filename):
-        all_lattices = []
-        with open(filename) as f:
-            lattice = []
-            for line in f:
-                if line[0] == "#":
-                    continue
-                lattice.append([float(x) for x in line.split()])
-                if len(lattice) == 3:
-                    all_lattices.append(lattice)
-                    lattice = []
-        return np.array(all_lattices)
-
-    def _show_lattice(self, i, lattice):
-        print("# %d" % (i + 1))
-        print(self._str_lattice(lattice))
-        # for v in lattice:
-        #     print(" ".join(["%20.16f" % x for x in v]))
-
-    def _str_lattice(self, lattice):
-        lines = []
-        for v in lattice:
-            lines.append(" ".join(["%20.16f" % x for x in v]))
-        return "\n".join(lines)
-
-    def _metric_tensor(self, lattice):
-        """
-        Args:
-            lattice: Lattice parameters in the form of
-                [[a_x, a_y, a_z],
-                 [b_x, b_y, b_z],
-                 [c_x, c_y, c_z]]
-        Returns:
-            Metric tensor:
-                [[a.a, a.b, a.c],
-                 [b.a, b.b, b.c],
-                 [c.a, c.b, c.c]]
-        """
-        return np.dot(lattice, np.transpose(lattice))
+def _str_lattice(lattice):
+    lines = []
+    for v in lattice:
+        lines.append(" ".join(["%20.16f" % x for x in v]))
+    return "\n".join(lines)
 
 
-if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestNiggliDelaunay)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    # unittest.main()
+def _metric_tensor(lattice):
+    """Return metric tensor.
+
+    Parameters
+    ----------
+    lattice: Lattice parameters in the form of
+        [[a_x, a_y, a_z],
+         [b_x, b_y, b_z],
+         [c_x, c_y, c_z]]
+
+    Returns
+    -------
+    Metric tensor:
+        [[a.a, a.b, a.c],
+         [b.a, b.b, b.c],
+         [c.a, c.b, c.c]]
+
+    """
+    return np.dot(lattice, np.transpose(lattice))
+
+
+def _read_file(filename):
+    all_lattices = []
+    with open(filename) as f:
+        lattice = []
+        for line in f:
+            if line[0] == "#":
+                continue
+            lattice.append([float(x) for x in line.split()])
+            if len(lattice) == 3:
+                all_lattices.append(lattice)
+                lattice = []
+    return np.array(all_lattices)
+
+
+def _test_niggli_angles(niggli_lattices):
+    for i, reference_lattice in enumerate(niggli_lattices):
+        angles = np.array(_get_angles(reference_lattice))
+        assert (angles > 90 - 1e-3).all() or (angles < 90 + 1e-3).all(), "%d %s" % (
+            i + 1,
+            angles,
+        )
+
+
+def _show_lattice(self, i, lattice):
+    print("# %d" % (i + 1))
+    print(self._str_lattice(lattice))
+    # for v in lattice:
+    #     print(" ".join(["%20.16f" % x for x in v]))
+
+
+def test_niggli_reduce():
+    """Test niggli_reduce."""
+    input_lattices = _read_file(cwd / "lattices.dat")
+    niggli_lattices = _read_file(cwd / "niggli_lattices.dat")
+    _test_niggli_angles(niggli_lattices)
+    _reduce(input_lattices, niggli_reduce, niggli_lattices)
+
+
+def test_delaunay_reduce():
+    """Test niggli_reduce."""
+    input_lattices = _read_file(cwd / "lattices.dat")
+    delaunay_lattices = _read_file(cwd / "delaunay_lattices.dat")
+    _reduce(input_lattices, delaunay_reduce, delaunay_lattices)

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -118,10 +118,10 @@ int niggli_get_micro_version(void) { return NIGGLI_MICRO_VERSION; }
 
 /* return 0 if failed */
 int niggli_reduce(double *lattice_, const double eps_) {
-    return periodic_niggli_reduce(lattice_, eps_, -1);
+    return niggli_reduce_periodic(lattice_, eps_, -1);
 }
 
-int periodic_niggli_reduce(double *lattice_, const double eps_,
+int niggli_reduce_periodic(double *lattice_, const double eps_,
                            const int aperiodic_axis) {
     int i, j, succeeded;
     NiggliParams *p;

--- a/src/niggli.h
+++ b/src/niggli.h
@@ -43,7 +43,7 @@ int niggli_get_major_version(void);
 int niggli_get_minor_version(void);
 int niggli_get_micro_version(void);
 int niggli_reduce(double* lattice_, const double eps_);
-int periodic_niggli_reduce(double* lattice_, const double eps_,
+int niggli_reduce_periodic(double* lattice_, const double eps_,
                            const int aperiodic_axis);
 
 #endif

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -934,7 +934,7 @@ static int change_basis_tricli(int tmat_int[3][3],
         }
     }
 
-    if (!periodic_niggli_reduce(niggli_cell, symprec * symprec,
+    if (!niggli_reduce_periodic(niggli_cell, symprec * symprec,
                                 aperiodic_axis)) {
         return 0;
     }
@@ -983,8 +983,8 @@ static int change_basis_monocli(int tmat_int[3][3],
     }
 
     if (!del_layer_delaunay_reduce_2D(smallest_lattice, conv_lattice,
-                                      unique_axis,
-                                      aperiodic_axis_conv, symprec)) {
+                                      unique_axis, aperiodic_axis_conv,
+                                      symprec)) {
         return 0;
     }
 


### PR DESCRIPTION
As a naming convention of non static function, the function name `periodic_niggli_reduce` was changed to `periodic_niggli_reduce`.

In addition, `test_niggli_delaunay.py` was migrated to pytest from python unittest.

Ping @site-g just for your information.