### PR TITLE
ci: Add concurrency to GH actions

### DIFF
--- a/.github/workflows/pypi-wheel-builds.yml
+++ b/.github/workflows/pypi-wheel-builds.yml
@@ -1,6 +1,10 @@
 name: pypi-wheel
 run-name: Spglib PyPI Wheel builds for linux
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     tags: [ "*test*" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 run-name: Run tests
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ develop ]


### PR DESCRIPTION
Currently jobs on GH action continue to run when you push new commits. This will cancel the running jobs if a new commit is pushed.

(confirmed it works in the actions tab)