### PR TITLE
Add "Julia interface" to interface.md

### DIFF
--- a/doc/interface.md
+++ b/doc/interface.md
@@ -19,6 +19,11 @@ obsolete and is not recommended to use.
 Rust interface contributed by Seaton Ullberg. The documentation is
 found at <https://docs.rs/crate/spglib/>.
 
+## Julia interface
+
+Julia interface contributed by [Qi Zhang](@singularitti). The documentation is
+found at <https://singularitti.github.io/Spglib.jl/stable/>.
+
 ## Ruby interface
 
 Note that this ruby interface was written in ancient times, so may not

--- a/doc/interface.md
+++ b/doc/interface.md
@@ -21,7 +21,7 @@ found at <https://docs.rs/crate/spglib/>.
 
 ## Julia interface
 
-Julia interface contributed by [Qi Zhang](@singularitti). The documentation is
+Julia interface contributed by [Qi Zhang](https://github.com/singularitti). The documentation is
 found at <https://singularitti.github.io/Spglib.jl/stable/>.
 
 ## Ruby interface

--- a/doc/interface.md
+++ b/doc/interface.md
@@ -21,8 +21,8 @@ found at <https://docs.rs/crate/spglib/>.
 
 ## Julia interface
 
-Julia interface contributed by [Qi Zhang](https://github.com/singularitti). The documentation is
-found at <https://singularitti.github.io/Spglib.jl/stable/>.
+[Julia interface](https://juliahub.com/ui/Packages/General/Spglib) contributed by [Qi Zhang](https://github.com/singularitti).
+The documentation is found at <https://singularitti.github.io/Spglib.jl/stable/>.
 
 ## Ruby interface
 


### PR DESCRIPTION
Greetings,
As a user of spglib and an active contributor within the Julia community, I have successfully ported the C-API to Julia, which can be accessed [here](https://github.com/singularitti/Spglib.jl). However, the magnetic interface is yet to be implemented and I would greatly appreciate any assistance in this regard.
The Spglib.jl is already being utilized by some individuals, and it is my aspiration to further promote both spglib and Spglib.jl, thereby expanding their user base.