### PR TITLE
Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+python:
+  install:
+    - path: .
+      extra_requirements:
+        - doc
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_build:
+      - echo "Placeholder for doxygen builds via cmake"
+sphinx:
+  configuration: doc/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "spglib"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 requires-python = ">=3.7"
 description = "This is the spglib module."
 license = { text = "BSD-3-Clause" }


### PR DESCRIPTION
Here is a temporary working version of the documentations:
https://spglib.readthedocs.io

Notice bottom left :partying_face:  

The easiest way to integrate this is to delete this testing version and recreate it from this github organization. Also if we have a url like `spglib.io` we can link it or a subdomain (`doc.spglib.io`) to that.

Do we want to stick with the current theme or go with a rtd one like in [readthedocs.io](https://docs.readthedocs.io/en/stable/index.html) or something else?