### PR TITLE
Refactor Github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload-wheel:
+        type: boolean
+        required: false
+        default: false
+        description: Upload wheel as an artifact
+      cibw_archs_linux:
+        required: false
+        type: string
+        default: auto aarch64
+        description: Linux architectures
+      cibw_archs_macos:
+        required: false
+        type: string
+        default: x86_64 arm64
+        description: Macos architectures
+      cibw_build:
+        required: false
+        type: string
+        description: Overwrite build targets
+  pull_request:
+    branches: [ develop ]
+  push:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    uses: ./.github/workflows/step_test.yaml
+
+  build-wheel:
+    uses: ./.github/workflows/step_build-wheel.yaml
+    needs: [ tests ]
+    with:
+      upload: ${{ inputs.upload-wheel || false }}
+      cibw_archs_linux: ${{ inputs.cibw_archs_linux || 'x86_64' }}
+      cibw_archs_macos: ${{ inputs.cibw_archs_macos || 'x86_64' }}
+      cibw_build: ${{ inputs.cibw_build }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,4 +45,4 @@ jobs:
       upload: ${{ inputs.upload-wheel || false }}
       cibw_archs_linux: ${{ inputs.cibw_archs_linux || 'x86_64' }}
       cibw_archs_macos: ${{ inputs.cibw_archs_macos || 'x86_64' }}
-      cibw_build: ${{ inputs.cibw_build }}
+      cibw_build: ${{ inputs.cibw_build || 'cp311-*' }}

--- a/.github/workflows/pypi-wheel-builds.yml
+++ b/.github/workflows/pypi-wheel-builds.yml
@@ -24,13 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.15.0
         env:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
@@ -43,14 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          cache: pip
       - name: Build sdist
-        run: |
-          pip install --upgrade pip build
-          python -m build
+        run: pipx run build
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz

--- a/.github/workflows/pypi-wheel-builds.yml
+++ b/.github/workflows/pypi-wheel-builds.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-11 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pypi-wheel-builds.yml
+++ b/.github/workflows/pypi-wheel-builds.yml
@@ -7,9 +7,9 @@ concurrency:
 
 on:
   push:
-    tags: [ "*test*" ]
+    branches: [ "test-PyPi" ]
   pull_request:
-    branches: [ test-PyPi-action ]
+    branches: [ "test-PyPi" ]
   # Make it able to be used in other workflows
   workflow_call:
 
@@ -18,8 +18,9 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, windows-2019, macOS-11 ]
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -42,11 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          cache: pip
       - name: Build sdist
         run: |
-          pip install numpy make cmake scikit-build-core build
-          ./python/get_nanoversion.sh
-          cat __nanoversion__.txt
+          pip install --upgrade pip build
           python -m build
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,10 @@ on:
 
 jobs:
   tests:
-    uses: ./.github/workflows/test.yml
-    secrets: inherit
+    uses: ./.github/workflows/step_test.yaml
   pypi-wheel:
     needs: [ tests ]
-    uses: ./.github/workflows/pypi-wheel-builds.yml
-    secrets: inherit
+    uses: ./.github/workflows/step_build-wheel.yaml
   upload_pypi:
     name: Upload to PyPI repository
     needs: [ tests, pypi-wheel ]

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -5,13 +5,32 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
-  push:
-    branches: [ "test-PyPi" ]
-  pull_request:
-    branches: [ "test-PyPi" ]
   # Make it able to be used in other workflows
   workflow_call:
+    inputs:
+      upload:
+        required: false
+        type: boolean
+        default: true
+        description: Upload wheel as artifact
+      cibw_archs_linux:
+        required: false
+        type: string
+        default: auto aarch64
+        description: Linux architectures
+      cibw_archs_macos:
+        required: false
+        type: string
+        default: x86_64 arm64
+        description: Macos architectures
+      cibw_build:
+        required: false
+        type: string
+        description: Overwrite build targets
 
 jobs:
   build_wheels:
@@ -27,11 +46,13 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         env:
-          CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_ARCHS_LINUX: ${{ inputs.cibw_archs_linux }}
+          CIBW_ARCHS_MACOS: ${{ inputs.cibw_archs_macos }}
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+        if: ${{ inputs.upload }}
 
   build_sdist:
     name: Build source distribution
