### PR TITLE
Update documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ ______________________________________________________________________
 
 <!--
 If you use spglib's Python API, please do not use ASE or Pymatgen's wrapper to make it easier to identify your problem.
-The format for crystal structures is shown here: https://spglib.github.io/spglib/python-spglib.html#variables
+The format for crystal structures is shown here: https://spglib.readthedocs.io/en/latest/python-spglib.html#variables
 If spglib returns different results by changing `symprec`, `angle_tolerance`, or `mag_symprec`, please report it too.
 -->
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,34 +161,3 @@ jobs:
           files: coverage.info,.coverage
           flags: python_api
           verbose: true
-
-  docs:
-    runs-on: ubuntu-latest
-    needs: [ ctest-linux ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y pandoc
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
-      - name: Install dependencies
-        run: |
-          conda install --yes -c conda-forge python=3.9
-          conda install --yes -c conda-forge numpy gcc_linux-64 pip pyyaml make cmake scikit-build-core
-      - name: Setup spglib with doc's dependencies
-        run: |
-          pip install .[doc]
-      - name: Build
-        run: |
-          sphinx-build doc docs_build
-      - name: Deploy docs at develop branch
-        if: ${{ github.ref == 'refs/heads/develop' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./docs_build
-          destination_dir: develop

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ improvements. See [Contributing.md](Contributing.md) for more details.
 
 ## Documentation
 
-See [spglib.github.io/spglib/](https://spglib.github.io/spglib/) for further
+See [https://spglib.readthedocs.io/](https://spglib.readthedocs.io/) for further
 documentation. See the [doc documentation](doc/README.md) for more information on
 how to contribute to the documentation.

--- a/doc/index.md
+++ b/doc/index.md
@@ -70,8 +70,8 @@ mailing list:
 
 ## Links
 
-- Document (this page): <https://spglib.github.io/spglib/>
-- Document (develop): <https://spglib.github.io/spglib/develop>
+- Documentation (this page): <https://spglib.readthedocs.io/>
+- Repository <https://github.com/spglib/spglib>
 - Conda: <https://anaconda.org/conda-forge/spglib>
 - PyPI: <https://pypi.org/project/spglib/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ maintainers = [
 ]
 
 [project.urls]
-homepage = "https://spglib.github.io/spglib/"
-documentation = "https://spglib.github.io/spglib/"
+homepage = "https://spglib.readthedocs.io/"
+documentation = "https://spglib.readthedocs.io/"
 repository = "https://github.com/spglib/spglib"
-changelog = "https://spglib.github.io/spglib/releases.html"
+changelog = "https://spglib.readthedocs.io/en/latest/releases.html"
 
 [project.optional-dependencies]
 testing = [


### PR DESCRIPTION
- [ ] Update documentation link on Conda [conda-forge/spglib-feedstock#82](https://github.com/conda-forge/spglib-feedstock/pull/82)
- [ ] Update documentation link on PyPI @lan496 
- [ ] Redirect https://spglib.gihub.io and https://spglib.gihub.io/spglib to https://spglib.readthedocs.io

The other note I had was about what do we do with previous versions? Do we want to recreate them, or should we just consider this version moving on to be maintained?

Closes: #252 