### PR TITLE
Add rpm spec file

### DIFF
--- a/.distro/spglib.rpmlintrc
+++ b/.distro/spglib.rpmlintrc
@@ -1,0 +1,2 @@
+addFilter("python.?-spglib.* dangling-relative-symlink .*libsymspg.so")
+addFilter("python.?-spglib.* explicit-lib-dependency")

--- a/.distro/spglib.spec
+++ b/.distro/spglib.spec
@@ -1,0 +1,116 @@
+Name:           spglib
+Summary:        C library for finding and handling crystal symmetries
+Version:        0.0.0
+Release:        %{autorelease}
+License:        BSD
+URL:            https://%{name}.readthedocs.io/
+
+Source0:        https://github.com/spglib/%{name}/archive/refs/tags/v%{version}.tar.gz
+Source1:        %{name}.rpmlintrc
+
+BuildRequires:  ninja-build
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  gcc-fortran
+BuildRequires:  gtest-devel
+BuildRequires:  python3-devel
+
+%description
+C library for finding and handling crystal symmetries.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains libraries and header files for developing
+applications that use %{name}.
+
+%package        fortran
+Summary:        Runtime files for %{name} Fortran bindings
+Requires:       %{name} = %{version}-%{release}
+Requires:       gcc-gfortran%{_isa}
+
+%description    fortran
+This package contains runtime files to run applications that were built
+using %{name}'s Fortran bindings.
+
+%package        fortran-devel
+Summary:        Development files for %{name} with Fortran bindings
+Requires:       %{name}-fortran%{?_isa} = %{version}-%{release}
+Requires:       %{name}-devel = %{version}-%{release}
+
+%description    fortran-devel
+This package contains Fortran module and header files for developing
+Fortran applications that use %{name}.
+
+%package -n     python3-%{name}
+Summary:        Python3 library of %{name}
+Requires:       %{name}
+
+%description -n python3-%{name}
+This package contains the libraries to
+develop applications with %{name} Python3 bindings.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%generate_buildrequires
+%pyproject_buildrequires -x test
+
+%build
+%cmake \
+    -DSPGLIB_SHARED_LIBS=ON \
+    -DSPGLIB_WITH_Fortran=ON \
+    -DSPGLIB_WITH_Python=OFF \
+    -DSPGLIB_WITH_TESTS=ON
+
+%cmake_build
+%pyproject_wheel
+
+%install
+%cmake_install
+
+%pyproject_install
+%pyproject_save_files %{name}
+
+%check
+%ctest
+%pytest -v
+
+%files
+%doc README.md
+%license COPYING
+%{_libdir}/libsymspg.so.*
+
+%files fortran
+%{_libdir}/libspglib_f08.so.*
+
+%files devel
+%{_libdir}/libsymspg.so
+%{_includedir}/spglib.h
+# Note: Different case-sensitivity comapred to %%{name}
+%{_libdir}/cmake/Spglib/SpglibConfig.cmake
+%{_libdir}/cmake/Spglib/SpglibConfigVersion.cmake
+%{_libdir}/cmake/Spglib/SpglibTargets_shared.cmake
+%{_libdir}/cmake/Spglib/SpglibTargets_shared-release.cmake
+%{_libdir}/cmake/Spglib/PackageCompsHelper.cmake
+%{_libdir}/pkgconfig/spglib.pc
+
+%files fortran-devel
+%{_libdir}/libspglib_f08.so
+%{_includedir}/spglib_f08.F90
+%{_includedir}/spglib_f08.mod
+%{_libdir}/pkgconfig/spglib_f08.pc
+%{_libdir}/cmake/Spglib/SpglibTargets_fortran_shared.cmake
+%{_libdir}/cmake/Spglib/SpglibTargets_fortran_shared-release.cmake
+
+%files -n python3-%{name}
+%{python3_sitearch}/%{name}/
+%exclude %{python3_sitearch}/%{name}/libsymspg.so*
+%exclude %{python3_sitearch}/%{name}/spglib.h
+%{python3_sitearch}/%{name}-*.dist-info/
+
+%changelog
+%autochangelog

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,62 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: .distro/spglib.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - src: .distro/spglib.spec
+    dest: spglib.spec
+  - .packit.yaml
+  - src: .distro/spglib.rpmlintrc
+    dest: spglib.rpmlintrc
+upstream_package_name: spglib
+downstream_package_name: spglib
+update_release: false
+upstream_tag_template: v{version}
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: lecris
+    project: spglib
+    update_release: true
+    release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
+    additional_repos:
+      - copr://@scikit-build/release
+    targets:
+      - fedora-development
+  - job: copr_build
+    trigger: commit
+    branch: main
+    owner: lecris
+    project: nightly
+    additional_repos:
+      - copr://@scikit-build/release
+    targets:
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+  - job: copr_build
+    trigger: release
+    owner: lecris
+    project: release
+    targets:
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-development
+      - fedora-latest
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched


### PR DESCRIPTION
To make it easier to maintain Fedora packages (and subsequently any Redhat, Centos, Opensuse, etc.), we should include a `spglib.spec` file with the supported build instructions. Currently this one is available and tracked at [my copr repo](https://copr.fedorainfracloud.org/coprs/lecris/spglib/). Adding this will help with package maintenance in that:
- A relevant copr build will be triggered for:
  - commits to `main` -> New build in `lecris/nightly`: Users can use this to test the newest version of `main` (no package update available for users)
  - PR -> New build in `lecris/spglib`: For CI puposes (automatically updates to check newest build
  - releases-> New build in `lecris/release`: Users can use this to get the newest stable releases before they are ported to Fedora
- The downstream spec files at `src.fedoraproject.org` are synchronized with these files (with appropriate version values).
- To build locally use `packit build in-mock` or other alternatives like `in-copr` (Much simpler than the traditional `rpmbuild`, `rpkg`, etc.)

Depends on: #268 