### PR TITLE
feat: Explicitly mark exported API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if (NOT DEFINED Spglib_IS_TOP_LEVEL)
 	endif ()
 endif ()
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
@@ -87,8 +88,6 @@ endif ()
 set(CMAKE_MACOSX_RPATH 1)
 # Windows setup
 if (WIN32)
-	# Make sure there is a .lib file to link to
-	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 	# Add appropriate debug flags
 	set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,7 @@ include(cmake/PackageCompsHelper.cmake)
 include(FetchContent)
 if (SPGLIB_INSTALL)
 	include(CMakePackageConfigHelpers)
-	if (UNIX)
-		include(GNUInstallDirs)
-	endif ()
+	include(GNUInstallDirs)
 endif ()
 
 # Define basic parameters

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,10 @@ GitHub release pages and in the git history.
   (Note: previously the project was not tested for the minimum CMake version)
 - Migrated the example and package test to the ctest test-suite
 
+### C interface
+
+- Explicitly mark public API for export
+
 ### Python API
 
 - Fixed the Python module build and installation in the pure CMake environment (without scikit-build-core)

--- a/cmake/CMakePresets-CI.json
+++ b/cmake/CMakePresets-CI.json
@@ -184,10 +184,6 @@
         "SPGLIB_WITH_Fortran": {
           "type": "BOOL",
           "value": false
-        },
-        "SPGLIB_SHARED_LIBS": {
-          "type": "BOOL",
-          "value": false
         }
       }
     },

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -84,6 +84,14 @@ add_custom_command(TARGET Spglib_python POST_BUILD
 		$<TARGET_FILE:Spglib_python>
 		${CMAKE_CURRENT_BINARY_DIR}/spglib/$<TARGET_FILE_NAME:Spglib_python>
 )
+# On Windows make sure the dll files are in the build directory
+# https://stackoverflow.com/a/73550650
+if (CMAKE_IMPORT_LIBRARY_SUFFIX)
+	add_custom_command(TARGET Spglib_python POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:Spglib_python> ${CMAKE_CURRENT_BINARY_DIR}/spglib/
+			COMMAND_EXPAND_LISTS
+	)
+endif ()
 
 #[=============================================================================[
 #                              Install or Export                              #

--- a/python/_spglib.c
+++ b/python/_spglib.c
@@ -162,15 +162,12 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        NULL};
 
 // Define macro to make sure symbol is exported
-// TODO: Switch to C23 native
-#if defined(_WIN32) || defined(WIN32)
-// Note: actually gcc and intel seem to also supports this syntax.
-#ifdef _MSC_VER
+// When compiling define API for export
+#if defined(_MSC_VER)
+// On windows the API must be explicitly marked for export/import
 #define EXPORT __declspec(dllexport)
 #else
-#define EXPORT __attribute__((dllexport))
-#endif
-#else
+// On Unix this is not necessary
 #define EXPORT __attribute__((visibility("default")))
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set_property(DIRECTORY APPEND PROPERTY
 		CMAKE_CONFIGURE_DEPENDS ${PROJECT_BINARY_DIR}/.git_commit
 )
 add_dependencies(Spglib_symspg Spglib_GitHash)
+target_compile_definitions(Spglib_symspg PRIVATE SPG_BUILD)
 
 # Add compiler warnings
 if (SPGLIB_COMPILATION_WARNING)

--- a/src/base.h
+++ b/src/base.h
@@ -1,0 +1,12 @@
+#ifndef SPGLIB_BASE_H
+#define SPGLIB_BASE_H
+
+#include "spglib.h"
+
+#ifdef SPG_TESTING
+#define SPG_API_TEST SPG_API
+#else
+#define SPG_API_TEST
+#endif
+
+#endif  // SPGLIB_BASE_H

--- a/src/cell.h
+++ b/src/cell.h
@@ -63,13 +63,15 @@ typedef struct {
     double *tensors;
 } Cell;
 
-Cell *cel_alloc_cell(const int size, const SiteTensorType tensor_rank);
-void cel_free_cell(Cell *cell);
+SPG_API_TEST Cell *cel_alloc_cell(const int size,
+                                  const SiteTensorType tensor_rank);
+SPG_API_TEST void cel_free_cell(Cell *cell);
 void cel_set_cell(Cell *cell, const double lattice[3][3],
                   const double position[][3], const int types[]);
-void cel_set_layer_cell(Cell *cell, const double lattice[3][3],
-                        const double position[][3], const int types[],
-                        const int aperiodic_axis);
+SPG_API_TEST void cel_set_layer_cell(Cell *cell, const double lattice[3][3],
+                                     const double position[][3],
+                                     const int types[],
+                                     const int aperiodic_axis);
 void cel_set_cell_with_tensors(Cell *cell, const double lattice[3][3],
                                const double position[][3], const int types[],
                                const double *tensors);

