### PR TITLE
Change installation location of spglib_f08.mod

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -22,7 +22,7 @@ install(TARGETS spglib_f08
 install(TARGETS spglib_f08_static
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.mod DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 configure_file(spglib_f08.pc.in ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.pc @ONLY)
 install(

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -14,7 +14,7 @@ set_property(TARGET spglib_f08 PROPERTY SOVERSION ${soserial})
 target_link_libraries(spglib_f08 PUBLIC symspg)
 target_include_directories(spglib_f08 PUBLIC
 		"$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>")
+		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 install(TARGETS spglib_f08
 		EXPORT spglibTargets

--- a/fortran/spglib_f08.pc.in
+++ b/fortran/spglib_f08.pc.in
@@ -5,4 +5,4 @@ Description: The spglib f08 library
 depends: spglib
 Version: @PROJECT_VERSION@
 Libs: -L${prefix}/@CMAKE_INSTALL_LIBDIR@ -lspglib_f08 -lsymspg
-Cflags: -I${prefix}/include -I${prefix}/@CMAKE_INSTALL_LIBDIR@
+Cflags: -I${prefix}/include -I${prefix}/@CMAKE_INSTALL_INCLUDEDIR@


### PR DESCRIPTION
I think `.mod` file of fortran should be put in `include` directory when installing.