### PR TITLE
Ensure thread-safety

### DIFF
--- a/src/spglib.c
+++ b/src/spglib.c
@@ -62,7 +62,7 @@
 /*-------*/
 /* error */
 /*-------*/
-static SpglibError spglib_error_code = SPGLIB_SUCCESS;
+static _Thread_local SpglibError spglib_error_code = SPGLIB_SUCCESS;
 
 typedef struct {
     SpglibError error;

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -207,6 +207,7 @@ int spg_get_micro_version(void) {
 /* error */
 /*-------*/
 SpglibError spg_get_error_code(void) { return spglib_error_code; }
+void spg_set_error_code(SpglibError err) { spglib_error_code = err; }
 
 char *spg_get_error_message(SpglibError error) {
     int i;


### PR DESCRIPTION
Are there other static variables that need to be changed?

TODO:
- [x] Test if it does what it says. If it can be done locally, that would be ok as well.
     Maybe a way to do this is to spawn a few thousands workers writing random values to `spglib_error_code` and re-reading after a delay to confirm it's the same value.
- [x] Check this compiles on intel compiler