### PR TITLE
Revive compiler warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: v1.5.3
     hooks:
       - id: clang-format
+        additional_dependencies: [ clang-format >= 16 ]
         args:
           - '-B_build-pre-commit'
           - '-DSPGLIB_WITH_Fortran=ON'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,12 @@
 configure_file(version.h.in version.h)
 
+# Add compiler warnings
+if (MSVC)
+	target_compile_options(Spglib_symspg PRIVATE /W4)
+else()
+	target_compile_options(Spglib_symspg PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
 # Configure main target
 target_sources(Spglib_symspg PRIVATE
 		arithmetic.c

--- a/src/kgrid.c
+++ b/src/kgrid.c
@@ -84,7 +84,7 @@ static void get_all_grid_addresses(int grid_address[][3], const int mesh[3]) {
                 address[2] = k;
                 grid_point = get_grid_point_single_mesh(address, mesh);
 
-                assert(mesh[0] * mesh[1] * mesh[2] > grid_point);
+                assert((size_t)(mesh[0] * mesh[1] * mesh[2]) > grid_point);
 
                 grid_address[grid_point][0] = address[0];
                 grid_address[grid_point][1] = address[1];

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -135,7 +135,7 @@ int kpt_get_irreducible_reciprocal_mesh(int grid_address[][3],
     num_ir = kpt_get_dense_irreducible_reciprocal_mesh(
         grid_address, dense_ir_mapping_table, mesh, is_shift, rot_reciprocal);
 
-    for (i = 0; i < mesh[0] * mesh[1] * mesh[2]; i++) {
+    for (i = 0; i < (size_t)(mesh[0] * mesh[1] * mesh[2]); i++) {
         ir_mapping_table[i] = dense_ir_mapping_table[i];
     }
 
@@ -176,7 +176,7 @@ int kpt_get_stabilized_reciprocal_mesh(
         grid_address, dense_ir_mapping_table, mesh, is_shift, is_time_reversal,
         rotations, num_q, qpoints);
 
-    for (i = 0; i < mesh[0] * mesh[1] * mesh[2]; i++) {
+    for (i = 0; i < (size_t)(mesh[0] * mesh[1] * mesh[2]); i++) {
         ir_mapping_table[i] = dense_ir_mapping_table[i];
     }
 
@@ -255,7 +255,8 @@ int kpt_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
                                  const int grid_address[][3], const int mesh[3],
                                  const double rec_lattice[3][3],
                                  const int is_shift[3]) {
-    int i, num_bz_map, num_bzgp;
+    int num_bzgp;
+    size_t i, num_bz_map;
     size_t *dense_bz_map;
 
     num_bz_map = mesh[0] * mesh[1] * mesh[2] * 8;
@@ -380,7 +381,8 @@ static MatINT *get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
                                                  const double symprec,
                                                  const size_t num_q,
                                                  const double qpoints[][3]) {
-    int i, j, k, l, is_all_ok, num_rot;
+    int i, l, is_all_ok, num_rot;
+    size_t j, k;
     int *ir_rot;
     double q_rot[3], diff[3];
     MatINT *rot_reciprocal_q;
@@ -466,15 +468,14 @@ static size_t get_dense_ir_reciprocal_mesh_normal(
     /* grid: reducible grid points */
     /* ir_mapping_table: the mapping from each point to ir-point. */
 
-    long i;
-    size_t grid_point_rot;
+    size_t i, grid_point_rot;
     int j;
     int address_double[3], address_double_rot[3];
 
     kgd_get_all_grid_addresses(grid_address, mesh);
 
 #pragma omp parallel for private(j, grid_point_rot, address_double, \
-                                 address_double_rot)
+                                     address_double_rot)
     for (i = 0; i < mesh[0] * mesh[1] * (size_t)(mesh[2]); i++) {
         kgd_get_grid_address_double_mesh(address_double, grid_address[i], mesh,
                                          is_shift);
@@ -501,8 +502,7 @@ static size_t get_dense_ir_reciprocal_mesh_normal(
 static size_t get_dense_ir_reciprocal_mesh_distortion(
     int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
     const int is_shift[3], const MatINT *rot_reciprocal) {
-    long i;
-    size_t grid_point_rot;
+    size_t i, grid_point_rot;
     int j, k, indivisible;
     int address_double[3], address_double_rot[3];
     long long_address_double[3], long_address_double_rot[3], divisor[3];
@@ -516,9 +516,9 @@ static size_t get_dense_ir_reciprocal_mesh_distortion(
         divisor[j] = mesh[(j + 1) % 3] * mesh[(j + 2) % 3];
     }
 
-#pragma omp parallel for private(j, k, grid_point_rot, address_double,    \
-                                 address_double_rot, long_address_double, \
-                                 long_address_double_rot)
+#pragma omp parallel for private(j, k, grid_point_rot, address_double,        \
+                                     address_double_rot, long_address_double, \
+                                     long_address_double_rot)
     for (i = 0; i < mesh[0] * mesh[1] * (size_t)(mesh[2]); i++) {
         kgd_get_grid_address_double_mesh(address_double, grid_address[i], mesh,
                                          is_shift);
@@ -568,8 +568,7 @@ static size_t get_dense_ir_reciprocal_mesh_distortion(
 }
 
 static size_t get_dense_num_ir(size_t ir_mapping_table[], const int mesh[3]) {
-    long i;
-    size_t num_ir;
+    size_t i, num_ir;
 
     num_ir = 0;
 

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -125,8 +125,8 @@ int niggli_reduce_periodic(double *lattice_, const double eps_,
                            const int aperiodic_axis) {
     int i, j, succeeded;
     NiggliParams *p;
-    int (*steps[8])(NiggliParams * p) = {step1, step2, step3, step4,
-                                         step5, step6, step7, step8};
+    int (*steps[8])(NiggliParams *p) = {step1, step2, step3, step4,
+                                        step5, step6, step7, step8};
 
     if (aperiodic_axis != -1) {
         steps[1] = step2_for_layer;

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -117,8 +117,8 @@ static int get_symmetry_from_dataset(
     const int num_atom, const double symprec, const double angle_tolerance);
 static MagneticSymmetry *get_symmetry_with_site_tensors(
     int equivalent_atoms[], int **permutations, double primitive_lattice[3][3],
-    const int max_size, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double angle_tolerance,
+    const Cell *cell, const int with_time_reversal, const int is_axial,
+    const double symprec, const double angle_tolerance,
     const double mag_symprec);
 static int get_multiplicity(const double lattice[3][3],
                             const double position[][3], const int types[],
@@ -481,7 +481,7 @@ int spgms_get_symmetry_with_site_tensors(
     cel_set_cell_with_tensors(cell, lattice, position, types, tensors);
 
     if ((magnetic_symmetry = get_symmetry_with_site_tensors(
-             equivalent_atoms, &permutations, primitive_lattice, max_size, cell,
+             equivalent_atoms, &permutations, primitive_lattice, cell,
              with_time_reversal, is_axial, symprec, angle_tolerance,
              mag_symprec)) == NULL) {
         /* spglib_error_code is filled in get_symmetry_with_tensors */
@@ -1168,7 +1168,6 @@ static SpglibMagneticDataset *get_magnetic_dataset(
     const double *tensors, const int tensor_rank, const int num_atom,
     const int is_axial, const double symprec, const double angle_tolerance,
     const double mag_symprec) {
-    int max_size;
     Cell *cell, *exact_cell, *exact_cell_std;
     Spacegroup *fsg, *xsg;
     MagneticSymmetry *magnetic_symmetry, *representatives;
@@ -1188,8 +1187,6 @@ static SpglibMagneticDataset *get_magnetic_dataset(
     dataset = NULL;
     permutations = NULL;
     equivalent_atoms = NULL;
-
-    max_size = num_atom * 96;
 
     /* Set cell and check overlapped atoms */
     if ((cell = cel_alloc_cell(num_atom, tensor_rank)) == NULL) {
@@ -1214,7 +1211,7 @@ static SpglibMagneticDataset *get_magnetic_dataset(
 
     /* Get magnetic symmetry operations of MSG */
     if ((magnetic_symmetry = get_symmetry_with_site_tensors(
-             equivalent_atoms, &permutations, primitive_lattice, max_size, cell,
+             equivalent_atoms, &permutations, primitive_lattice, cell,
              1, /* with_time_reversal */
              is_axial, symprec, angle_tolerance, mag_symprec)) == NULL) {
         spglib_error_code = SPGERR_SYMMETRY_OPERATION_SEARCH_FAILED;
@@ -1728,8 +1725,8 @@ err:
 /* Return NULL if failed */
 static MagneticSymmetry *get_symmetry_with_site_tensors(
     int equivalent_atoms[], int **permutations, double primitive_lattice[3][3],
-    const int max_size, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double angle_tolerance,
+    const Cell *cell, const int with_time_reversal, const int is_axial,
+    const double symprec, const double angle_tolerance,
     const double mag_symprec) {
     int i;
     MagneticSymmetry *magnetic_symmetry;

--- a/test/test_dataset_access.cpp
+++ b/test/test_dataset_access.cpp
@@ -10,7 +10,7 @@ static void show_spacegroup_type(const SpglibSpacegroupType spgtype);
 TEST(test_dataset_access, test_spg_get_symmetry_from_database) {
     int rotations[192][3][3];
     double translations[192][3];
-    int i, j, size;
+    int size;
 
     size = spg_get_symmetry_from_database(rotations, translations, 460);
     ASSERT_EQ(size, 36);
@@ -29,7 +29,6 @@ TEST(test_dataset_access, test_spg_get_hall_number_from_symmetry) {
     double position[][3] = {{0, 0, 0}, {0.5, 0.5, 0.5}};
     int types[] = {1, 1};
     int num_atom = 2;
-    int retval = 0;
     double symprec = 1e-5;
 
     int hall_number;
@@ -66,10 +65,8 @@ TEST(test_dataset_access, test_spg_get_spacegroup_type_from_symmetry) {
     double position[][3] = {{0, 0, 0}, {0.5, 0.5, 0.5}};
     int types[] = {1, 1};
     int num_atom = 2;
-    int retval = 0;
     double symprec = 1e-5;
 
-    int hall_number;
     SpglibSpacegroupType spgtype;
     SpglibDataset *dataset;
 

--- a/test/test_kpoints.cpp
+++ b/test/test_kpoints.cpp
@@ -10,7 +10,7 @@ TEST(test_kpoints, test_spg_get_ir_reciprocal_mesh) {
         {0, 0, 0},     {0.5, 0.5, 0.5}, {0.3, 0.3, 0},
         {0.7, 0.7, 0}, {0.2, 0.8, 0.5}, {0.8, 0.2, 0.5},
     };
-    int num_ir, retval;
+    int num_ir;
     int types[] = {1, 1, 2, 2, 2, 2};
     int num_atom = 6;
     int m = 40;
@@ -88,7 +88,6 @@ TEST(test_kpoints, test_spg_relocate_BZ_grid_address) {
                                 {0.17573761, 0.17573761, -0.17573761}};
     int rotations[][3][3] = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
 
-    int retval = 0;
     int(*bz_grid_address)[3], (*grid_address)[3];
     int *grid_mapping_table, *bz_map;
 
@@ -139,7 +138,6 @@ TEST(test_kpoints, test_spg_relocate_dense_BZ_grid_address) {
                                 {0.17573761, 0.17573761, -0.17573761}};
     int rotations[][3][3] = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
 
-    int retval = 0;
     int(*bz_grid_address)[3], (*grid_address)[3];
     size_t *grid_mapping_table, *bz_map;
 

--- a/test/test_magnetic_symmetry.cpp
+++ b/test/test_magnetic_symmetry.cpp
@@ -17,7 +17,7 @@ TEST(test_magnetic_symmetry, test_spg_get_magnetic_symmetry_from_database) {
     int rotations[384][3][3];
     double translations[384][3];
     int time_reversals[384];
-    int i, j, size;
+    int size;
 
     /* bns_number: 146.12, uni_number 1242 */
     /* hall_number: 433 -> 146:h */
@@ -37,7 +37,7 @@ TEST(test_magnetic_symmetry, test_spg_get_symmetry_with_collinear_spin) {
     int equivalent_atoms[2];
     double spins[2];
     int num_atom = 2;
-    int i, j, size, retval, max_size;
+    int size, max_size;
 
     int(*rotation)[3][3];
     double(*translation)[3];
@@ -91,7 +91,7 @@ TEST(test_magnetic_symmetry, test_spg_get_symmetry_with_collinear_spin) {
 TEST(test_magnetic_symmetry, test_spg_get_symmetry_with_site_tensors) {
     /* MAGNDATA #0.1: LaMnO3 */
     /* BNS: Pn'ma' (62.448), MHall: -P 2ac' 2n' (546) */
-    int max_size, size, i, j;
+    int max_size, size, i;
     double lattice[][3] = {{5.7461, 0, 0}, {0, 7.6637, 0}, {0, 0, 5.5333}};
     /* clang-format off */
     double position[][3] = {
@@ -393,7 +393,7 @@ TEST(test_magnetic_symmetry, test_spgms_get_magnetic_dataset_high_mag_symprec) {
     double symprec = 1e-5;
     double mag_symprec = 1e-1;  // with high mag_symprec
 
-    int i, size;
+    int size;
     int equivalent_atoms[3];
     double primitive_lattice[3][3];
     int(*rotations)[3][3];

--- a/test/test_symmetry_search.cpp
+++ b/test/test_symmetry_search.cpp
@@ -17,7 +17,7 @@ TEST(test_symmetry_search, test_spg_get_symmetry) {
         {0.3, 0.3, 0.5},  {0.7, 0.7, 0.5},  {0.2, 0.8, 0.75}, {0.8, 0.2, 0.75}};
     int types[] = {1, 1, 2, 2, 2, 2, 1, 1, 2, 2, 2, 2};
     int num_atom = 12;
-    int i, j, size, retval, max_size;
+    int i, j, size, max_size;
     double origin_shift[3] = {0.1, 0.1, 0};
 
     int(*rotation)[3][3];


### PR DESCRIPTION
This PR adds useful compiler warning flags depending on the compilers.
Ref: https://cmake.org/cmake/help/latest/command/add_compile_options.html#example