### PR TITLE
Fix typo for arithmetic crystal class 6/mmmP

### DIFF
--- a/src/arithmetic.c
+++ b/src/arithmetic.c
@@ -113,7 +113,7 @@ static const char arithmetic_crystal_class_symbols[74][7] = {
     "6mmP  ", /* 55 */
     "-62mP ", /* 56 */
     "-6m2P ", /* 57 */
-    "6/mmm ", /* 58 */
+    "6/mmmP", /* 58 */
     "23P   ", /* 59 */
     "23F   ", /* 60 */
     "23I   ", /* 61 */


### PR DESCRIPTION
c.f. https://dictionary.iucr.org/Arithmetic_crystal_class