### PR TITLE
fix: RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,5 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
-    post_create_environment:
-      - pip install --pre --upgrade sphinx-book-theme
 sphinx:
   configuration: doc/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,8 @@ build:
   tools:
     python: "3"
   jobs:
+    post_checkout:
+      - git fetch --unshallow || true
     post_create_environment:
       - pip install --pre --upgrade sphinx-book-theme
 sphinx:


### PR DESCRIPTION
RTD was git cloning shallow so it was missing tags when on PRs. I am not sure why the issue just occurred now, but regardless, this should fix the issue.

Also reverted the `sphinx-book-theme` pre-release