### PR TITLE
Change PyPI publishing to `Trusted publishing`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,14 @@ jobs:
     uses: ./.github/workflows/pypi-wheel-builds.yml
     secrets: inherit
   upload_pypi:
-    name: Upload to pypi repository
+    name: Upload to PyPI repository
     needs: [ tests, pypi-wheel ]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/spglib/
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -29,15 +34,10 @@ jobs:
         # TODO: Maybe we can move this to main PyPI since it is marked rc
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish package to PyPI
         if: ${{ !contains(github.ref, 'rc') }}
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
   release:
     needs: [ upload_pypi ]
     name: Create release


### PR DESCRIPTION
This eliminates the usage of secrets which can otherwise be a security vulnerability. This is the implementation that [`scikit-build-core` uses](https://github.com/scikit-build/scikit-build-core/blob/2f808b7229d2fbfabdd605c119304fbca18c66a2/.github/workflows/cd.yml#L27-L41) and where I got inspired for this

Reference: https://github.com/pypa/gh-action-pypi-publish#trusted-publishing

@lan496 If we go with this, later the token secrets should be deleted.