### PR TITLE
ci: Update codecov to v4

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -31,4 +31,4 @@ coverage:
           - python_api
 codecov:
   notify:
-    after_n_builds: 4
+    wait_for_ci: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,8 @@ jobs:
     name: 👀 coverage
     needs: [ tests ]
     uses: ./.github/workflows/step_coverage.yaml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build-wheel:
     name: build-wheel

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -2,6 +2,11 @@ name: 👀 coverage
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: Codecov token of the main repository
+        required: false
+
 
 permissions:
   contents: read
@@ -29,8 +34,9 @@ jobs:
           # https://github.com/danielealbano/lcov-action/issues/11
           remove_patterns: /test/,/cmake-build*/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: ${{ matrix.coverage }} coverage
           files: coverage.info
           flags: ${{ matrix.coverage }}
@@ -62,8 +68,9 @@ jobs:
           # https://github.com/danielealbano/lcov-action/issues/11
           remove_patterns: /test/,/cmake-build*/,/tmp/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           name: python_api coverage
           files: coverage.info,.coverage
           flags: python_api

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+### CI
+
+- [\[#425\]](https://github.com/spglib/spglib/pull/425) - Update to codecov v4
+
 ## v2.3.1 (10 Feb. 2024)
 
 ### Fortran API


### PR DESCRIPTION
Closes #417 

I've also move the `codecov.yaml` to `.github` folder to clean-up the front page a bit. We could to the same with `.readthedocs.yaml`, `Contributing.md`, `CITATION.cff`, `.mdformat.toml` (this one just add it to `.pre-commit-config.yaml`)