### PR TITLE
fix: Fortran api

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,11 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+### Fortran API
+
+- [\[#421\]] - Allow importing Fortran API when library/consumer compilers differ
+- [\[#421\]] - Fix building Fortran API from exported `spglib_f08.F90`
+
 ### Fixes
 
 - [\[#426\]] - Fix Windows installation path
@@ -2123,5 +2128,6 @@ in bravais.c.
 ```
 
 [setuptools-scm]: https://setuptools-scm.readthedocs.io/en/latest/extending/#available-implementations
+[\[#421\]]: https://github.com/spglib/spglib/pull/421
 [\[#422\]]: https://github.com/spglib/spglib/pull/422
 [\[#426\]]: https://github.com/spglib/spglib/pull/426

--- a/cmake/SpglibConfig.cmake.in
+++ b/cmake/SpglibConfig.cmake.in
@@ -19,9 +19,26 @@ if (NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/PackageCompsHelper.cmake)
 	message(WARNING "Missing helper file PackageCompsHelper.cmake")
 	set(Spglib_FOUND FALSE)
 	return()
-endif()
+endif ()
 
 include(${CMAKE_CURRENT_LIST_DIR}/PackageCompsHelper.cmake)
 find_package_with_comps(PACKAGE Spglib PRINT LOAD_ALL_DEFAULT HAVE_GLOBAL_SHARED_STATIC)
 
 check_required_components(Spglib)
+
+# For Fortran targets, check that the modules are usable with the current compiler
+if (CMAKE_Fortran_COMPILER AND TARGET Spglib::fortran_mod)
+	# TODO: CMake 3.25 use the modern try_compile signature. Remove the explicit CMakeScratch
+	try_compile(spglib_fortran_try_compile ${CMAKE_BINARY_DIR}/CMakeFiles/CMakeScratch/spglib_fortran
+			SOURCES ${CMAKE_CURRENT_LIST_DIR}/try_compile.f90
+			LINK_LIBRARIES Spglib::fortran_mod
+	)
+	if (spglib_fortran_try_compile)
+		# If the compilation was successful, use the module version of the library
+		add_library(Spglib::fortran ALIAS Spglib::fortran_mod)
+	else ()
+		# Otherwise, assume it was because of incompatible compiler
+		# Add the bundled `.f90` files as sources instead
+		add_library(Spglib::fortran ALIAS Spglib::fortran_include)
+	endif ()
+endif ()

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -3,6 +3,15 @@ add_library(Spglib_fortran)
 add_library(Spglib::fortran ALIAS Spglib_fortran)
 configure_file(spglib_version.f90.in spglib_version.f90)
 
+# This target is only used in the SpglibConfig.cmake
+add_library(Spglib_fortran_include INTERFACE)
+target_sources(Spglib_fortran_include INTERFACE
+		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/spglib_f08.F90>"
+)
+set_target_properties(Spglib_fortran_include PROPERTIES
+		EXPORT_NAME fortran_include
+)
+
 # Concatenate the contents of the fortran file so it can be compiled from source
 execute_process(COMMAND ${CMAKE_COMMAND} -E cat
 		${CMAKE_CURRENT_BINARY_DIR}/spglib_version.f90
@@ -22,15 +31,16 @@ target_sources(Spglib_fortran PRIVATE
 set_target_properties(Spglib_fortran PROPERTIES
 		VERSION ${PROJECT_VERSION}
 		SOVERSION ${PROJECT_VERSION_MAJOR}
-		EXPORT_NAME fortran
+		EXPORT_NAME fortran_mod
 		OUTPUT_NAME spglib_f08
 )
-set_target_properties(Spglib_fortran PROPERTIES
+set_target_properties(Spglib_fortran_include PROPERTIES
 		PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.F90
 )
 target_include_directories(Spglib_fortran PUBLIC
 		"$<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>")
 target_link_libraries(Spglib_fortran PUBLIC Spglib_symspg)
+target_link_libraries(Spglib_fortran_include INTERFACE Spglib_symspg)
 # Note: Fortran wrapper is not linked to OpenMP library because it should not be defining any such setup
 
 # Install
@@ -54,7 +64,7 @@ if (SPGLIB_INSTALL)
 	endif ()
 	target_include_directories(Spglib_fortran PUBLIC
 			"$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}>")
-	install(TARGETS Spglib_fortran
+	install(TARGETS Spglib_fortran Spglib_fortran_include
 			EXPORT SpglibTargets-fortran
 			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Spglib_Runtime
 			NAMELINK_COMPONENT Spglib_Development
@@ -63,6 +73,10 @@ if (SPGLIB_INSTALL)
 			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Spglib_Runtime
 	)
 	export_components(COMPONENT fortran LIB_TYPE ${SPGLIB_LIB_TYPE})
+	install(FILES try_compile.f90
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Spglib
+			COMPONENT Spglib_Development
+	)
 
 	# Maybe it is handled automatically
 	install(FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/spglib_f08.mod

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -3,6 +3,16 @@ add_library(Spglib_fortran)
 add_library(Spglib::fortran ALIAS Spglib_fortran)
 configure_file(spglib_version.f90.in spglib_version.f90)
 
+# Concatenate the contents of the fortran file so it can be compiled from source
+execute_process(COMMAND ${CMAKE_COMMAND} -E cat
+		${CMAKE_CURRENT_BINARY_DIR}/spglib_version.f90
+		${CMAKE_CURRENT_SOURCE_DIR}/spglib_f08.F90
+		OUTPUT_VARIABLE spglib_f08_concat
+		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.F90 ${spglib_f08_concat})
+
+# Use the separate files for the project itself so that they are properly re-built
 target_sources(Spglib_fortran PRIVATE
 		spglib_f08.F90
 		${CMAKE_CURRENT_BINARY_DIR}/spglib_version.f90
@@ -14,9 +24,10 @@ set_target_properties(Spglib_fortran PROPERTIES
 		SOVERSION ${PROJECT_VERSION_MAJOR}
 		EXPORT_NAME fortran
 		OUTPUT_NAME spglib_f08
-		PUBLIC_HEADER spglib_f08.F90)
+)
 set_target_properties(Spglib_fortran PROPERTIES
-		PUBLIC_HEADER spglib_f08.F90)
+		PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.F90
+)
 target_include_directories(Spglib_fortran PUBLIC
 		"$<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>")
 target_link_libraries(Spglib_fortran PUBLIC Spglib_symspg)

--- a/fortran/try_compile.f90
+++ b/fortran/try_compile.f90
@@ -1,0 +1,5 @@
+program try_compile
+    use spglib_f08
+
+    print *, version
+end program try_compile


### PR DESCRIPTION
- Fix an issue with `spglib_f08.F90` not having the `spglib_version` Fortran module
- Add target `Spglib::fortran_include` and `Spglib::fortran_mod` so that `Spglib::fortran` is an alias is to either of these depending on if the `.mod` file is importable or not

TODO:
- [x] Changelog

This PR should be added for a Spglib v2.3.1

Closes #415, #416

@dmt4 thanks for opening those issues, I am quite glad how this design turned out, and I will present this at an upcoming meeting. Do you want to take it for a spin?