### PR TITLE
Initial refactor for layer group implementation

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -37,32 +37,32 @@
 
 #include <stdio.h>
 
-void dbg_print_matrix_d3(double a[3][3]) {
+void dbg_print_matrix_d3(const double a[3][3]) {
     int i;
     for (i = 0; i < 3; i++) {
         printf("%f %f %f\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_matrix_i3(int a[3][3]) {
+void dbg_print_matrix_i3(const int a[3][3]) {
     int i;
     for (i = 0; i < 3; i++) {
         printf("%d %d %d\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vectors_d3(double a[][3], int size) {
+void dbg_print_vectors_d3(const double a[][3], int size) {
     int i;
     for (i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vector_d3(double a[3]) {
+void dbg_print_vector_d3(const double a[3]) {
     printf("%f %f %f\n", a[0], a[1], a[2]);
 }
 
-void dbg_print_vectors_with_label(double a[][3], int b[], int size) {
+void dbg_print_vectors_with_label(const double a[][3], const int b[], int size) {
     int i;
     for (i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);

--- a/src/debug.c
+++ b/src/debug.c
@@ -62,7 +62,8 @@ void dbg_print_vector_d3(const double a[3]) {
     printf("%f %f %f\n", a[0], a[1], a[2]);
 }
 
-void dbg_print_vectors_with_label(const double a[][3], const int b[], int size) {
+void dbg_print_vectors_with_label(const double a[][3], const int b[],
+                                  int size) {
     int i;
     for (i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);

--- a/src/debug.h
+++ b/src/debug.h
@@ -45,11 +45,11 @@
 #define debug_print_vectors_with_label(...) \
     dbg_print_vectors_with_label(__VA_ARGS__)
 
-void dbg_print_matrix_d3(double a[3][3]);
-void dbg_print_matrix_i3(int a[3][3]);
-void dbg_print_vector_d3(double a[3]);
-void dbg_print_vectors_d3(double a[][3], int size);
-void dbg_print_vectors_with_label(double a[][3], int b[], int size);
+void dbg_print_matrix_d3(const double a[3][3]);
+void dbg_print_matrix_i3(const int a[3][3]);
+void dbg_print_vector_d3(const double a[3]);
+void dbg_print_vectors_d3(const double a[][3], int size);
+void dbg_print_vectors_with_label(const double a[][3], const int b[], int size);
 
 #else
 #define debug_print(...)

--- a/src/delaunay.c
+++ b/src/delaunay.c
@@ -338,18 +338,6 @@ static int get_extended_basis(double basis[4][3], const double lattice[3][3],
     return lattice_rank;
 }
 
-// @brief Delaunay reduction for monoclinic/oblique or monoclinic/rectangular
-// @param[out] red_lattice
-// @param[in] lattice
-// @param[in] unique_axis
-//            Two-fold axis or mirror-plane-perpendicular axis
-// @param[in] aperiodic_axis
-// @param[in] symprec
-// @note For Monoclinic/oblique, the unique axis is also the aperiodic axis.
-//       Axes are {j, k, unique_axis(=aperiodic_axis)}.
-//       For Monoclinic/rectangular, axes are {unique_axis, j,
-//       k(=aperiodic_axis)}. j and k are delaunay reduced, which can be
-//       incomplete for Monoclinic/Rectangular
 int del_layer_delaunay_reduce_2D(double red_lattice[3][3],
                                  const double lattice[3][3],
                                  const int unique_axis,

--- a/src/delaunay.h
+++ b/src/delaunay.h
@@ -39,8 +39,6 @@
 
 int del_delaunay_reduce(double lattice_new[3][3], const double lattice[3][3],
                         const double symprec);
-int del_delaunay_reduce_2D(double min_lattice[3][3], const double lattice[3][3],
-                           const int unique_axis, const double symprec);
 int del_layer_delaunay_reduce(double min_lattice[3][3],
                               const double lattice[3][3],
                               const int aperiodic_axis, const double symprec);

--- a/src/delaunay.h
+++ b/src/delaunay.h
@@ -42,6 +42,19 @@ int del_delaunay_reduce(double lattice_new[3][3], const double lattice[3][3],
 int del_layer_delaunay_reduce(double min_lattice[3][3],
                               const double lattice[3][3],
                               const int aperiodic_axis, const double symprec);
+
+// @brief Delaunay reduction for monoclinic/oblique or monoclinic/rectangular
+// @param[out] red_lattice
+// @param[in] lattice
+// @param[in] unique_axis
+//            Two-fold axis or mirror-plane-perpendicular axis
+// @param[in] aperiodic_axis
+// @param[in] symprec
+// @note For Monoclinic/oblique, the unique axis is also the aperiodic axis.
+//       Axes are {j, k, unique_axis(=aperiodic_axis)}.
+//       For Monoclinic/rectangular, axes are {unique_axis, j,
+//       k(=aperiodic_axis)}. j and k are delaunay reduced, which can be
+//       incomplete for Monoclinic/Rectangular
 int del_layer_delaunay_reduce_2D(double min_lattice[3][3],
                                  const double lattice[3][3],
                                  const int unique_axis,

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -474,7 +474,7 @@ static size_t get_dense_ir_reciprocal_mesh_normal(
     kgd_get_all_grid_addresses(grid_address, mesh);
 
 #pragma omp parallel for private(j, grid_point_rot, address_double, \
-                                 address_double_rot)
+                                     address_double_rot)
     for (i = 0; i < mesh[0] * mesh[1] * (size_t)(mesh[2]); i++) {
         kgd_get_grid_address_double_mesh(address_double, grid_address[i], mesh,
                                          is_shift);
@@ -516,9 +516,9 @@ static size_t get_dense_ir_reciprocal_mesh_distortion(
         divisor[j] = mesh[(j + 1) % 3] * mesh[(j + 2) % 3];
     }
 
-#pragma omp parallel for private(j, k, grid_point_rot, address_double,    \
-                                 address_double_rot, long_address_double, \
-                                 long_address_double_rot)
+#pragma omp parallel for private(j, k, grid_point_rot, address_double,        \
+                                     address_double_rot, long_address_double, \
+                                     long_address_double_rot)
     for (i = 0; i < mesh[0] * mesh[1] * (size_t)(mesh[2]); i++) {
         kgd_get_grid_address_double_mesh(address_double, grid_address[i], mesh,
                                          is_shift);

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -117,12 +117,15 @@ int niggli_get_minor_version(void) { return NIGGLI_MINOR_VERSION; }
 int niggli_get_micro_version(void) { return NIGGLI_MICRO_VERSION; }
 
 /* return 0 if failed */
-int niggli_reduce(double *lattice_, const double eps_) {
-    return niggli_reduce_periodic(lattice_, eps_, -1);
-}
-
-int niggli_reduce_periodic(double *lattice_, const double eps_,
-                           const int aperiodic_axis) {
+// For bulk, set `aperiodic_axis=-1`
+// @note For layer group, Niggli steps are modified to maintain the non-periodic
+// axis
+//       - First, Move aperiodic axis to c
+//       - Step 2 is skipped
+//       - (Steps 5 and 6 are not modified because axis c is perpendicular to
+//       the plane)
+int niggli_reduce(double *lattice_, const double eps_,
+                  const int aperiodic_axis) {
     int i, j, succeeded;
     NiggliParams *p;
     int (*steps[8])(NiggliParams * p) = {step1, step2, step3, step4,
@@ -140,6 +143,7 @@ int niggli_reduce_periodic(double *lattice_, const double eps_,
     }
 
     /* Step 0 */
+    // Move aperiodic axis to c for layer
     if (!(((aperiodic_axis == 0 || aperiodic_axis == 1) &&
            layer_swap_axis(p, aperiodic_axis)) ||
           ((aperiodic_axis == -1 || aperiodic_axis == 2) &&

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -128,8 +128,8 @@ int niggli_reduce(double *lattice_, const double eps_,
                   const int aperiodic_axis) {
     int i, j, succeeded;
     NiggliParams *p;
-    int (*steps[8])(NiggliParams * p) = {step1, step2, step3, step4,
-                                         step5, step6, step7, step8};
+    int (*steps[8])(NiggliParams *p) = {step1, step2, step3, step4,
+                                        step5, step6, step7, step8};
 
     if (aperiodic_axis != -1) {
         steps[1] = step2_for_layer;

--- a/src/niggli.h
+++ b/src/niggli.h
@@ -42,8 +42,7 @@
 int niggli_get_major_version(void);
 int niggli_get_minor_version(void);
 int niggli_get_micro_version(void);
-int niggli_reduce(double* lattice_, const double eps_);
-int niggli_reduce_periodic(double* lattice_, const double eps_,
-                           const int aperiodic_axis);
+int niggli_reduce(double* lattice_, const double eps_,
+                  const int aperiodic_axis);
 
 #endif

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -613,8 +613,7 @@ static int get_rotation_type(const int rot[3][3]) {
 // @param[in] laue
 // @param[in] pointsym
 // @param[in] aperiodic_axis
-static int get_axes(int axes[3], const Laue laue,
-                    const PointSymmetry* pointsym,
+static int get_axes(int axes[3], const Laue laue, const PointSymmetry* pointsym,
                     const int aperiodic_axis) {
     switch (laue) {
         case LAUE1:

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -330,6 +330,7 @@ static int inversion[3][3] = {
     {0, 0, -1},
 };
 
+// length of `rot_axes` should be equal to `NUM_ROT_AXES`
 static int rot_axes[][3] = {
     {1, 0, 0},   {0, 1, 0},   {0, 0, 1},   {0, 1, 1},   {1, 0, 1},
     {1, 1, 0},   {0, 1, -1},  {-1, 0, 1},  {1, -1, 0},  {1, 1, 1}, /* 10 */
@@ -382,19 +383,15 @@ static int is_exist_axis(const int axis_vec[3], const int axis_index);
 static void sort_axes(int axes[3]);
 static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis);
 
-/* Return pointgroup.number = 0 if failed */
+// @brief Return pointgroup.number = 0 if failed.
+// @param[out] transform_mat
+// @param[in] rotations
+// @param[in] num_rotations
+// @param[in] aperiodic_axis Use `aperiodic_axis=-1` for space group.
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
                                          const int rotations[][3][3],
-                                         const int num_rotations) {
-    return ptg_get_layer_transformation_matrix(transform_mat, rotations,
-                                               num_rotations, -1);
-}
-
-/* Layer group does not have cubic point groups */
-Pointgroup ptg_get_layer_transformation_matrix(int transform_mat[3][3],
-                                               const int rotations[][3][3],
-                                               const int num_rotations,
-                                               const int aperiodic_axis) {
+                                         const int num_rotations,
+                                         const int aperiodic_axis) {
     int i, j, pg_num;
     int axes[3];
     PointSymmetry pointsym;
@@ -410,7 +407,9 @@ Pointgroup ptg_get_layer_transformation_matrix(int transform_mat[3][3],
 
     pg_num = get_pointgroup_number_by_rotations(rotations, num_rotations);
 
+    // Layer group does not have cubic point groups (28 <= pg_num < 32)
     if (pg_num > 0 && (aperiodic_axis == -1 || pg_num < 28)) {
+        // Based on step (c) of R. W. Grosse-Kunstleve (1999)
         pointgroup = ptg_get_pointgroup(pg_num);
         pointsym = ptg_get_pointsymmetry(rotations, num_rotations);
         get_axes(axes, pointgroup.laue, &pointsym, aperiodic_axis);
@@ -451,6 +450,7 @@ Pointgroup ptg_get_pointgroup(const int pointgroup_number) {
     return pointgroup;
 }
 
+// @brief Construct PointSymmetry from given `rotations`
 PointSymmetry ptg_get_pointsymmetry(const int rotations[][3][3],
                                     const int num_rotations) {
     int i, j;
@@ -512,6 +512,10 @@ end:
     return pg_num;
 }
 
+// @brief Return counts of types of rotations
+// @param[out] table counts of {-6, -4, -3, -2, 1, 1, 2, 3, 4, 6}-fold rotations
+// or roto-rotations
+// @param[in] pointsym
 static int get_pointgroup_class_table(int table[10],
                                       const PointSymmetry* pointsym) {
     /* Look-up table */
@@ -602,13 +606,21 @@ static int get_rotation_type(const int rot[3][3]) {
     return rot_type;
 }
 
-static int get_axes(int axes[3], const Laue laue, const PointSymmetry* pointsym,
+// @brief Get conventional axes for point group `pointsym`
+// @note For layer group, Laue class 2/m and mmm need a special care
+// @param[out] axes three indices of `rot_axes`. If they are larger than
+//             NUM_ROT_AXES, it represents the negative direction.
+// @param[in] laue
+// @param[in] pointsym
+// @param[in] aperiodic_axis
+static int get_axes(int axes[3], const Laue laue,
+                    const PointSymmetry* pointsym,
                     const int aperiodic_axis) {
     switch (laue) {
         case LAUE1:
-            axes[0] = 0;
-            axes[1] = 1;
-            axes[2] = 2;
+            axes[0] = 0;  // {1, 0, 0}
+            axes[1] = 1;  // {0, 1, 0}
+            axes[2] = 2;  // {0, 0, 1}
             break;
         case LAUE2M:
             if (aperiodic_axis == -1) {
@@ -669,7 +681,7 @@ static int laue2m(int axes[3], const PointSymmetry* pointsym) {
             continue;
         }
 
-        /* The first axis */
+        /* The first axis (unique axis b) */
         axes[1] = get_rotation_axis(prop_rot);
         break;
     }
@@ -684,7 +696,7 @@ static int laue2m(int axes[3], const PointSymmetry* pointsym) {
     is_found = 0;
     for (i = 0; i < num_ortho_axis; i++) {
         norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-        if (norm < min_norm - ZERO_PREC) {
+        if (norm < min_norm) {
             min_norm = norm;
             axes[0] = ortho_axes[i];
             is_found = 1;
@@ -699,7 +711,7 @@ static int laue2m(int axes[3], const PointSymmetry* pointsym) {
     is_found = 0;
     for (i = 0; i < num_ortho_axis; i++) {
         norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-        if ((norm < min_norm - ZERO_PREC) && (ortho_axes[i] != axes[0])) {
+        if ((norm < min_norm) && (ortho_axes[i] != axes[0])) {
             min_norm = norm;
             axes[2] = ortho_axes[i];
             is_found = 1;
@@ -726,6 +738,8 @@ err:
     return 0;
 }
 
+// @note The two-fold axis is set to axis-a. Axes b and c forms the periodic
+// plane.
 static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
                         const int aperiodic_axis) {
     int i, num_ortho_axis, norm, min_norm, is_found;
@@ -760,7 +774,7 @@ static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
         is_found = 0;
         for (i = 0; i < num_ortho_axis; i++) {
             norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-            if (norm < min_norm - ZERO_PREC) {
+            if (norm < min_norm) {
                 min_norm = norm;
                 axes[1] = ortho_axes[i];
                 is_found = 1;
@@ -775,7 +789,7 @@ static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
         is_found = 0;
         for (i = 0; i < num_ortho_axis; i++) {
             norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-            if ((norm < min_norm - ZERO_PREC) && (ortho_axes[i] != axes[1])) {
+            if ((norm < min_norm) && (ortho_axes[i] != axes[1])) {
                 min_norm = norm;
                 axes[2] = ortho_axes[i];
                 is_found = 1;
@@ -792,7 +806,7 @@ static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
         for (i = 0; i < num_ortho_axis; i++) {
             if (rot_axes[ortho_axes[i]][aperiodic_axis] == 0) {
                 norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-                if (norm < min_norm - ZERO_PREC) {
+                if (norm < min_norm) {
                     min_norm = norm;
                     axes[1] = ortho_axes[i];
                     is_found = 1;
@@ -810,7 +824,7 @@ static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
             if (rot_axes[ortho_axes[i]][aperiodic_axis] == 1 ||
                 rot_axes[ortho_axes[i]][aperiodic_axis] == -1) {
                 norm = mat_norm_squared_i3(rot_axes[ortho_axes[i]]);
-                if (norm < min_norm - ZERO_PREC) {
+                if (norm < min_norm) {
                     min_norm = norm;
                     axes[2] = ortho_axes[i];
                     is_found = 1;
@@ -1155,6 +1169,7 @@ static int lauem3m(int axes[3], const PointSymmetry* pointsym) {
 }
 #endif
 
+// For Laue classes 4/m, 4/mmm, -3, -3/m, 6/m, 6/mmm
 static int laue_one_axis(int axes[3], const PointSymmetry* pointsym,
                          const int rot_order) {
     int i, j, num_ortho_axis, det, is_found, tmpval;
@@ -1170,7 +1185,7 @@ static int laue_one_axis(int axes[3], const PointSymmetry* pointsym,
         /* Search four-fold rotation */
         if (rot_order == 4) {
             if (mat_get_trace_i3(prop_rot) == 1) {
-                /* The first axis */
+                /* The first axis (c axis) */
                 axes[2] = get_rotation_axis(prop_rot);
                 break;
             }
@@ -1179,7 +1194,7 @@ static int laue_one_axis(int axes[3], const PointSymmetry* pointsym,
         /* Search three-fold rotation */
         if (rot_order == 3) {
             if (mat_get_trace_i3(prop_rot) == 0) {
-                /* The first axis */
+                /* The first axis (c axis) */
                 axes[2] = get_rotation_axis(prop_rot);
                 break;
             }
@@ -1244,6 +1259,7 @@ end:
     return 1;
 }
 
+// For Laue classes mmm, m-3, m-3m
 static int lauennn(int axes[3], const PointSymmetry* pointsym,
                    const int rot_order, const int aperiodic_axis) {
     int i, count, axis;
@@ -1307,6 +1323,11 @@ end:
     return axis;
 }
 
+// Output indices of `rot_axes` orthogonal to the axis of `proper_rot`
+// @param[out] ortho_axes indices of `rot_axes`
+// @param[in] proper_rot Proper rotation
+// @param[in] rot_order
+// @return Size of orthogonal axes
 static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
                                const int rot_order) {
     int i, num_ortho_axis;
@@ -1315,6 +1336,7 @@ static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
 
     num_ortho_axis = 0;
 
+    // sum_rot = proper_rot + ... + proper_rot^rot_order
     mat_copy_matrix_i3(sum_rot, identity);
     mat_copy_matrix_i3(rot, identity);
     for (i = 0; i < rot_order - 1; i++) {
@@ -1323,6 +1345,7 @@ static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
     }
 
     for (i = 0; i < NUM_ROT_AXES; i++) {
+        // Kernel of `sum_rot` is always orthogonal to the axis of `proper_rot`
         mat_multiply_matrix_vector_i3(vec, sum_rot, rot_axes[i]);
         if (vec[0] == 0 && vec[1] == 0 && vec[2] == 0) {
             ortho_axes[num_ortho_axis] = i;
@@ -1333,6 +1356,7 @@ static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
     return num_ortho_axis;
 }
 
+// @brief If `rot` is improper, output `rot` with inversion.
 static void get_proper_rotation(int prop_rot[3][3], const int rot[3][3]) {
     if (mat_get_determinant_i3(rot) == -1) {
         mat_multiply_matrix_i3(prop_rot, inversion, rot);
@@ -1341,6 +1365,7 @@ static void get_proper_rotation(int prop_rot[3][3], const int rot[3][3]) {
     }
 }
 
+// @brief Construct `tmat` from given indices corresponding to `rot_axes`
 static void set_transformation_matrix(int tmat[3][3], const int axes[3]) {
     int i, j, s[3];
 
@@ -1358,6 +1383,8 @@ static void set_transformation_matrix(int tmat[3][3], const int axes[3]) {
     }
 }
 
+// @brief Return 1 if axis_vec == rot_axes[axis_index],
+//        -1 if axis_vec == -rot_axes[axis_index], otherwise return 0.
 static int is_exist_axis(const int axis_vec[3], const int axis_index) {
     if ((axis_vec[0] == rot_axes[axis_index][0]) &&
         (axis_vec[1] == rot_axes[axis_index][1]) &&
@@ -1376,19 +1403,19 @@ static void sort_axes(int axes[3]) {
     int axis;
     int t_mat[3][3];
 
-    if (axes[1] > axes[2] + ZERO_PREC) {
+    if (axes[1] > axes[2]) {
         axis = axes[1];
         axes[1] = axes[2];
         axes[2] = axis;
     }
 
-    if (axes[0] > axes[1] + ZERO_PREC) {
+    if (axes[0] > axes[1]) {
         axis = axes[0];
         axes[0] = axes[1];
         axes[1] = axis;
     }
 
-    if (axes[1] > axes[2] + ZERO_PREC) {
+    if (axes[1] > axes[2]) {
         axis = axes[1];
         axes[1] = axes[2];
         axes[2] = axis;
@@ -1402,8 +1429,8 @@ static void sort_axes(int axes[3]) {
     }
 }
 
-/* Warning when rot_axes[axes[i]][aperiodic_axis] == -2, -3, 2, 3 */
-/* I am not sure if this would ever happen. */
+// Sort two-fold axes for Laue class mmm for layer group.
+// Non-periodic axis is maintained to be c-axis.
 static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis) {
     int i, lattice_rank, arank, axis, axis_i;
     int t_mat[3][3];
@@ -1432,6 +1459,8 @@ static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis) {
             axes[1] = axis;
         }
     } else {
+        // Warning when rot_axes[axes[i]][aperiodic_axis] == -2, -3, 2, 3
+        // I am not sure if this would ever happen.
         warning_print("spglib: Invalid axes were found ");
         warning_print("(line %d, %s).\n", __LINE__, __FILE__);
         for (i = 0; i < 3; i++) {

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -383,11 +383,6 @@ static int is_exist_axis(const int axis_vec[3], const int axis_index);
 static void sort_axes(int axes[3]);
 static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis);
 
-// @brief Return pointgroup.number = 0 if failed.
-// @param[out] transform_mat
-// @param[in] rotations
-// @param[in] num_rotations
-// @param[in] aperiodic_axis Use `aperiodic_axis=-1` for space group.
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
                                          const int rotations[][3][3],
                                          const int num_rotations,

--- a/src/pointgroup.h
+++ b/src/pointgroup.h
@@ -72,6 +72,11 @@ typedef struct {
     Laue laue;
 } Pointgroup;
 
+// @brief Return pointgroup.number = 0 if failed.
+// @param[out] transform_mat
+// @param[in] rotations
+// @param[in] num_rotations
+// @param[in] aperiodic_axis Use `aperiodic_axis=-1` for space group.
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
                                          const int rotations[][3][3],
                                          const int num_rotations,

--- a/src/pointgroup.h
+++ b/src/pointgroup.h
@@ -74,11 +74,8 @@ typedef struct {
 
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
                                          const int rotations[][3][3],
-                                         const int num_rotations);
-Pointgroup ptg_get_layer_transformation_matrix(int transform_mat[3][3],
-                                               const int rotations[][3][3],
-                                               const int num_rotations,
-                                               const int aperiodic_axis);
+                                         const int num_rotations,
+                                         const int aperiodic_axis);
 Pointgroup ptg_get_pointgroup(const int pointgroup_number);
 PointSymmetry ptg_get_pointsymmetry(const int rotations[][3][3],
                                     const int num_rotations);

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -918,8 +918,7 @@ err:
     return 0;
 }
 
-/* Triclinic: Niggli cell reduction */
-/* Return 0 if failed */
+// Perform Niggli cell reduction for Triclinic. Return 0 if failed.
 static int change_basis_tricli(int tmat_int[3][3],
                                const double conv_lattice[3][3],
                                const double primitive_lattice[3][3],
@@ -934,8 +933,7 @@ static int change_basis_tricli(int tmat_int[3][3],
         }
     }
 
-    if (!niggli_reduce_periodic(niggli_cell, symprec * symprec,
-                                aperiodic_axis)) {
+    if (!niggli_reduce(niggli_cell, symprec * symprec, aperiodic_axis)) {
         return 0;
     }
 

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -838,8 +838,8 @@ static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
     /* For rhombohedral system, basis vectors for hP */
     /* (hexagonal lattice basis) are provided by tmat_int, */
     /* but may be either obverse or reverse setting. */
-    pointgroup = ptg_get_layer_transformation_matrix(
-        tmat_int, symmetry->rot, symmetry->size, aperiodic_axis);
+    pointgroup = ptg_get_transformation_matrix(tmat_int, symmetry->rot,
+                                               symmetry->size, aperiodic_axis);
 
     debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("initial transformation matrix\n");

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -988,7 +988,7 @@ int spg_niggli_reduce(double lattice[3][3], const double symprec) {
         }
     }
 
-    succeeded = niggli_reduce(vals, symprec);
+    succeeded = niggli_reduce(vals, symprec, -1 /* aperiodic_axis */);
 
     if (succeeded) {
         for (i = 0; i < 3; i++) {

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -670,8 +670,8 @@ int spg_get_pointgroup(char symbol[6], int transform_mat[3][3],
                        const int rotations[][3][3], const int num_rotations) {
     Pointgroup pointgroup;
 
-    pointgroup =
-        ptg_get_transformation_matrix(transform_mat, rotations, num_rotations);
+    pointgroup = ptg_get_transformation_matrix(
+        transform_mat, rotations, num_rotations, -1 /* aperiodic_axis*/);
 
     if (pointgroup.number == 0) {
         spglib_error_code = SPGERR_POINTGROUP_NOT_FOUND;

--- a/src/symmetry.c
+++ b/src/symmetry.c
@@ -976,8 +976,8 @@ static PointSymmetry get_lattice_symmetry(const Cell *cell,
 
                     if (is_identity_metric(metric, metric_orig, symprec,
                                            angle_tol)) {
-                        if ((aperiodic_axis == -1 && num_sym > 47) ||
-                            (aperiodic_axis != -1 && num_sym > 23)) {
+                        if ((aperiodic_axis == -1 && num_sym >= 48) ||
+                            (aperiodic_axis != -1 && num_sym >= 24)) {
                             warning_print(
                                 "spglib: Too many lattice symmetries was "
                                 "found.\n");
@@ -999,8 +999,8 @@ static PointSymmetry get_lattice_symmetry(const Cell *cell,
             }
         }
 
-        if ((aperiodic_axis == -1 && num_sym < 49) ||
-            (aperiodic_axis != -1 && num_sym < 25) || angle_tol < 0) {
+        if ((aperiodic_axis == -1 && num_sym <= 48) ||
+            (aperiodic_axis != -1 && num_sym <= 24) || angle_tol < 0) {
             lattice_sym.size = num_sym;
             return transform_pointsymmetry(&lattice_sym, cell->lattice,
                                            min_lattice);
@@ -1121,6 +1121,8 @@ err:
     return lat_sym_new;
 }
 
+// @brief Set an integer matrix to `axes`. Three integer vectors are specified
+//        by indices of array `symmetry.c:relative_axes`.
 static void set_axes(int axes[3][3], const int a1, const int a2, const int a3) {
     int i;
     for (i = 0; i < 3; i++) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(CTests
 		test_error.cpp
+    test_symmetry.cpp
 		test_symmetry_search.cpp
 		test_spacegroup_type_search.cpp
 		test_find_primitive_cell.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(CTests
+		test_delaunay.cpp
 		test_error.cpp
-    test_symmetry.cpp
+		test_symmetry.cpp
 		test_symmetry_search.cpp
 		test_spacegroup_type_search.cpp
 		test_find_primitive_cell.cpp

--- a/test/README.md
+++ b/test/README.md
@@ -40,6 +40,28 @@ TEST(<your_test_suite_name>, <test_name>) {
 }
 ```
 
+## VSCode setting
+
+Although Googletest is automatically prepared, you may need to install it locally to highlight structs and functions.
+
+The below is an example of `c_cpp_properties.json` for Mac (assume Googletest is installed by brew).
+```json
+{
+    "configurations": [
+        {
+            ...
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${workspaceFolder}/src",
+                "${workspaceFolder}/test",
+                "/opt/homebrew/include/"
+            ],
+            ...
+        }
+    ]
+}
+```
+
 ## Utility functions for preparing structures
 
 When you find a doubtful `cell` with Python API, the following python snippets will be useful to prepare a test case for Python testing and C testing.

--- a/test/README.md
+++ b/test/README.md
@@ -45,6 +45,7 @@ TEST(<your_test_suite_name>, <test_name>) {
 Although Googletest is automatically prepared, you may need to install it locally to highlight structs and functions.
 
 The below is an example of `c_cpp_properties.json` for Mac (assume Googletest is installed by brew).
+
 ```json
 {
     "configurations": [

--- a/test/test_delaunay.cpp
+++ b/test/test_delaunay.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+    #include <math.h>
+    #include "delaunay.h"
+    #include "debug.h"
+}
+
+TEST(test_delaunay, test_delaunay_reduce_layer) {
+    double min_lattice[3][3];
+    // Unimodular matrix
+    double lattice[3][3] = {
+        {1, 0, 0},
+        {0, 37, 10},
+        {0, 11, 3},
+    };
+    const int aperiodic_axis = 0;
+    const double symprec = 1e-5;
+
+    del_layer_delaunay_reduce(min_lattice, lattice, aperiodic_axis, symprec);
+
+    // Shortest vectors in the periodic plane are [0, 1, 0] and [0, 0, 1]
+    debug_print_matrix_d3(min_lattice);
+    for (int i = 0; i < 3; ++i) {
+        double sum = fabs(min_lattice[0][i]) + fabs(min_lattice[1][i]) + fabs(min_lattice[2][i]);
+        ASSERT_FLOAT_EQ(sum, 1);
+    }
+}

--- a/test/test_delaunay.cpp
+++ b/test/test_delaunay.cpp
@@ -1,9 +1,10 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-    #include <math.h>
-    #include "delaunay.h"
-    #include "debug.h"
+#include <math.h>
+
+#include "debug.h"
+#include "delaunay.h"
 }
 
 TEST(test_delaunay, test_delaunay_reduce_layer) {
@@ -22,7 +23,8 @@ TEST(test_delaunay, test_delaunay_reduce_layer) {
     // Shortest vectors in the periodic plane are [0, 1, 0] and [0, 0, 1]
     debug_print_matrix_d3(min_lattice);
     for (int i = 0; i < 3; ++i) {
-        double sum = fabs(min_lattice[0][i]) + fabs(min_lattice[1][i]) + fabs(min_lattice[2][i]);
+        double sum = fabs(min_lattice[0][i]) + fabs(min_lattice[1][i]) +
+                     fabs(min_lattice[2][i]);
         ASSERT_FLOAT_EQ(sum, 1);
     }
 }

--- a/test/test_symmetry.cpp
+++ b/test/test_symmetry.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-    #include "cell.h"
-    #include "symmetry.h"
-    #include "utils.h"
+#include "cell.h"
+#include "symmetry.h"
+#include "utils.h"
 }
 
 TEST(test_symmetry, test_get_lattice_symmetry_layer) {
@@ -19,9 +19,7 @@ TEST(test_symmetry, test_get_lattice_symmetry_layer) {
         {0, 1, 0},
         {0, 0, 1},
     };
-    double positions[1][3] = {
-        {0, 0, 0}
-    };
+    double positions[1][3] = {{0, 0, 0}};
     const int types[1] = {0};
     const int aperiodic_axis = 2;
     const double symprec = 1e-5;

--- a/test/test_symmetry.cpp
+++ b/test/test_symmetry.cpp
@@ -26,6 +26,8 @@ TEST(test_symmetry, test_get_lattice_symmetry_layer) {
     const double angle_tolerance = -1;
 
     cell = cel_alloc_cell(size, NOSPIN);
+    ASSERT_NE(cell, nullptr);
+    ASSERT_EQ(spg_get_error_code(), SPGLIB_SUCCESS);
     cel_set_layer_cell(cell, lattice, positions, types, aperiodic_axis);
 
     // Bravais group of the two-dimensional lattice is 4/mmm

--- a/test/test_symmetry.cpp
+++ b/test/test_symmetry.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+    #include "cell.h"
+    #include "symmetry.h"
+    #include "utils.h"
+}
+
+TEST(test_symmetry, test_get_lattice_symmetry_layer) {
+    Cell *cell;
+    Symmetry *symmetry;
+
+    cell = NULL;
+    symmetry = NULL;
+
+    const int size = 1;
+    double lattice[3][3] = {
+        {1, 0, 0},
+        {0, 1, 0},
+        {0, 0, 1},
+    };
+    double positions[1][3] = {
+        {0, 0, 0}
+    };
+    const int types[1] = {0};
+    const int aperiodic_axis = 2;
+    const double symprec = 1e-5;
+    const double angle_tolerance = -1;
+
+    cell = cel_alloc_cell(size, NOSPIN);
+    cel_set_layer_cell(cell, lattice, positions, types, aperiodic_axis);
+
+    // Bravais group of the two-dimensional lattice is 4/mmm
+    symmetry = sym_get_operation(cell, symprec, angle_tolerance);
+    ASSERT_EQ(symmetry->size, 16);
+}

--- a/test/test_symmetry.cpp
+++ b/test/test_symmetry.cpp
@@ -33,4 +33,9 @@ TEST(test_symmetry, test_get_lattice_symmetry_layer) {
     // Bravais group of the two-dimensional lattice is 4/mmm
     symmetry = sym_get_operation(cell, symprec, angle_tolerance);
     ASSERT_EQ(symmetry->size, 16);
+
+    sym_free_symmetry(symmetry);
+    cel_free_cell(cell);
+    symmetry = NULL;
+    cell = NULL;
 }


### PR DESCRIPTION
This PR addresses the following as a by-product of my code reading for the layer group implementation.

- delete unused functions
- add docstrings and comments
- refactor `match_hall_symbol_db`
- add tests for delaynay reduction and layer-group symmetry