### PR TITLE
Include an autoreleaser

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: 🛠 Breaking Changes
+      labels:
+        # Should automatically detect major change
+        - Semver-Major
+        - breaking-changes
+    - title: 🎉 New Features
+      labels:
+        - new-feature
+        - enhancement
+    - title: ⚠️ Deprecation
+      labels:
+        - deprecation
+    - title: 🐞 Bug fixes
+      labels:
+        - bug
+    - title: 📔 Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - '*'

--- a/.github/workflows/pypi-wheel-builds.yml
+++ b/.github/workflows/pypi-wheel-builds.yml
@@ -3,9 +3,11 @@ run-name: Spglib PyPI Wheel builds for linux
 
 on:
   push:
-    tags: [ "v[0-9]+.[0-9]+.[0-9]+*" ]
+    tags: [ "*test*" ]
   pull_request:
     branches: [ test-PyPi-action ]
+  # Make it able to be used in other workflows
+  workflow_call:
 
 jobs:
   build_wheels:
@@ -45,26 +47,3 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
-
-  upload_pypi:
-    name: Upload to pypi repository
-    needs: [ build_wheels, build_sdist ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - name: Publish package to TestPyPI
-        if: ${{ !contains(github.ref, 'test') && contains(github.ref, 'rc') && github.event_name != 'pull_request' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish package to PyPI
-        if: ${{ !contains(github.ref, 'test') && !contains(github.ref, 'rc') && github.event_name != 'pull_request' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: release
+run-name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+
+jobs:
+  tests:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+  pypi-wheel:
+    needs: [ tests ]
+    uses: ./.github/workflows/pypi-wheel-builds.yml
+    secrets: inherit
+  upload_pypi:
+    name: Upload to pypi repository
+    needs: [ tests, pypi-wheel ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package to TestPyPI
+        if: ${{ contains(github.ref, 'rc') }}
+        # TODO: Maybe we can move this to main PyPI since it is marked rc
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish package to PyPI
+        if: ${{ !contains(github.ref, 'rc') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+  release:
+    needs: [ upload_pypi ]
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: ${{ contains(github.ref, 'rc') }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: softprops/action-gh-release@v1
         with:
+          name: Spglib ${{ github.ref_name }}
           draft: true
           prerelease: ${{ contains(github.ref, 'rc') }}
           generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+  # Make it able to be used in other workflows
+  workflow_call:
 
 jobs:
   pre-commit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,4 @@ repos:
     rev: 0.21.0
     hooks:
       - id: check-github-workflows
+      - id: check-readthedocs


### PR DESCRIPTION
- Moved the PyPI releaser to `release.yml` workflow. Simplifies if statements
- `release.yml` is only called on `vX.Y.Z` or `vX.Y.Z-rcA` tags. It uploads to PyPI as well as creates a release draft (Check on [my fork](https://github.com/LecrisUT/spglib/releases) for example)

Basically the workflow we need to change for this:
- Label issues and/or PR with one of the relevant labels
- When ready, push a label with appropriate format 
- After action is complete, review the draft, add a human-friendly `Main Changes` if necessary, release the release

Closes: #251 