### PR TITLE
ci: Switch coverage to `gcovr`

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,3 +1,16 @@
+flags:
+  c_api:
+    paths:
+      - src/*
+  fortran_api:
+    paths:
+      - src/*
+      - fortran/*
+  python_api:
+    paths:
+      - src/*
+      - python/*
+
 coverage:
   status:
     project:

--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,16 +1,3 @@
-flags:
-  c_api:
-    paths:
-      - src/*
-  fortran_api:
-    paths:
-      - src/*
-      - fortran/*
-  python_api:
-    paths:
-      - src/*
-      - python/*
-
 coverage:
   status:
     project:

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -27,11 +27,17 @@ jobs:
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "ci-coverage-${{ matrix.coverage }}"
+      - name: Get coverage data
+        # TODO: Switch to tagged release
+        uses: threeal/gcovr-action@xml-out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.coverage }} coverage
+          disable_search: true
+          plugin: noop
+          files: coverage-gcovr.xml
           flags: ${{ matrix.coverage }}
           verbose: true
 
@@ -53,11 +59,17 @@ jobs:
              --config-settings=cmake.define.SPGLIB_TEST_COVERAGE=ON \
              --config-settings=build-dir=cmake-build-coverage
       - name: Test pytest with coverage
-        run: pytest --cov
+        run: pytest --cov --cov-report=xml:coverage-pytest.xml
+      - name: Get coverage data
+        # TODO: Switch to tagged release
+        uses: threeal/gcovr-action@xml-out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: python_api coverage
+          disable_search: true
+          plugin: noop
+          files: coverage-gcovr.xml,coverage-pytest.xml
           flags: python_api
           verbose: true

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -23,22 +23,19 @@ jobs:
         with:
           fetch-depth: 0
       - uses: lukka/get-cmake@latest
-      - name: Get test coverage for ${{ matrix.coverage }}
+      - name: Run CMake workflow
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "ci-coverage-${{ matrix.coverage }}"
-      - name: Get lcov data
-        uses: danielealbano/lcov-action@v3
-        with:
-          # Note lcov-action prepends and appends wild-cards *. Account for those
-          # https://github.com/danielealbano/lcov-action/issues/11
-          remove_patterns: /test/,/cmake-build*/
+      - name: Get coverage data
+        # TODO: Switch to tagged release
+        uses: threeal/gcovr-action@xml-out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.coverage }} coverage
-          files: coverage.info
+          files: coverage.xml
           flags: ${{ matrix.coverage }}
           verbose: true
 
@@ -52,27 +49,23 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - name: Setup spglib
+      - name: Build spglib
         run: |
-          python -m pip install --upgrade pip
           pip install -e .[test-cov] \
              --config-settings=cmake.define.CMAKE_C_COMPILER=gcc \
              --config-settings=cmake.define.SPGLIB_WITH_TESTS=ON \
              --config-settings=cmake.define.SPGLIB_TEST_COVERAGE=ON \
-             --config-settings=build-dir=build
+             --config-settings=build-dir=cmake-build-coverage
       - name: Test pytest with coverage
         run: pytest --cov=spglib
-      - name: Get lcov data
-        uses: danielealbano/lcov-action@v3
-        with:
-          # Note lcov-action prepends and appends wild-cards *. Account for those
-          # https://github.com/danielealbano/lcov-action/issues/11
-          remove_patterns: /test/,/cmake-build*/,/tmp/
+      - name: Get coverage data
+        # TODO: Switch to tagged release
+        uses: threeal/gcovr-action@xml-out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: python_api coverage
-          files: coverage.info,.coverage
+          files: coverage.xml,.coverage
           flags: python_api
           verbose: true

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -35,7 +35,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.coverage }} coverage
-          files: coverage.xml
+          disable_search: true
+          plugin: noop
+          files: coverage-gcovr.xml
           flags: ${{ matrix.coverage }}
           verbose: true
 
@@ -57,7 +59,7 @@ jobs:
              --config-settings=cmake.define.SPGLIB_TEST_COVERAGE=ON \
              --config-settings=build-dir=cmake-build-coverage
       - name: Test pytest with coverage
-        run: pytest --cov=spglib
+        run: pytest --cov --cov-report=xml:coverage-pytest.xml
       - name: Get coverage data
         # TODO: Switch to tagged release
         uses: threeal/gcovr-action@xml-out
