### PR TITLE
fix: Fortran pkg-config file

### DIFF
--- a/fortran/spglib_f08.pc.in
+++ b/fortran/spglib_f08.pc.in
@@ -1,6 +1,7 @@
 Name: @PROJECT_NAME@
 Description: The spglib f08 library
-depends: spglib
 Version: @PROJECT_VERSION@
+
+Requires: spglib
 Libs: -L@CMAKE_INSTALL_FULL_LIBDIR@ -lspglib_f08 -lsymspg
 Cflags: -I@CMAKE_INSTALL_FULL_MODULEDIR@


### PR DESCRIPTION
Found this when working on an old debian container. Apparently `depends` is not the correct syntax it should be `Requires`. Surprised these were not picked up by the tmt tests