### PR TITLE
Fix quick for autodoc2 render plugin

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,6 +69,10 @@ html_static_path = ["_static"]
 # Autodoc2
 # -----------------------------------------------------------------------------
 autodoc2_output_dir = "api/python-api"
+autodoc2_render_plugin = "myst"
+autodoc2_docstring_parser_regexes = [
+    (r".*", "rst"),
+]
 autodoc2_packages = [
     {
         "path": "../python/spglib/spglib.py",


### PR DESCRIPTION
After merging https://github.com/spglib/spglib/pull/387, I have noticed auto summaries are generated in reStructuredText, not compatible with other myst documents. 
https://spglib.readthedocs.io/en/latest/python-interface.html#version

This PR uses myst as autodoc2 render plugin and uses reStructuredText only for docstrings.