### PR TITLE
chore: Post release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif ()
 ]==============================================================================================]
 
 project(Spglib
-		VERSION 2.2.0
+		VERSION 2.3.0
 		LANGUAGES C)
 
 # Back-porting to PROJECT_IS_TOP_LEVEL to older cmake

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+### Python interface
+
+- Dropped Python 3.7 support
+
 ## v2.2.0 (6 Dec. 2023)
 
 This minor release includes update of crystallographic databases to adopt the latest editions of *International Tables for Crystallography*:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "spglib"
-version = "2.2.0"
-requires-python = ">=3.7"
+version = "2.3.0"
+requires-python = ">=3.8"
 description = "This is the spglib module."
 license = { text = "BSD-3-Clause" }
 readme = "python/README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,24 @@ maintainers = [
     {name="Cristian Le", email="git@lecris.dev"},
     {name="Kohei Shinohara", email="kshinohara0508@gmail.com"},
 ]
+classifiers = [
+    "Topic :: Scientific/Engineering :: Physics",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: C",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: C",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Development Status :: 5 - Production/Stable",
+]
 
 [project.urls]
 homepage = "https://spglib.readthedocs.io/"


### PR DESCRIPTION
This PR bumps the versions to indicate for the user where the development of the new release started. Maybe should revisit #273 at some point. Python upstream supports it now.

Also I noticed there were no metadata classifiers, so I've added them here for the new release

Closes: #373 
Depends on: #375 