### PR TITLE
ci: Silence codecov until all coverage tests are uploaded

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -28,3 +28,6 @@ coverage:
       python_api:
         flags:
           - python_api
+codecov:
+  notify:
+    after_n_builds: 3


### PR DESCRIPTION
If another API is introduced, this one should be increased again