### PR TITLE
Fix: build wheel workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,12 @@ jobs:
       cibw_archs_linux: ${{ inputs.cibw_archs_linux || 'x86_64' }}
       cibw_archs_macos: ${{ inputs.cibw_archs_macos || 'x86_64' }}
       cibw_build: ${{ inputs.cibw_build || 'cp311-*' }}
+  pass:
+    needs: [tests, build-wheel]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all CI jobs
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+    if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: softprops/action-gh-release@v1
         with:
           name: Spglib ${{ github.ref_name }}

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -42,7 +42,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-11 ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # CIBW requires emulation to build for arm linux
         # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
       - name: Set up QEMU for Linux-arm
@@ -65,7 +65,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -43,6 +43,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        # CIBW requires emulation to build for arm linux
+        # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+      - name: Set up QEMU for Linux-arm
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         env:

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - name: Build sdist
         run: pipx run build
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -135,3 +135,12 @@ jobs:
           files: coverage.info,.coverage
           flags: python_api
           verbose: true
+  pass:
+    needs: [pre-commit, tests, coverage, coverage-pytest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test jobs
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+    if: always()

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - uses: pre-commit/action@v3.0.0
 
   tests:
@@ -109,6 +111,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
+          python-version: 3.x
           cache: pip
       - name: Setup spglib
         run: |

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Check pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -54,7 +54,7 @@ jobs:
           printenv >> $GITHUB_ENV
           echo $PATH >> $GITHUB_PATH
         if: matrix.toolchain == 'intel'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Patch /etc/lsb-release for experimental python
         # Mimic Ubuntu in order to be able to download experimental python
         run : |
@@ -82,7 +82,7 @@ jobs:
       matrix:
         coverage: [ unit_tests, c_api, fortran_api ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - name: Get test coverage for ${{ matrix.coverage }}
         uses: lukka/run-cmake@v10.3
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ tests ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Either the emulation is needed in order to build for linux-arm or we can try CircleCI.

~~Experimenting with CircleCI for a while in https://github.com/LecrisUT/spglib/actions/workflows/ci.yaml~~

Will come back to CircleCI and CirrusCI in a later PR.