### PR TITLE
Silence C warning "arrays with different qualifiers"

### DIFF
--- a/cmake/CMakePresets-CI.json
+++ b/cmake/CMakePresets-CI.json
@@ -12,10 +12,6 @@
         "default"
       ],
       "cacheVariables": {
-        "CMAKE_C_STANDARD": {
-          "type": "STRING",
-          "value": "23"
-        },
         "SPGLIB_WITH_Fortran": {
           "type": "BOOL",
           "value": true

--- a/cmake/CMakePresets-CI.json
+++ b/cmake/CMakePresets-CI.json
@@ -12,6 +12,10 @@
         "default"
       ],
       "cacheVariables": {
+        "CMAKE_C_STANDARD": {
+          "type": "STRING",
+          "value": "23"
+        },
         "SPGLIB_WITH_Fortran": {
           "type": "BOOL",
           "value": true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,9 @@ configure_file(version.h.in version.h)
 if (MSVC)
 	target_compile_options(Spglib_symspg PRIVATE /W4)
 else()
-	target_compile_options(Spglib_symspg PRIVATE -Wall -Wextra -Wpedantic)
+	# TODO: C23: Disabled -Wpedantic because of warning spam
+	#  Add it back when C23 standard is widespread and revert this [Temp][C23] commit
+	target_compile_options(Spglib_symspg PRIVATE -Wall -Wextra)
 endif()
 
 # Configure main target


### PR DESCRIPTION
Bumped the C standard used in the CI to C23. This should silence the warning.

~~This is not a viable solution because in practice we should only require C17 or C11 standard for now. I will make a proper warning suppression for these specific warnings. For now I just want to check that in the future it is automatically resolved ~~

So bumping to C23 indeed silences the warning, but it is too early to apply that standard. Instead I've disabled `-Wpedantic` with a TODO for when C23 is applied. Note that #297 is an alternative to the compiler warnings where we have more flexibility to disable these warnings.