### PR TITLE
ci: Use container with pre-installed toolchains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,58 +20,15 @@ jobs:
 
   ctest-linux:
     runs-on: ubuntu-latest
-    container: fedora
+    container: ghcr.io/lecrisut/dev-env:f37
     needs: [ pre-commit ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         experimental: [ false ]
-        toolchain: [ gcc, llvm ]
-        include:
-          - toolchain: intel
-            experimental: true
+        toolchain: [ gcc, llvm, intel ]
     steps:
-      - name: Install common packages
-        run: |
-          sudo dnf -y install git libasan gtest-devel
-      - name: Install GCC packages
-        run: |
-          sudo dnf -y install gcc g++ gcc-fortran
-        if: matrix.toolchain == 'gcc'
-      - name: Install Intel compiler pre-requisites
-        # findutils and procps are needed by intel compiler to run setvars.sh
-        # Intel does not have a ld program, so we need them from binutils, but binutils does not work without gcc
-        run: |
-          sudo dnf -y install findutils procps binutils gcc g++
-        if: matrix.toolchain == 'intel'
-      # Instructions for linux CI are adapted from upstream: https://github.com/oneapi-src/oneapi-ci (build_linux_dnf_cpp)
-      - name: Add Intel compiler repository and get versioned dependencies of dnf packages
-        run: |
-          tee > /tmp/oneAPI.repo << EOF
-          [oneAPI]
-          name=Intel(R) oneAPI repository
-          baseurl=https://yum.repos.intel.com/oneapi
-          enabled=1
-          gpgcheck=1
-          repo_gpgcheck=1
-          gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          EOF
-          sudo mv /tmp/oneAPI.repo /etc/yum.repos.d/
-          dnf -y repoquery --deplist intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran | tee depends.txt
-        if: matrix.toolchain == 'intel'
-      - name: Cache Intel compiler
-        id: cache-install
-        uses: actions/cache@v3
-        with:
-          path: |
-            /opt/intel/oneapi
-          key: Intel-Compiler-${{ hashFiles('**/depends.txt') }}
-        if: matrix.toolchain == 'intel'
-      - name: Install Intel compiler
-        run: |
-          sudo dnf install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran
-        if: matrix.toolchain == 'intel' && steps.cache-install.outputs.cache-hit != 'true'
       - name: Activate Intel compilers
         # Not elegant, it will propagate all environment variable.
         # Intel does not provide a way to output the environment variables to a file
@@ -81,26 +38,12 @@ jobs:
           printenv >> $GITHUB_ENV
           echo $PATH >> $GITHUB_PATH
         if: matrix.toolchain == 'intel'
-      - name: Install LLVM compilers
-        # TODO: Currently using gfortran because flang tests fail. See #241 for more details
-        run: |
-          sudo dnf install -y clang gcc-gfortran lld
-        if: matrix.toolchain == 'llvm'
       - uses: actions/checkout@v3
       - uses: lukka/get-cmake@latest
       - name: Run CMake configuration for ${{ matrix.toolchain }} toolchain
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "${{ matrix.toolchain }}-ci"
-      # Not sure about this step
-      - name: Remove unused files from Intel cache
-        run: |
-          LATEST_VERSION=$(ls -1 /opt/intel/oneapi/compiler/ | grep -v latest | sort | tail -1)
-          sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/compiler/lib/ia32_lin
-          sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/bin/ia32
-          sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/lib/emu
-          sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/lib/oclfpga
-        if: matrix.toolchain == 'intel' && steps.cache-install.outputs.cache-hit != 'true'
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I have a container that I am using with pre-installed toolchains (based on [nlohmann/json-ci](https://github.com/nlohmann/json-ci)). If you want, we can migrate/copy/fork this to spglib organization for better control of the container os and toolchain versions.

A few things to note:
- Containers are fedora based, so they don't have multiple compiler support like in Ubuntu
- Containers are bare-bone without debugging packages.Trying to avoid the issues that nlohmann has maintaining a monolith container
- Intel compiler is not available for Fedora38, ubuntu 23.04, etc. (supposedly will be fixed in 2023.2 release)