### PR TITLE
Test fixture

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Define/clear local variables to be used
@@ -12,6 +12,7 @@ set_target_properties(Spglib_tests PROPERTIES
 		OUTPUT_NAME test_suite
 		)
 target_sources(Spglib_tests PRIVATE
+		c_fixtures.cpp
 		utils.c
 		)
 target_link_libraries(Spglib_tests

--- a/test/c_fixtures.cpp
+++ b/test/c_fixtures.cpp
@@ -1,0 +1,112 @@
+#include "c_fixtures.hpp"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+void Dataset::SetUp() {
+    input = GetParam();
+    // First print the parameters
+    input.print();
+
+    // Have to copy arrays to get the appropriate C type data
+    std::vector<double[3]> positions(input.atoms.size());
+    std::vector<int> types(input.atoms.size());
+    // Can't figure how to push_back vector of native array
+    auto i = 0;
+    for (auto& atom : input.atoms) {
+        for (auto j = 0; j < 3; j++) {
+            positions[i][j] = atom.position[j];
+        }
+        types[i] = atom.type_number;
+        i++;
+    }
+    dataset = spg_get_dataset(input.lattice, positions.data(), types.data(),
+                              (int)input.atoms.size(), input.tolerance);
+    ASSERT_EQ(spg_get_error_code(), SPGLIB_SUCCESS);
+}
+void Dataset::TearDown() {
+    if (dataset != nullptr) {
+        spg_free_dataset(dataset);
+        dataset = nullptr;
+    }
+}
+Dataset::~Dataset() {
+    if (dataset != nullptr) {
+        spg_free_dataset(dataset);
+        dataset = nullptr;
+    }
+}
+
+DatasetInput::Atoms::Atoms(const double position[3], int type_number)
+    : position{}, type_number{type_number} {
+    for (auto i = 0; i < 3; i++) {
+        this->position[i] = position[i];
+    }
+}
+DatasetInput::Atoms::Atoms(const std::array<double, 3>& position,
+                           int type_number)
+    : position{position}, type_number{type_number} {}
+DatasetInput::Atoms::Atoms(const std::array<double, 3>&& position,
+                           int type_number)
+    : position{position}, type_number{type_number} {}
+DatasetInput::DatasetInput(const double lattice[3][3],
+                           std::vector<Atoms>&& atoms, double tolerance,
+                           double angle_tolerance)
+    : lattice{},
+      atoms{atoms},
+      tolerance{tolerance},
+      angle_tolerance{angle_tolerance} {
+    for (auto i = 0; i < 3; i++) {
+        for (auto j = 0; j < 3; j++) {
+            this->lattice[i][j] = lattice[i][j];
+        }
+    }
+}
+DatasetInput::DatasetInput(const std::array<std::array<double, 3>, 3>& lattice,
+                           std::vector<Atoms>&& atoms, double tolerance,
+                           double angle_tolerance)
+    : lattice{},
+      atoms{atoms},
+      tolerance{tolerance},
+      angle_tolerance{angle_tolerance} {
+    for (auto i = 0; i < 3; i++) {
+        for (auto j = 0; j < 3; j++) {
+            this->lattice[i][j] = lattice[i][j];
+        }
+    }
+}
+DatasetInput::DatasetInput(const std::array<std::array<double, 3>, 3>& lattice,
+                           std::vector<Atoms>& atoms, double tolerance,
+                           double angle_tolerance)
+    : lattice{},
+      atoms{atoms},
+      tolerance{tolerance},
+      angle_tolerance{angle_tolerance} {
+    for (auto i = 0; i < 3; i++) {
+        for (auto j = 0; j < 3; j++) {
+            this->lattice[i][j] = lattice[i][j];
+        }
+    }
+}
+void DatasetInput::print() {
+    std::cout << "Lattice parameter:" << std::endl;
+
+    for (auto i = 0; i < 3; i++) {
+        std::cout << "[ " << lattice[0][i] << ", " << lattice[1][i] << ", "
+                  << lattice[2][i] << " ]" << std::endl;
+    }
+    std::cout << "Number of atoms: " << atoms.size() << std::endl;
+    std::cout << "Tolerance: " << tolerance << std::endl;
+    std::cout << "Angle tolerance: " << angle_tolerance << std::endl;
+    std::cout << "Hall number: "
+              << (hall_number.has_value() ? std::to_string(hall_number.value())
+                                          : "Not present")
+              << std::endl;
+    std::cout << "Atomic positions:\n";
+    for (auto& atom : atoms) {
+        std::cout << "[ " << atom.position[0] << ", " << atom.position[1]
+                  << ", " << atom.position[2]
+                  << " ] type_number = " << atom.type_number << std::endl;
+    }
+}

