### PR TITLE
Document behavior for type-II magnetic crystal structure

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -77,6 +77,9 @@ alternative package (hopefully with better functionalities) until then.
 
 - get_symmetry with `is_magnetic=True` is deprecated at version 2.0. Use
   `get_magnetic_symmetry` for magnetic symmetry search.
+- As of version 2.0, the behavior of `get_symmetry` with zero magmoms (corresponding to type-II MSG) is changed.
+  When all magmoms are zero, the newer `get_symmetry` returns the same spatial symmetry with `time_reversal=True` and `time-reversal=False`.
+  This doubles the size of symmetry operations compared to the previous version.
 
 #### `get_spacegroup_type`
 


### PR DESCRIPTION
This PR explicitly documents the breaking change of `get_symmetry` for a structure with zero magmoms between spglib v1 and v2.
Although this point is mentioned in https://github.com/spglib/spglib/issues/150#issuecomment-1180158502, it will be more decent to describe it in the document.
Also, this behavior (unexpectedly) seems to cause issues in other packages: for example, https://github.com/materialsproject/pymatgen/issues/2725 and https://github.com/materialsproject/pymatgen/issues/3006.

CC: @atztogo 