### PR TITLE
Refactor python optional dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Setup spglib
         # TODO: switch to editable installs
         run: |
-          pip install .[testing] \
+          pip install .[test-cov] \
             --config-settings=cmake.define.SPGLIB_TEST_COVERAGE=ON \
             --config-settings=build-dir=build
       - name: Test with pytest and code coverage

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ python:
   install:
     - path: .
       extra_requirements:
-        - doc
+        - docs
 build:
   os: ubuntu-22.04
   tools:

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,7 +7,7 @@ This directory contains python-sphinx documentation source.
 Python>=3.8 required for `importlib.metadata`.
 
 ```shell
-$ pip install -e ".[doc]"
+$ pip install -e ".[docs]"
 $ cd doc
 $ make html
 $ sphinx-autobuild . _build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,20 +29,37 @@ repository = "https://github.com/spglib/spglib"
 changelog = "https://spglib.readthedocs.io/en/latest/releases.html"
 
 [project.optional-dependencies]
-testing = [
+test = [
     "codecov",
     "pytest",
-    "pytest-cov",
-    "pytest-benchmark",
     "pyyaml",
 ]
-doc = [
+docs = [
     "Sphinx==4.5.0",
     "sphinx-autobuild==2021.3.14",
     "sphinxcontrib-bibtex==2.4.2",
     "sphinx-book-theme==0.3.3",
     "myst-parser==0.18.0",
     "linkify-it-py==2.0.0"
+]
+test-cov = [
+    "spglib[test]",
+    "pytest-cov",
+]
+test-benchmark = [
+    "spglib[test]",
+    "pytest-benchmark",
+]
+dev = [
+    "spglib[test]",
+    "pre-commit",
+]
+# Alternative names for compatibility
+doc = [
+    "spglib[docs]",
+]
+testing = [
+    "spglib[test]",
 ]
 
 [tool.scikit-build]
@@ -56,7 +73,7 @@ cmake.args = [
 
 [tool.cibuildwheel]
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*", "*-macosx_arm64"]
-test-extras = "testing"
+test-extras = "test"
 test-command = "pytest {package}/python/test --benchmark-skip"
 # Do not run test on emulated environments
 test-skip = "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
@@ -72,7 +89,7 @@ repair-wheel-command = ""
 repair-wheel-command = ""
 
 [tool.pytest.ini_options]
-addopts = "--benchmark-skip"
+addopts = "-m 'not benchmark'"
 testpaths = ["python/test"]
 
 [tool.coverage.run]

--- a/python/README.rst
+++ b/python/README.rst
@@ -52,7 +52,7 @@ To include testing or documentation environments, simply include the relevant ex
 
 .. code-block:: console
 
-    $ pip install .[testing,doc]
+    $ pip install .[test]
 
 Running tests
 ~~~~~~~~~~~~~


### PR DESCRIPTION
- Renamed optional dependencies to be closer to `scikit-build`. Aliases are kept for compatibility
- Expanded optional dependencies to separate convergence and benchmark testing. Added development set with `pre-commit`
- Fixed pytest option to not depend on `pytest-benchmark`