--- a/test/c_fixtures.hpp
+++ b/test/c_fixtures.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <optional>
+#include <vector>
+
+extern "C" {
+#include "spglib.h"
+}
+
+struct DatasetInput {
+    struct Atoms {
+        std::array<double, 3> position;
+        int type_number;
+        Atoms(const double position[3], int type_number);
+        Atoms(const std::array<double, 3>& position, int type_number);
+        Atoms(const std::array<double, 3>&& position, int type_number);
+    };
+    double lattice[3][3]{};
+    std::vector<Atoms> atoms;
+    double tolerance{};
+    double angle_tolerance{};
+    std::optional<int> hall_number;
+    DatasetInput(const double lattice[3][3], std::vector<Atoms>&& atoms,
+                 double tolerance = 0.0, double angle_tolerance = 0.0);
+    DatasetInput(const std::array<std::array<double, 3>, 3>& lattice,
+                 std::vector<Atoms>&& atoms, double tolerance = 0.0,
+                 double angle_tolerance = 0.0);
+    DatasetInput(const std::array<std::array<double, 3>, 3>& lattice,
+                 std::vector<Atoms>& atoms, double tolerance = 0.0,
+                 double angle_tolerance = 0.0);
+    DatasetInput() = default;
+    void print();
+};
+
+class Dataset : public testing::TestWithParam<DatasetInput> {
+   protected:
+    void TearDown() override;
+    void SetUp() override;
+    ~Dataset() override;
+    SpglibDataset* dataset = nullptr;
+    DatasetInput input;
+};

--- a/test/functional/c/test_dataset_access.cpp
+++ b/test/functional/c/test_dataset_access.cpp
@@ -1,9 +1,38 @@
 #include <gtest/gtest.h>
 
+#include "c_fixtures.hpp"
+
 extern "C" {
 #include "spglib.h"
 #include "utils.h"
 }
