### PR TITLE
[Temp] Disable intel toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora
     needs: [ pre-commit ]
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        toolchain: [ gcc, intel, llvm ]
+        experimental: [ false ]
+        toolchain: [ gcc, llvm ]
+        include:
+          - toolchain: intel
+            experimental: true
     steps:
       - name: Install common packages
         run: |


### PR DESCRIPTION
Intel's GPG key has expired, and they haven't fixed it yet. Marked intel toolchain as allowed to fail for the time-being