### PR TITLE
Python: fix packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ testing = [
 ]
 
 [tool.scikit-build]
-#wheel.packages = "python/spglib"
+wheel.packages = ["python/spglib"]
 wheel.install-dir = "spglib"
 cmake.args = [
     "-DSPGLIB_WITH_Python=ON",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -28,4 +28,7 @@ else()
 endif()
 install(TARGETS Spglib_python
 		LIBRARY DESTINATION ${Python_INSTALL_DIR} COMPONENT Spglib_Runtime)
-install(DIRECTORY spglib/ DESTINATION ${Python_INSTALL_DIR} COMPONENT Spglib_Runtime)
+
+if(NOT SKBUILD)
+  install(DIRECTORY spglib/ DESTINATION ${Python_INSTALL_DIR} COMPONENT Spglib_Runtime)
+endif()

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,6 +1,0 @@
-include src/*.h
-include src/*.c
-include __nanoversion__.txt
-include examples/*.py
-recursive-include test *
-recursive-exclude test *.pyc

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -38,7 +38,7 @@ import warnings
 import numpy as np
 
 try:
-    from . import _spglib as spg
+    from spglib import _spglib as spg
 except ImportError:
     import os.path
     import re
@@ -56,7 +56,7 @@ except ImportError:
             "Spglib C++ library is not installed and no bundled version was detected"
         )
     cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), bundled_lib))
-    from . import _spglib as spg
+    from spglib import _spglib as spg
 
 
 class SpglibError(object):


### PR DESCRIPTION
Using Python for the python portion is better, especially for editable installs. Still seems to be an issue in scikit-build-core with the path on the editable install for the .so file, though, so will look into it.