+
+// TODO: Make a list of relevant dataset input instantiations
+INSTANTIATE_TEST_SUITE_P(
+    DatasetAccess, Dataset,
+    testing::Values(
+        /* Input 1 */
+        /* Im-3m (229) */
+        DatasetInput{
+            {
+                {{4, 0, 0}, {0, 4, 0}, {0, 0, 4}} /* lattice */
+            },
+            {
+                /* Vector of atoms */
+                {
+
+                    {0, 0, 0}, /* position */
+                    1          /* type_number */
+                },             /* atom 1 */
+                {
+
+                    {0.5, 0.5, 0.5}, /* position */
+                    1                /* type_number */
+                },                   /* atom 2 */
+
+            },
+            1e-5 /* tolerance/symprec */
+        }));
 
 TEST(DatasetAccess, test_spg_get_symmetry_from_database) {
     int rotations[192][3][3];
@@ -15,71 +44,32 @@ TEST(DatasetAccess, test_spg_get_symmetry_from_database) {
     show_symmetry_operations(rotations, translations, size);
 }
 
-TEST(DatasetAccess, test_spg_get_hall_number_from_symmetry) {
-    /* Im-3m (229) */
-    double lattice[3][3] = {{4, 0, 0}, {0, 4, 0}, {0, 0, 4}};
-    double position[][3] = {{0, 0, 0}, {0.5, 0.5, 0.5}};
-    int types[] = {1, 1};
-    int num_atom = 2;
-    double symprec = 1e-5;
-
-    int hall_number;
-    SpglibSpacegroupType spgtype;
-    SpglibDataset *dataset;
-
-    dataset = NULL;
-
-    dataset = spg_get_dataset(lattice, position, types, num_atom, symprec);
-    ASSERT_TRUE(dataset != NULL);
-
+TEST_P(Dataset, test_spg_get_hall_number_from_symmetry) {
     printf("hall_number = %d is found by spg_get_dataset.\n",
            dataset->hall_number);
-    hall_number = spg_get_hall_number_from_symmetry(
+    int hall_number = spg_get_hall_number_from_symmetry(
         dataset->rotations, dataset->translations, dataset->n_operations,
-        symprec);
+        input.tolerance);
     printf("hall_number = %d is found by spg_get_hall_number_from_symmetry.\n",
            hall_number);
-    ASSERT_EQ(hall_number, dataset->hall_number);
-    ASSERT_EQ(hall_number, 529);
+    EXPECT_EQ(hall_number, dataset->hall_number);
+    EXPECT_EQ(hall_number, 529);
 
-    spgtype = spg_get_spacegroup_type(hall_number);
-    ASSERT_EQ(spgtype.number, 229);
+    auto spgtype = spg_get_spacegroup_type(hall_number);
+    EXPECT_EQ(spgtype.number, 229);
     show_spacegroup_type(spgtype);
-
-    if (dataset) {
-        spg_free_dataset(dataset);
-    }
 }
 
-TEST(DatasetAccess, test_spg_get_spacegroup_type_from_symmetry) {
-    /* Im-3m (229) */
-    double lattice[3][3] = {{4, 0, 0}, {0, 4, 0}, {0, 0, 4}};
-    double position[][3] = {{0, 0, 0}, {0.5, 0.5, 0.5}};
-    int types[] = {1, 1};
-    int num_atom = 2;
-    double symprec = 1e-5;
-
-    SpglibSpacegroupType spgtype;
-    SpglibDataset *dataset;
-
-    dataset = NULL;
-
-    dataset = spg_get_dataset(lattice, position, types, num_atom, symprec);
-    ASSERT_TRUE(dataset != NULL);
-
+TEST_P(Dataset, test_spg_get_spacegroup_type_from_symmetry) {
     printf("hall_number = %d is found by spg_get_dataset.\n",
            dataset->hall_number);
-    spgtype = spg_get_spacegroup_type_from_symmetry(
+    auto spgtype = spg_get_spacegroup_type_from_symmetry(
         dataset->rotations, dataset->translations, dataset->n_operations,
-        lattice, symprec);
+        input.lattice, input.tolerance);
     printf("number = %d is found by spg_get_spacegroup_type_from_symmetry.\n",
            spgtype.number);
 
     show_spacegroup_type(spgtype);
-    ASSERT_EQ(spgtype.number, dataset->spacegroup_number);
-    ASSERT_EQ(spgtype.number, 229);
-
-    if (dataset) {
-        spg_free_dataset(dataset);
-    }
+    EXPECT_EQ(spgtype.number, dataset->spacegroup_number);
+    EXPECT_EQ(spgtype.number, 229);
 }


### PR DESCRIPTION
This is an example of using googletest test parameterized test fixture. With this it should be easier to get the test data from the test files that are used in python.

See `/test/functional/test_dataset_access.cpp` for example usage.

<details><summary>TODO:</summary>

- [ ] Dataset test fixture
  - [x] `spg_get_dataset`
  - [ ] `spg_get_layer_dataset`
  - [ ] `spgat_get_dataset`
  - [ ] `spg_get_dataset_with_hall_number`
  - [ ] `spgat_get_dataset_with_hall_number`
  - [ ] `from_file`
- [ ] MagneticDataset test fixture
  - [ ] `spg_get_magnetic_dataset`
  - [ ] `spgms_get_magnetic_dataset`
  - [ ] `from_file`?
- [ ] SpglibSpacegroupType test fixture
- [ ] SpglibMagneticSpacegroupType test fixture
- [ ] Symmetry test fixture
- [ ] MagneticSymmetry test fixture
- [ ] Cell test fixture
- [ ] MatINT test fixture
- [ ] VecDBL test fixture
- [ ] OverlapChecker test fixture
- [ ] DataContainer test fixture
- [ ] Primitive test fixture
- [ ] ExtraStructure test fixture

</details>