--- a/src/delaunay.h
+++ b/src/delaunay.h
@@ -35,13 +35,16 @@
 #ifndef __delaunay_H__
 #define __delaunay_H__
 
+#include "base.h"
 #include "mathfunc.h"
 
-int del_delaunay_reduce(double lattice_new[3][3], const double lattice[3][3],
-                        const double symprec);
-int del_layer_delaunay_reduce(double min_lattice[3][3],
-                              const double lattice[3][3],
-                              const int aperiodic_axis, const double symprec);
+SPG_API_TEST int del_delaunay_reduce(double lattice_new[3][3],
+                                     const double lattice[3][3],
+                                     const double symprec);
+SPG_API_TEST int del_layer_delaunay_reduce(double min_lattice[3][3],
+                                           const double lattice[3][3],
+                                           const int aperiodic_axis,
+                                           const double symprec);
 
 // @brief Delaunay reduction for monoclinic/oblique or monoclinic/rectangular
 // @param[out] red_lattice

--- a/src/mathfunc.h
+++ b/src/mathfunc.h
@@ -35,6 +35,8 @@
 #ifndef __mathfunc_H__
 #define __mathfunc_H__
 
+#include "base.h"
+
 typedef struct {
     int size;
     int (*mat)[3][3];
@@ -48,7 +50,7 @@ typedef struct {
 double mat_get_determinant_d3(const double a[3][3]);
 int mat_get_determinant_i3(const int a[3][3]);
 int mat_get_trace_i3(const int a[3][3]);
-void mat_copy_matrix_d3(double a[3][3], const double b[3][3]);
+SPG_API_TEST void mat_copy_matrix_d3(double a[3][3], const double b[3][3]);
 void mat_copy_matrix_i3(int a[3][3], const int b[3][3]);
 void mat_copy_vector_d3(double a[3], const double b[3]);
 void mat_copy_vector_i3(int a[3], const int b[3]);
@@ -57,8 +59,8 @@ int mat_check_identity_matrix_d3(const double a[3][3], const double b[3][3],
                                  const double symprec);
 int mat_check_identity_matrix_id3(const int a[3][3], const double b[3][3],
                                   const double symprec);
-void mat_multiply_matrix_d3(double m[3][3], const double a[3][3],
-                            const double b[3][3]);
+SPG_API_TEST void mat_multiply_matrix_d3(double m[3][3], const double a[3][3],
+                                         const double b[3][3]);
 void mat_multiply_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]);
 void mat_multiply_matrix_di3(double m[3][3], const double a[3][3],
                              const int b[3][3]);
@@ -73,14 +75,15 @@ void mat_multiply_matrix_vector_di3(double v[3], const double a[3][3],
                                     const int b[3]);
 void mat_add_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]);
 void mat_cast_matrix_3i_to_3d(double m[3][3], const int a[3][3]);
-void mat_cast_matrix_3d_to_3i(int m[3][3], const double a[3][3]);
-int mat_inverse_matrix_d3(double m[3][3], const double a[3][3],
-                          const double precision);
+SPG_API_TEST void mat_cast_matrix_3d_to_3i(int m[3][3], const double a[3][3]);
+SPG_API_TEST int mat_inverse_matrix_d3(double m[3][3], const double a[3][3],
+                                       const double precision);
 int mat_get_similar_matrix_d3(double m[3][3], const double a[3][3],
                               const double b[3][3], const double precision);
 void mat_transpose_matrix_d3(double a[3][3], const double b[3][3]);
 void mat_transpose_matrix_i3(int a[3][3], const int b[3][3]);
-void mat_get_metric(double metric[3][3], const double lattice[3][3]);
+SPG_API_TEST void mat_get_metric(double metric[3][3],
+                                 const double lattice[3][3]);
 double mat_norm_squared_d3(const double a[3]);
 int mat_norm_squared_i3(const int a[3]);
 void mat_cross_product_d3(double v[3], const double a[3], const double b[3]);

--- a/src/niggli.h
+++ b/src/niggli.h
@@ -35,6 +35,8 @@
 #ifndef __NIGGLI_H__
 #define __NIGGLI_H__
 
+#include "base.h"
+
 #define NIGGLI_MAJOR_VERSION 0
 #define NIGGLI_MINOR_VERSION 1
 #define NIGGLI_MICRO_VERSION 2
@@ -42,7 +44,7 @@
 int niggli_get_major_version(void);
 int niggli_get_minor_version(void);
 int niggli_get_micro_version(void);