@@ -66,6 +68,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: python_api coverage
-          files: coverage.xml,.coverage
+          disable_search: true
+          plugin: noop
+          files: coverage-gcovr.xml,coverage-pytest.xml
           flags: python_api
           verbose: true

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -27,17 +27,11 @@ jobs:
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "ci-coverage-${{ matrix.coverage }}"
-      - name: Get coverage data
-        # TODO: Switch to tagged release
-        uses: threeal/gcovr-action@xml-out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.coverage }} coverage
-          disable_search: true
-          plugin: noop
-          files: coverage-gcovr.xml
           flags: ${{ matrix.coverage }}
           verbose: true
 
@@ -59,17 +53,11 @@ jobs:
              --config-settings=cmake.define.SPGLIB_TEST_COVERAGE=ON \
              --config-settings=build-dir=cmake-build-coverage
       - name: Test pytest with coverage
-        run: pytest --cov --cov-report=xml:coverage-pytest.xml
-      - name: Get coverage data
-        # TODO: Switch to tagged release
-        uses: threeal/gcovr-action@xml-out
+        run: pytest --cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: python_api coverage
-          disable_search: true
-          plugin: noop
-          files: coverage-gcovr.xml,coverage-pytest.xml
           flags: python_api
           verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ venv
 env
 .venv
 .env
+
+coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,9 @@ markers = [
 
 [tool.coverage.run]
 command_line = '-m pytest'
-# TODO: Cannot report relative to project path because we cannot do editable installs yet
-#source = ['python/spglib']
-source = ['spglib']
+source = [
+    "python/spglib",
+]
 
 [tool.ruff]
 line-length = 88
@@ -211,8 +211,11 @@ skip = "doc/references.bib"
 ignore = "W002"
 
 [tool.gcovr]
-cobertura = "coverage.xml"
+cobertura = "coverage-gcovr.xml"
 exclude = [
     "src/msg_database.c",
     "src/spg_database.c",
+]
+gcov-ignore-errors = [
+    "source_not_found",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ dependencies = [
     "importlib-resources; python_version<'3.10'",
 ]
 authors = [
-    {name="Atsushi Togo", email="atz.togo@gmail.com"},
+    { name = "Atsushi Togo", email = "atz.togo@gmail.com" },
 ]
 maintainers = [
-    {name="Atsushi Togo", email="atz.togo@gmail.com"},
-    {name="Cristian Le", email="git@lecris.dev"},
-    {name="Kohei Shinohara", email="kshinohara0508@gmail.com"},
+    { name = "Atsushi Togo", email = "atz.togo@gmail.com" },
+    { name = "Cristian Le", email = "git@lecris.dev" },
+    { name = "Kohei Shinohara", email = "kshinohara0508@gmail.com" },
 ]
 classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
@@ -131,13 +131,13 @@ source = ['spglib']
 [tool.ruff]
 line-length = 88
 extend-select = [
-    "F",           # pyflakes
+    "F", # pyflakes
     # "W",           # pycodestyle-warnings
-    "E",           # pycodestyle-errors
+    "E", # pycodestyle-errors
     # "C90",         # mccabe
-    "I",           # isort
+    "I", # isort
     # "N",           # pep8-naming
-    "D",           # pydocstyle
+    "D", # pydocstyle
     # "UP",          # pyupgrade
     # "YTT",         # flake8-2020
     # "ANN",         # flake8-annotations
@@ -184,9 +184,9 @@ extend-ignore = [
     "D101",
     "D102",
     "D103",
-    "D203",  # Confilct with D211
+    "D203", # Confilct with D211
     "D205",
-    "D213",  # Conflict with D212
+    "D213", # Conflict with D212
 ]
 exclude = [
     "database",
@@ -209,3 +209,10 @@ skip = "doc/references.bib"
 
 [tool.check-wheel-contents]
 ignore = "W002"
+
+[tool.gcovr]
+cobertura = "coverage.xml"
+exclude = [
+    "src/msg_database.c",
+    "src/spg_database.c",
+]


### PR DESCRIPTION
This can simplify the action and make the coverage report more reproducible since it calls only one command.

Waiting on https://github.com/threeal/gcovr-action/issues/151 to simplify this action

Depends on: #308 