### PR TITLE
ci: Bump cibuildhweel

### DIFF
--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16
         env:
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_ARCHS_LINUX: ${{ inputs.cibw_archs_linux }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+### CI
+
+- [\[#422\]] - Update to ci-build-wheel v2.16
+
 ## v2.3.0 (27 Jan. 2024)
 
 ### Features
@@ -2115,3 +2119,4 @@ in bravais.c.
 ```
 
 [setuptools-scm]: https://setuptools-scm.readthedocs.io/en/latest/extending/#available-implementations
+[\[#422\]]: https://github.com/spglib/spglib/pull/422


### PR DESCRIPTION
It started failing in #421 and #423 , probably because of changes on Github actions.

Anyway, simply bumping the version of `cibuildwheel` seems to resolve this issue

Upstream issue: https://github.com/pypa/cibuildwheel/issues/1748