-int niggli_reduce(double* lattice_, const double eps_,
-                  const int aperiodic_axis);
+SPG_API_TEST int niggli_reduce(double* lattice_, const double eps_,
+                               const int aperiodic_axis);
 
 #endif

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -33,6 +33,7 @@
 /* POSSIBILITY OF SUCH DAMAGE. */
 
 #include "spglib.h"
+#include "base.h"
 
 #include <stddef.h>
 #include <stdio.h>
@@ -236,7 +237,9 @@ int spg_get_micro_version() {
 /* error */
 /*-------*/
 SpglibError spg_get_error_code(void) { return spglib_error_code; }
-void spg_set_error_code(SpglibError err) { spglib_error_code = err; }
+SPG_API_TEST void spg_set_error_code(SpglibError err) {
+    spglib_error_code = err;
+}
 
 char *spg_get_error_message(SpglibError error) {
     int i;

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -39,6 +39,23 @@
 extern "C" {
 #endif
 
+#ifdef SPG_BUILD
+// When compiling define API for export
+#if defined(_MSC_VER)
+// On windows the API must be explicitly marked for export/import
+#define SPG_API __declspec(dllexport)
+#else
+// On Unix this is not necessary
+#define SPG_API __attribute__((visibility("default")))
+#endif
+#elif defined(_MSC_VER)
+// Otherwise mark it for import (Only needed for windows)
+#define SPG_API __declspec(dllimport)
+#else
+// Not building and not on windows, no need to do anything
+#define SPG_API
+#endif
+
 #include <stddef.h>
 
 /*
@@ -184,56 +201,56 @@ typedef struct {
     int type;
 } SpglibMagneticSpacegroupType;
 
-const char *spg_get_version();
-const char *spg_get_version_full();
-const char *spg_get_commit();
-int spg_get_major_version();
-int spg_get_minor_version();
-int spg_get_micro_version();
+SPG_API const char *spg_get_version();
+SPG_API const char *spg_get_version_full();
+SPG_API const char *spg_get_commit();
+SPG_API int spg_get_major_version();
+SPG_API int spg_get_minor_version();
+SPG_API int spg_get_micro_version();
 
-SpglibError spg_get_error_code(void);
-char *spg_get_error_message(SpglibError spglib_error);
+SPG_API SpglibError spg_get_error_code(void);
+SPG_API char *spg_get_error_message(SpglibError spglib_error);
 
-SpglibDataset *spg_get_dataset(const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const int num_atom, const double symprec);
+SPG_API SpglibDataset *spg_get_dataset(const double lattice[3][3],
+                                       const double position[][3],
+                                       const int types[], const int num_atom,
+                                       const double symprec);
 
 /* This is for test using */
-SpglibDataset *spg_get_layer_dataset(const double lattice[3][3],
-                                     const double position[][3],
-                                     const int types[], const int num_atom,
-                                     const int aperiodic_axis,
-                                     const double symprec);
+SPG_API SpglibDataset *spg_get_layer_dataset(
+    const double lattice[3][3], const double position[][3], const int types[],
+    const int num_atom, const int aperiodic_axis, const double symprec);
 
-SpglibMagneticDataset *spg_get_magnetic_dataset(
+SPG_API SpglibMagneticDataset *spg_get_magnetic_dataset(
     const double lattice[3][3], const double position[][3], const int types[],
     const double *tensors, const int tensor_rank, const int num_atom,
     const int is_axial, const double symprec);
 
-SpglibMagneticDataset *spgms_get_magnetic_dataset(
+SPG_API SpglibMagneticDataset *spgms_get_magnetic_dataset(
     const double lattice[3][3], const double position[][3], const int types[],
     const double *tensors, const int tensor_rank, const int num_atom,
     const int is_axial, const double symprec, const double angle_tolerance,
     const double mag_symprec);
 
-SpglibDataset *spgat_get_dataset(const double lattice[3][3],
-                                 const double position[][3], const int types[],
-                                 const int num_atom, const double symprec,
-                                 const double angle_tolerance);
+SPG_API SpglibDataset *spgat_get_dataset(const double lattice[3][3],
+                                         const double position[][3],
+                                         const int types[], const int num_atom,
+                                         const double symprec,
+                                         const double angle_tolerance);
 
 /* hall_number = 0 gives the same as spg_get_dataset. */
-SpglibDataset *spg_get_dataset_with_hall_number(
+SPG_API SpglibDataset *spg_get_dataset_with_hall_number(
     const double lattice[3][3], const double position[][3], const int types[],
     const int num_atom, const int hall_number, const double symprec);
 
 /* hall_number = 0 gives the same as spgat_get_dataset. */
-SpglibDataset *spgat_get_dataset_with_hall_number(
+SPG_API SpglibDataset *spgat_get_dataset_with_hall_number(
     const double lattice[3][3], const double position[][3], const int types[],
     const int num_atom, const int hall_number, const double symprec,
     const double angle_tolerance);
 
-void spg_free_dataset(SpglibDataset *dataset);
-void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset);
+SPG_API void spg_free_dataset(SpglibDataset *dataset);
+SPG_API void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset);
 
 /* Find symmetry operations. The operations are stored in */
 /* ``rotation`` and ``translation``. The number of operations is */
@@ -241,31 +258,31 @@ void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset);
 /* given in fractional coordinates, and ``rotation[i]`` and */
 /* ``translation[i]`` with same index give a symmetry operations, */
 /* i.e., these have to be used together. */
-int spg_get_symmetry(int rotation[][3][3], double translation[][3],
-                     const int max_size, const double lattice[3][3],
-                     const double position[][3], const int types[],
-                     const int num_atom, const double symprec);
+SPG_API int spg_get_symmetry(int rotation[][3][3], double translation[][3],
+                             const int max_size, const double lattice[3][3],
+                             const double position[][3], const int types[],
+                             const int num_atom, const double symprec);
 
-int spgat_get_symmetry(int rotation[][3][3], double translation[][3],
-                       const int max_size, const double lattice[3][3],
-                       const double position[][3], const int types[],
-                       const int num_atom, const double symprec,
-                       const double angle_tolerance);
+SPG_API int spgat_get_symmetry(int rotation[][3][3], double translation[][3],
+                               const int max_size, const double lattice[3][3],
+                               const double position[][3], const int types[],
+                               const int num_atom, const double symprec,
+                               const double angle_tolerance);
 
 /* Find symmetry operations with collinear spins on atoms. */
-int spg_get_symmetry_with_collinear_spin(
+SPG_API int spg_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     const int max_size, const double lattice[3][3], const double position[][3],
     const int types[], const double spins[], const int num_atom,
     const double symprec);
 
-int spgat_get_symmetry_with_collinear_spin(
+SPG_API int spgat_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     const int max_size, const double lattice[3][3], const double position[][3],
     const int types[], const double spins[], const int num_atom,
     const double symprec, const double angle_tolerance);
 
-int spgms_get_symmetry_with_collinear_spin(
+SPG_API int spgms_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     const int max_size, const double lattice[3][3], const double position[][3],
     const int types[], const double spins[], const int num_atom,
@@ -293,14 +310,14 @@ int spgms_get_symmetry_with_collinear_spin(
  * @param symprec
  * @return int Number of symmetry operations. Return 0 if failed.
  */
-int spg_get_symmetry_with_site_tensors(
+SPG_API int spg_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     double primitive_lattice[3][3], int *spin_flips, const int max_size,
     const double lattice[3][3], const double position[][3], const int types[],
     const double *tensors, const int tensor_rank, const int num_atom,
     const int with_time_reversal, const int is_axial, const double symprec);
 
-int spgat_get_symmetry_with_site_tensors(
+SPG_API int spgat_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     double primitive_lattice[3][3], int *spin_flips, const int max_size,
     const double lattice[3][3], const double position[][3], const int types[],
@@ -308,7 +325,7 @@ int spgat_get_symmetry_with_site_tensors(
     const int with_time_reversal, const int is_axial, const double symprec,
     const double angle_tolerance);
 
-int spgms_get_symmetry_with_site_tensors(
+SPG_API int spgms_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
     double primitive_lattice[3][3], int *spin_flips, const int max_size,
     const double lattice[3][3], const double position[][3], const int types[],
@@ -318,10 +335,10 @@ int spgms_get_symmetry_with_site_tensors(
 
 /* Deprecated at v2.0 */
 /* Space group type (hall_number) is searched from symmetry operations. */
-int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
-                                      const double translation[][3],
-                                      const int num_operations,
-                                      const double symprec);
+SPG_API int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
+                                              const double translation[][3],
+                                              const int num_operations,
+                                              const double symprec);
 /**
  * @brief Search space group type from symmetry operations
  *
@@ -332,60 +349,66 @@ int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
  * @param symprec
  * @return SpglibSpacegroupType
  */
-SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
+SPG_API SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
     const int rotation[][3][3], const double translation[][3],
     const int num_operations, const double lattice[3][3], const double symprec);
 
-SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
-    const int rotations[][3][3], const double translations[][3],
-    const int *time_reversals, const int num_operations,
-    const double lattice[3][3], const double symprec);
+SPG_API SpglibMagneticSpacegroupType
+spg_get_magnetic_spacegroup_type_from_symmetry(const int rotations[][3][3],
+                                               const double translations[][3],
+                                               const int *time_reversals,
+                                               const int num_operations,
+                                               const double lattice[3][3],
+                                               const double symprec);
 
 /* Return exact number of symmetry operations. This function may */
 /* be used in advance to allocate memory space for symmetry */
 /* operations. */
-int spg_get_multiplicity(const double lattice[3][3], const double position[][3],
-                         const int types[], const int num_atom,
-                         const double symprec);
+SPG_API int spg_get_multiplicity(const double lattice[3][3],
+                                 const double position[][3], const int types[],
+                                 const int num_atom, const double symprec);
 
-int spgat_get_multiplicity(const double lattice[3][3],
-                           const double position[][3], const int types[],
-                           const int num_atom, const double symprec,
-                           const double angle_tolerance);
+SPG_API int spgat_get_multiplicity(const double lattice[3][3],
+                                   const double position[][3],
+                                   const int types[], const int num_atom,
+                                   const double symprec,
+                                   const double angle_tolerance);
 
 /* Space group is found in international table symbol (``symbol``) and */
 /* number (return value). 0 is returned when it fails. */
-int spg_get_international(char symbol[11], const double lattice[3][3],
-                          const double position[][3], const int types[],
-                          const int num_atom, const double symprec);
+SPG_API int spg_get_international(char symbol[11], const double lattice[3][3],
+                                  const double position[][3], const int types[],
+                                  const int num_atom, const double symprec);
 
-int spgat_get_international(char symbol[11], const double lattice[3][3],
-                            const double position[][3], const int types[],
-                            const int num_atom, const double symprec,
-                            const double angle_tolerance);
+SPG_API int spgat_get_international(char symbol[11], const double lattice[3][3],
+                                    const double position[][3],
+                                    const int types[], const int num_atom,
+                                    const double symprec,
+                                    const double angle_tolerance);
 
 /* Space group is found in schoenflies (``symbol``) and as number (return */
 /* value).  0 is returned when it fails. */
-int spg_get_schoenflies(char symbol[7], const double lattice[3][3],
-                        const double position[][3], const int types[],
-                        const int num_atom, const double symprec);
+SPG_API int spg_get_schoenflies(char symbol[7], const double lattice[3][3],
+                                const double position[][3], const int types[],
+                                const int num_atom, const double symprec);
 
-int spgat_get_schoenflies(char symbol[7], const double lattice[3][3],
-                          const double position[][3], const int types[],
-                          const int num_atom, const double symprec,
-                          const double angle_tolerance);
+SPG_API int spgat_get_schoenflies(char symbol[7], const double lattice[3][3],
+                                  const double position[][3], const int types[],
+                                  const int num_atom, const double symprec,
+                                  const double angle_tolerance);
 
 /* Point group symbol is obtained from the rotation part of */
 /* symmetry operations */
-int spg_get_pointgroup(char symbol[6], int trans_mat[3][3],
-                       const int rotations[][3][3], const int num_rotations);
+SPG_API int spg_get_pointgroup(char symbol[6], int trans_mat[3][3],
+                               const int rotations[][3][3],
+                               const int num_rotations);
 
 /* Space-group operations in built-in database are accessed by index */
 /* of hall symbol. The index is defined as number from 1 to 530. */
 /* The maximum number of symmetry operations is 192. */
-int spg_get_symmetry_from_database(int rotations[192][3][3],
-                                   double translations[192][3],
-                                   const int hall_number);
+SPG_API int spg_get_symmetry_from_database(int rotations[192][3][3],
+                                           double translations[192][3],
+                                           const int hall_number);
 
 /* This is unstable feature under active development! */
 /* Magnetic space-group operations in built-in database are accessed by UNI
@@ -398,32 +421,33 @@ int spg_get_symmetry_from_database(int rotations[192][3][3],
 /* For type-IV, hall_number changes settings in maximal space group. */
 /* When hall_number = 0, the smallest hall number corresponding to
  * uni_number is used. */
-int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
-                                            double translations[384][3],
-                                            int time_reversals[384],
-                                            const int uni_number,
-                                            const int hall_number);
+SPG_API int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
+                                                    double translations[384][3],
+                                                    int time_reversals[384],
+                                                    const int uni_number,
+                                                    const int hall_number);
 
 /* Space-group type information is accessed by index of hall symbol. */
 /* The index is defined as number from 1 to 530. */
-SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number);
+SPG_API SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number);
 
 /* This is unstable feature under active development! */
 /* Magnetic space-group type information is accessed by index of UNI symbol.
  */
 /* The index is defined as number from 1 to 1651. */
-SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type(
-    const int uni_number);
+SPG_API SpglibMagneticSpacegroupType
+spg_get_magnetic_spacegroup_type(const int uni_number);
 
-int spg_standardize_cell(double lattice[3][3], double position[][3],
-                         int types[], const int num_atom,
-                         const int to_primitive, const int no_idealize,
-                         const double symprec);
+SPG_API int spg_standardize_cell(double lattice[3][3], double position[][3],
+                                 int types[], const int num_atom,
+                                 const int to_primitive, const int no_idealize,
+                                 const double symprec);
 
-int spgat_standardize_cell(double lattice[3][3], double position[][3],
-                           int types[], const int num_atom,
-                           const int to_primitive, const int no_idealize,
-                           const double symprec, const double angle_tolerance);
+SPG_API int spgat_standardize_cell(double lattice[3][3], double position[][3],
+                                   int types[], const int num_atom,
+                                   const int to_primitive,
+                                   const int no_idealize, const double symprec,
+                                   const double angle_tolerance);
 
 /* This is a wrapper of spg_standardize_cell. */
 /* A primitive cell is found from an input cell. */
@@ -431,12 +455,14 @@ int spgat_standardize_cell(double lattice[3][3], double position[][3],
  */
 /* ``num_atom`` is returned as return value. */
 /* When any primitive cell is not found, 0 is returned. */
-int spg_find_primitive(double lattice[3][3], double position[][3], int types[],
-                       const int num_atom, const double symprec);
+SPG_API int spg_find_primitive(double lattice[3][3], double position[][3],
+                               int types[], const int num_atom,
+                               const double symprec);
 
-int spgat_find_primitive(double lattice[3][3], double position[][3],
-                         int types[], const int num_atom, const double symprec,
-                         const double angle_tolerance);
+SPG_API int spgat_find_primitive(double lattice[3][3], double position[][3],
+                                 int types[], const int num_atom,
+                                 const double symprec,
+                                 const double angle_tolerance);
 
 /* This is a wrapper of spg_standardize_cell. */
 /* Bravais lattice with internal atomic points are returned. */
@@ -444,16 +470,18 @@ int spgat_find_primitive(double lattice[3][3], double position[][3],
 /* those of input cell. */
 /* When bravais lattice could not be found, or could not be */
 /* symmetrized, 0 is returned. */
-int spg_refine_cell(double lattice[3][3], double position[][3], int types[],
-                    const int num_atom, const double symprec);
+SPG_API int spg_refine_cell(double lattice[3][3], double position[][3],
+                            int types[], const int num_atom,
+                            const double symprec);
 
-int spgat_refine_cell(double lattice[3][3], double position[][3], int types[],
-                      const int num_atom, const double symprec,
-                      const double angle_tolerance);
+SPG_API int spgat_refine_cell(double lattice[3][3], double position[][3],
+                              int types[], const int num_atom,
+                              const double symprec,
+                              const double angle_tolerance);
 
 /* Delaunay reduction for lattice parameters */
 /* ``lattice`` is overwritten when the reduction ends succeeded. */
-int spg_delaunay_reduce(double lattice[3][3], const double symprec);
+SPG_API int spg_delaunay_reduce(double lattice[3][3], const double symprec);
 
 /*---------*/
 /* kpoints */
@@ -464,10 +492,10 @@ int spg_delaunay_reduce(double lattice[3][3], const double symprec);
 /* A q-point in fractional coordinates is given as */
 /* ((grid_address * 2 + (shift != 0)) / (mesh * 2)). */
 /* Each element of shift[] is 0 or non-zero. */
-int spg_get_grid_point_from_address(const int grid_address[3],
-                                    const int mesh[3]);
-size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
-                                             const int mesh[3]);
+SPG_API int spg_get_grid_point_from_address(const int grid_address[3],
+                                            const int mesh[3]);
+SPG_API size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
+                                                     const int mesh[3]);
 
 /* Irreducible reciprocal grid points are searched from uniform */
 /* mesh grid points specified by ``mesh`` and ``is_shift``. */
@@ -485,13 +513,12 @@ size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
 /* ``grid_address``. The number of the irreducible k-points are */
 /* returned as the return value.  The time reversal symmetry is */
 /* imposed by setting ``is_time_reversal`` 1. */
-int spg_get_ir_reciprocal_mesh(int grid_address[][3], int ir_mapping_table[],
-                               const int mesh[3], const int is_shift[3],
-                               const int is_time_reversal,
-                               const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const int num_atom, const double symprec);
-size_t spg_get_dense_ir_reciprocal_mesh(
+SPG_API int spg_get_ir_reciprocal_mesh(
+    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
+    const int is_shift[3], const int is_time_reversal,
+    const double lattice[3][3], const double position[][3], const int types[],
+    const int num_atom, const double symprec);
+SPG_API size_t spg_get_dense_ir_reciprocal_mesh(
     int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
     const int is_shift[3], const int is_time_reversal,
     const double lattice[3][3], const double position[][3], const int types[],
@@ -505,11 +532,11 @@ size_t spg_get_dense_ir_reciprocal_mesh(
 /* in ``map`` as indices of ``grid_address``. The number of the */
 /* reduced k-points with stabilizers are returned as the return */
 /* value. */
-int spg_get_stabilized_reciprocal_mesh(
+SPG_API int spg_get_stabilized_reciprocal_mesh(
     int grid_address[][3], int ir_mapping_table[], const int mesh[3],
     const int is_shift[3], const int is_time_reversal, const int num_rot,
     const int rotations[][3][3], const int num_q, const double qpoints[][3]);
-size_t spg_get_dense_stabilized_reciprocal_mesh(
+SPG_API size_t spg_get_dense_stabilized_reciprocal_mesh(
     int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
     const int is_shift[3], const int is_time_reversal, const int num_rot,
     const int rotations[][3][3], const int num_q, const double qpoints[][3]);
@@ -518,20 +545,18 @@ size_t spg_get_dense_stabilized_reciprocal_mesh(
 /* to a grid address ``address_orig`` and resulting grid points are stored
  * in */
 /* ``rot_grid_points``. Return 0 if failed. */
-void spg_get_grid_points_by_rotations(int rot_grid_points[],
-                                      const int address_orig[3],
-                                      const int num_rot,
-                                      const int rot_reciprocal[][3][3],
-                                      const int mesh[3], const int is_shift[3]);
-void spg_get_dense_grid_points_by_rotations(
+SPG_API void spg_get_grid_points_by_rotations(
+    int rot_grid_points[], const int address_orig[3], const int num_rot,
+    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3]);
+SPG_API void spg_get_dense_grid_points_by_rotations(
     size_t rot_grid_points[], const int address_orig[3], const int num_rot,
     const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3]);
 
-void spg_get_BZ_grid_points_by_rotations(
+SPG_API void spg_get_BZ_grid_points_by_rotations(
     int rot_grid_points[], const int address_orig[3], const int num_rot,
     const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3],
     const int bz_map[]);
-void spg_get_dense_BZ_grid_points_by_rotations(
+SPG_API void spg_get_dense_BZ_grid_points_by_rotations(
     size_t rot_grid_points[], const int address_orig[3], const int num_rot,
     const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3],
     const size_t bz_map[]);
@@ -558,11 +583,12 @@ void spg_get_dense_BZ_grid_points_by_rotations(
 /* bz_map is used to recover grid point index expanded to include BZ */
 /* surface from grid address. The grid point indices are mapped to */
 /* (mesh[0] * 2) x (mesh[1] * 2) x (mesh[2] * 2) space (bz_map). */
-int spg_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
-                                 const int grid_address[][3], const int mesh[3],
-                                 const double rec_lattice[3][3],
-                                 const int is_shift[3]);
-size_t spg_relocate_dense_BZ_grid_address(
+SPG_API int spg_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
+                                         const int grid_address[][3],
+                                         const int mesh[3],
+                                         const double rec_lattice[3][3],
+                                         const int is_shift[3]);
+SPG_API size_t spg_relocate_dense_BZ_grid_address(
     int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
     const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]);
 
@@ -570,7 +596,7 @@ size_t spg_relocate_dense_BZ_grid_address(
 /* Niggli */
 /*--------*/
 /* Return 0 if failed */
-int spg_niggli_reduce(double lattice[3][3], const double symprec);
+SPG_API int spg_niggli_reduce(double lattice[3][3], const double symprec);
 
 #ifdef __cplusplus
 }

--- a/src/symmetry.h
+++ b/src/symmetry.h
@@ -57,11 +57,12 @@ typedef struct {
 } PointSymmetry;
 
 Symmetry *sym_alloc_symmetry(const int size);
-void sym_free_symmetry(Symmetry *symmetry);
+SPG_API_TEST void sym_free_symmetry(Symmetry *symmetry);
 MagneticSymmetry *sym_alloc_magnetic_symmetry(const int size);
 void sym_free_magnetic_symmetry(MagneticSymmetry *symmetry);
-Symmetry *sym_get_operation(const Cell *primitive, const double symprec,
-                            const double angle_tolerance);
+SPG_API_TEST Symmetry *sym_get_operation(const Cell *primitive,
+                                         const double symprec,
+                                         const double angle_tolerance);
 Symmetry *sym_reduce_operation(const Cell *primitive, const Symmetry *symmetry,
                                const double symprec,
                                const double angle_tolerance);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -173,15 +173,17 @@ function(Spglib_add_gtest)
 	target_sources(${ARGS_TARGET} PRIVATE ${ARGS_SOURCES})
 	gtest_add_tests(TARGET ${ARGS_TARGET}
 			SOURCES ${ARGS_SOURCES}
-			TEST_LIST google_tests)
+			TEST_LIST google_tests
+	)
 
 	# Set test labels
 	get_directory_property(test_labels LABELS)
 	list(APPEND test_labels ${ARGS_LABELS})
-	foreach (g_test IN LISTS google_tests)
-		set_tests_properties(${g_test} PROPERTIES
-				LABELS "${test_labels}")
-	endforeach ()
+	set_tests_properties(${google_tests} PROPERTIES
+			LABELS "${test_labels}"
+			# https://stackoverflow.com/a/77990416
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:Spglib_tests>,\;>"
+	)
 endfunction()
 
 function(Spglib_add_test test)

--- a/test/README.md
+++ b/test/README.md
@@ -223,6 +223,17 @@ def print_cpp_cell(cell):
     print("\n".join(contents))
 ```
 
+#### Exposing API for unit tests
+
+Normally all functions outside of the exported `spglib.h` are not exposed, but for the purposes of unit testing, we need
+access to these. Currently, we don't know a clear way of resolving this issue, but we know two ways of addressing this:
+
+- Building Spglib as a static library for linking to the test-suite
+- Use a macro `SPG_API_TEST` that expands to `SPG_API` when building unit tests
+
+We have opted for the latter approach for now, so keep in mind when writing unit tests to include `SPG_API_TEST`
+directive.
+
 ## Tmt test-suite
 
 The [`tmt`] test layer is primarily for orchestrating and running all the tests in arbitrary environments, e.g. in the

--- a/test/example/c_api/CMakeLists.txt
+++ b/test/example/c_api/CMakeLists.txt
@@ -12,3 +12,16 @@ add_executable(example_full example_full.c)
 
 target_link_libraries(example PRIVATE Spglib::symspg)
 target_link_libraries(example_full PRIVATE Spglib::symspg)
+
+# Windows is weird like that :/
+# https://stackoverflow.com/a/73550650
+if (CMAKE_IMPORT_LIBRARY_SUFFIX)
+	add_custom_command(TARGET example POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:example> $<TARGET_FILE_DIR:example>
+			COMMAND_EXPAND_LISTS
+	)
+	add_custom_command(TARGET example_full POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:example_full> $<TARGET_FILE_DIR:example_full>
+			COMMAND_EXPAND_LISTS
+	)
+endif ()

--- a/test/package/FetchContent/CMakeLists.txt
+++ b/test/package/FetchContent/CMakeLists.txt
@@ -32,6 +32,8 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${Spglib_VERSION}\n*$"
+		# https://stackoverflow.com/a/77990416
+		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
 
 if (SPGLIB_WITH_Fortran)
@@ -44,5 +46,7 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${Spglib_VERSION}[ \n]*Spglib_Fortran version: ${Spglib_VERSION}[ \n]*$"
+			# https://stackoverflow.com/a/77990416
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
 endif ()

--- a/test/package/find_package/CMakeLists.txt
+++ b/test/package/find_package/CMakeLists.txt
@@ -20,6 +20,8 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${Spglib_VERSION}\n*$"
+		# https://stackoverflow.com/a/77990416
+		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
 
 if (SPGLIB_WITH_Fortran)
@@ -31,5 +33,7 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${Spglib_VERSION}[ \n]*Spglib_Fortran version: ${Spglib_VERSION}[ \n]*$"
+			# https://stackoverflow.com/a/77990416
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
 endif ()

--- a/test/package/pkg-config/CMakeLists.txt
+++ b/test/package/pkg-config/CMakeLists.txt
@@ -15,6 +15,8 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${spglib_VERSION}\n*$"
+		# https://stackoverflow.com/a/77990416
+		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
 
 if (SPGLIB_WITH_Fortran)
@@ -28,5 +30,7 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${spglib_VERSION}[ \n]*Spglib_Fortran version: ${spglib_fortran_VERSION}[ \n]*$"
+			# https://stackoverflow.com/a/77990416
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
 endif ()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ if (TARGET Spglib_symspg)
 	target_include_directories(Spglib_tests PRIVATE
 			${Spglib_SOURCE_DIR}/src
 	)
+	target_compile_definitions(Spglib_symspg PRIVATE SPG_TESTING)
 	Spglib_add_gtest(TARGET Spglib_tests SOURCES
 			test_delaunay.cpp
 			test_niggli.cpp


### PR DESCRIPTION
Windows systems are quite weird where you have to define both when you import and export stuff. Previously in the CI we got around it by building as static, but that is not appropriate as we've seen with the C# interface discussion [^1].

@husakm can you try this one out?

[^1]: https://github.com/spglib/spglib/discussions/399#discussioncomment-8207195