@@ -43,3 +64,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
+        if: ${{ inputs.upload }}

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -30,12 +30,15 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: [ gcc, llvm, intel, windows, macos ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: windows-latest
             toolchain: windows
           - os: macos-11
             toolchain: macos
+          - python-version: "3.12"
+            experimental: true
+            pip-extra-flags: --pre
     steps:
       - name: Enable msvc toolchain on windows
         uses: ilammy/msvc-dev-cmd@v1
@@ -54,9 +57,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
         # TODO: Replace with editable install once configure presets are available
       - name: Install python bindings
-        run: python3 -m pip install .[test]
+        run: python3 -m pip install  ${{ matrix.pip-extra-flags }} .[test]
       - uses: lukka/get-cmake@latest
       - name: Run CMake configuration for ${{ matrix.toolchain }} toolchain
         uses: lukka/run-cmake@v10.3

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -6,12 +6,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
-  # Make it able to be used in other workflows
   workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:
@@ -32,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: [ gcc, llvm, intel, windows, macos ]
-        python-version: [ "3.9", "3.10", "3.11"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
             toolchain: windows

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,11 +35,22 @@ jobs:
     additional_repos:
       - copr://@scikit-build/release
     targets:
-      - fedora-development
+      # TODO: Switch to fedora-all once F37 support is dropped
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-development
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
     fmf_path: .distro
   - job: copr_build
     trigger: commit
@@ -51,8 +62,10 @@ jobs:
     targets:
       - fedora-development-x86_64
       - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-development-aarch64
       - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: copr_build
     trigger: release
     owner: lecris
@@ -60,20 +73,25 @@ jobs:
     targets:
       - fedora-development-x86_64
       - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
       - fedora-development-aarch64
       - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
   - job: tests
     trigger: commit
     branch: main
     targets:
-      - fedora-development
-      - fedora-latest
+      - fedora-development-x86_64
+      - fedora-latest-x86_64
+      - fedora-latest-stable-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-aarch64
     fmf_path: .distro
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-development
-      - fedora-latest
+      - fedora-rawhide
   - job: koji_build
     trigger: commit
     dist_git_branches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,10 @@ cmake.args = [
 ]
 
 [tool.cibuildwheel]
-skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*", "*-macosx_arm64"]
+# cp312: Cannot build numpy yet
+# macosx_arm64: Cannot test on Github. Could add Cirrus CI/Circle CI
+# pp, win32, i686, muslinux: Remove 32bit variants, PyPY interpreter and unnecessary musl variant
+skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*", "*-macosx_arm64", "cp312-*"]
 test-extras = "test"
 test-command = "pytest {package}/test/functional/python"
 # Do not run test on emulated environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ cmake.args = [
 [tool.cibuildwheel]
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*", "*-macosx_arm64"]
 test-extras = "test"
-test-command = "pytest {package}/python/test --benchmark-skip"
+test-command = "pytest {package}/test/functional/python"
 # Do not run test on emulated environments
 test-skip = "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
 
@@ -90,6 +90,10 @@ repair-wheel-command = ""
 [tool.pytest.ini_options]
 addopts = "-m 'not benchmark'"
 testpaths = ["test/functional/python"]
+markers = [
+    # Define benchmark marker to avoid warnings of marker not defined
+    "benchmark: benchmarking tets",
+]
 
 [tool.coverage.run]
 command_line = '-m pytest'


### PR DESCRIPTION
For now this PR:
- fixes build-wheel CI
- refactors the CI into individual steps
- allows to trigger CI, primarily build-wheel, via github UI
- enables build wheel (only `cp311-*` variants) in default CI. Should not be necessary since the default CI runs them as well, but another sanity check doesn't hurt.
  One thing I've noticed. The wheel builds are not really used in uploading to `PyPI`. `PyPI` is building the package from source on their side as well. We should get the badge and put it on the `README.md` to keep track of it

Let me know if the tests done here are a bit excessive and I can move some of them to `workflow_dispatch`. E.g. we could make it run only python `3.11` and `3.12` on the normal CI.