### PR TITLE
fix: Julia packaging issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ option(SPGLIB_WARNINGS "Spglib: Enable warning messages" ON)
 mark_as_advanced(SPGLIB_WITH_WARNINGS)
 option(SPGLIB_DEBUG "Spglib: Build in debug mode" ${_Spglib_default_debug})
 mark_as_advanced(SPGLIB_DEBUG)
+option(SPGLIB_COMPILATION_WARNING "Spglib: Enable compilation warnings" OFF)
+mark_as_advanced(SPGLIB_COMPILATION_WARNING)
 
 #[==============================================================================================[
 #                                     Project configuration                                     #

--- a/cmake/CMakePresets-CI.json
+++ b/cmake/CMakePresets-CI.json
@@ -27,6 +27,10 @@
         "CMAKE_BUILD_TYPE": {
           "type": "STRING",
           "value": "RelWithDebInfo"
+        },
+        "SPGLIB_COMPILATION_WARNING": {
+          "type": "BOOL",
+          "value": true
         }
       },
       "errors": {

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -37,7 +37,7 @@ e.g. `-DSPGLIB_WITH_Fortran=ON`.
 | **SPGLIB_WITH_Fortran**  |                 OFF                 | Build Fortran API                                                                  |
 | **SPGLIB_WITH_Python**   |                 OFF                 | Build Python API                                                                   |
 | **SPGLIB_WITH_TESTS**    |                 ON                  | Include basic tests                                                                |
-| **SPGLIB_USE_OMP**       |                 OFF                 | Use OpenMPI                                                                        |
+| **SPGLIB_USE_OMP**       |                 OFF                 | Use OpenMP                                                                         |
 | **SPGLIB_USE_SANITIZER** |                 ""                  | Specify a sanitizer to compile with<br/> e.g. `address`                            |
 | CMAKE_INSTALL_PREFIX     | OS specific<br/>(e.g. `/usr/local`) | Location where to install built project                                            |
 | BUILD_SHARED_LIBS        |                 ON                  | Whether to build shared or statically linked libraries<br/>(Currently unsupported) |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,15 @@
 configure_file(version.h.in version.h)
 
 # Add compiler warnings
-if (MSVC)
-	target_compile_options(Spglib_symspg PRIVATE /W4)
-else()
-	# TODO: C23: Disabled -Wpedantic because of warning spam
-	#  Add it back when C23 standard is widespread and revert this [Temp][C23] commit
-	target_compile_options(Spglib_symspg PRIVATE -Wall -Wextra)
-endif()
+if (SPGLIB_COMPILATION_WARNING)
+	if (MSVC)
+		target_compile_options(Spglib_symspg PRIVATE /W4)
+	else()
+		# TODO: C23: Disabled -Wpedantic because of warning spam
+		#  Add it back when C23 standard is widespread and revert this [Temp][C23] commit
+		target_compile_options(Spglib_symspg PRIVATE -Wall -Wextra)
+	endif()
+endif ()
 
 # Configure main target
 target_sources(Spglib_symspg PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 enable_language(CXX)
+include(GoogleTest)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)


### PR DESCRIPTION
Trying to fix https://github.com/JuliaPackaging/Yggdrasil/pull/7310, and do a bit of cleanup.

- [x] Added missing `include(GoogleTest)`. It is surprising that this issue was not picked up by any other CI/downstream
- [x] Moved compilation warnings to only CI. Downstream is getting bombarded with warnings that are slow to fix and it makes it hard to debug on their side.
- [x] ~~`_Thread_local` is not detected in Julia's packaging CI~~ compiler issue on their end

@singularitti I will try to make some quick fixes here, but can you create the patches and try them on the Julia side CI?

After this we'll need to cherry-pick this one and add them to `release-2.1` hotfix branch 