### PR TITLE
style: Change a few styles

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,4 @@ BasedOnStyle: Google
 IndentWidth: 4
 IncludeBlocks: Preserve
 QualifierAlignment: Right
+IndentPPDirectives: BeforeHash

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Google
 IndentWidth: 4
 IncludeBlocks: Preserve
+QualifierAlignment: Right

--- a/python/_spglib.c
+++ b/python/_spglib.c
@@ -164,11 +164,11 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
 // Define macro to make sure symbol is exported
 // When compiling define API for export
 #if defined(_MSC_VER)
-// On windows the API must be explicitly marked for export/import
-#define EXPORT __declspec(dllexport)
+    // On windows the API must be explicitly marked for export/import
+    #define EXPORT __declspec(dllexport)
 #else
-// On Unix this is not necessary
-#define EXPORT __attribute__((visibility("default")))
+    // On Unix this is not necessary
+    #define EXPORT __attribute__((visibility("default")))
 #endif
 
 EXPORT PyObject *PyInit__spglib(void) {

--- a/src/arithmetic.c
+++ b/src/arithmetic.c
@@ -54,7 +54,7 @@ static int arithmetic_crystal_classes[231] = {
     59, 61, 62, 62, 63, 63, 64, 62, 64, 65, 65, 66, 66, 67, 65, 65, 67, 68,
     69, 70, 68, 69, 70, 71, 71, 71, 71, 72, 72, 72, 72, 73, 73};
 
-static const char arithmetic_crystal_class_symbols[74][7] = {
+static char const arithmetic_crystal_class_symbols[74][7] = {
     "      ", /*  0 */
     "1P    ", /*  1 */
     "-1P   ", /*  2 */
@@ -131,7 +131,7 @@ static const char arithmetic_crystal_class_symbols[74][7] = {
     "m-3mI "  /* 73 */
 };
 
-int arth_get_symbol(char symbol[7], const int spgroup_number) {
+int arth_get_symbol(char symbol[7], int const spgroup_number) {
     int i, arth_number;
 
     if (spgroup_number < 1 || spgroup_number > 230) {

--- a/src/arithmetic.h
+++ b/src/arithmetic.h
@@ -35,6 +35,6 @@
 #ifndef __arithmetic_H__
 #define __arithmetic_H__
 
-int arth_get_symbol(char symbol[7], const int spgroup_number);
+int arth_get_symbol(char symbol[7], int const spgroup_number);
 
 #endif

--- a/src/base.h
+++ b/src/base.h
@@ -4,9 +4,9 @@
 #include "spglib.h"
 
 #ifdef SPG_TESTING
-#define SPG_API_TEST SPG_API
+    #define SPG_API_TEST SPG_API
 #else
-#define SPG_API_TEST
+    #define SPG_API_TEST
 #endif
 
 #endif  // SPGLIB_BASE_H

--- a/src/cell.c
+++ b/src/cell.c
@@ -45,25 +45,25 @@
 #define REDUCE_RATE 0.95
 #define NUM_ATTEMPT 100
 
-static Cell *trim_cell(int *mapping_table, const double trimmed_lattice[3][3],
-                       const Cell *cell, const double symprec);
+static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
+                       Cell const *cell, double const symprec);
 static void set_positions_and_tensors(Cell *trimmed_cell,
-                                      const VecDBL *position,
-                                      const SiteTensorType tensor_rank,
-                                      const double *tensors,
-                                      const int *mapping_table,
-                                      const int *overlap_table);
-static VecDBL *translate_atoms_in_trimmed_lattice(const Cell *cell,
-                                                  const int tmat_p_i[3][3]);
-static int *get_overlap_table(const VecDBL *position, const int cell_size,
-                              const int *cell_types, const Cell *trimmed_cell,
-                              const double symprec);
+                                      VecDBL const *position,
+                                      SiteTensorType const tensor_rank,
+                                      double const *tensors,
+                                      int const *mapping_table,
+                                      int const *overlap_table);
+static VecDBL *translate_atoms_in_trimmed_lattice(Cell const *cell,
+                                                  int const tmat_p_i[3][3]);
+static int *get_overlap_table(VecDBL const *position, int const cell_size,
+                              int const *cell_types, Cell const *trimmed_cell,
+                              double const symprec);
 
 // @brief Allocate Cell. NULL is returned if failed
 // @param size number of atoms
 // @param tensor_rank rank of site tensors for magnetic symmetry. Set -1 if
 // not used.
-Cell *cel_alloc_cell(const int size, const SiteTensorType tensor_rank) {
+Cell *cel_alloc_cell(int const size, SiteTensorType const tensor_rank) {
     Cell *cell;
 
     cell = NULL;
@@ -140,8 +140,8 @@ void cel_free_cell(Cell *cell) {
     }
 }
 
-void cel_set_cell(Cell *cell, const double lattice[3][3],
-                  const double position[][3], const int types[]) {
+void cel_set_cell(Cell *cell, double const lattice[3][3],
+                  double const position[][3], int const types[]) {
     int i, j;
     mat_copy_matrix_d3(cell->lattice, lattice);
     for (i = 0; i < cell->size; i++) {
@@ -153,9 +153,9 @@ void cel_set_cell(Cell *cell, const double lattice[3][3],
 }
 
 /* aperiodic_axis = -1 for none; = 0 1 2 for a b c */
-void cel_set_layer_cell(Cell *cell, const double lattice[3][3],
-                        const double position[][3], const int types[],
-                        const int aperiodic_axis) {
+void cel_set_layer_cell(Cell *cell, double const lattice[3][3],
+                        double const position[][3], int const types[],
+                        int const aperiodic_axis) {
     int i, j;
     mat_copy_matrix_d3(cell->lattice, lattice);
     for (i = 0; i < cell->size; i++) {
@@ -172,9 +172,9 @@ void cel_set_layer_cell(Cell *cell, const double lattice[3][3],
     cell->aperiodic_axis = aperiodic_axis;
 }
 
-void cel_set_cell_with_tensors(Cell *cell, const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const double *tensors) {
+void cel_set_cell_with_tensors(Cell *cell, double const lattice[3][3],
+                               double const position[][3], int const types[],
+                               double const *tensors) {
     int i, j;
 
     cel_set_cell(cell, lattice, position, types);
@@ -189,7 +189,7 @@ void cel_set_cell_with_tensors(Cell *cell, const double lattice[3][3],
     }
 }
 
-Cell *cel_copy_cell(const Cell *cell) {
+Cell *cel_copy_cell(Cell const *cell) {
     Cell *cell_new;
 
     cell_new = NULL;
@@ -211,8 +211,8 @@ Cell *cel_copy_cell(const Cell *cell) {
     return cell_new;
 }
 
-int cel_is_overlap(const double a[3], const double b[3],
-                   const double lattice[3][3], const double symprec) {
+int cel_is_overlap(double const a[3], double const b[3],
+                   double const lattice[3][3], double const symprec) {
     int i;
     double v_diff[3];
 
@@ -229,10 +229,10 @@ int cel_is_overlap(const double a[3], const double b[3],
     }
 }
 
-int cel_is_overlap_with_same_type(const double a[3], const double b[3],
-                                  const int type_a, const int type_b,
-                                  const double lattice[3][3],
-                                  const double symprec) {
+int cel_is_overlap_with_same_type(double const a[3], double const b[3],
+                                  int const type_a, int const type_b,
+                                  double const lattice[3][3],
+                                  double const symprec) {
     if (type_a == type_b) {
         return cel_is_overlap(a, b, lattice, symprec);
     } else {
@@ -242,7 +242,7 @@ int cel_is_overlap_with_same_type(const double a[3], const double b[3],
 
 /* 1: At least one overlap of a pair of atoms was found. */
 /* 0: No overlap of atoms was found. */
-int cel_any_overlap(const Cell *cell, const double symprec) {
+int cel_any_overlap(Cell const *cell, double const symprec) {
     int i, j;
 
     for (i = 0; i < cell->size; i++) {
@@ -258,7 +258,7 @@ int cel_any_overlap(const Cell *cell, const double symprec) {
 
 /* 1: At least one overlap of a pair of atoms with same type was found. */
 /* 0: No overlap of atoms was found. */
-int cel_any_overlap_with_same_type(const Cell *cell, const double symprec) {
+int cel_any_overlap_with_same_type(Cell const *cell, double const symprec) {
     int i, j;
 
     for (i = 0; i < cell->size; i++) {
@@ -275,9 +275,9 @@ int cel_any_overlap_with_same_type(const Cell *cell, const double symprec) {
 
 /* Modified from cel_is_overlap */
 /* Periodic boundary condition only applied on 2 directions */
-int cel_layer_is_overlap(const double a[3], const double b[3],
-                         const double lattice[3][3], const int periodic_axes[2],
-                         const double symprec) {
+int cel_layer_is_overlap(double const a[3], double const b[3],
+                         double const lattice[3][3], int const periodic_axes[2],
+                         double const symprec) {
     double v_diff[3];
 
     v_diff[0] = a[0] - b[0];
@@ -295,11 +295,11 @@ int cel_layer_is_overlap(const double a[3], const double b[3],
     }
 }
 
-int cel_layer_is_overlap_with_same_type(const double a[3], const double b[3],
-                                        const int type_a, const int type_b,
-                                        const double lattice[3][3],
-                                        const int periodic_axes[2],
-                                        const double symprec) {
+int cel_layer_is_overlap_with_same_type(double const a[3], double const b[3],
+                                        int const type_a, int const type_b,
+                                        double const lattice[3][3],
+                                        int const periodic_axes[2],
+                                        double const symprec) {
     if (type_a == type_b) {
         return cel_layer_is_overlap(a, b, lattice, periodic_axes, symprec);
     } else {
@@ -309,9 +309,9 @@ int cel_layer_is_overlap_with_same_type(const double a[3], const double b[3],
 
 /* 1: At least one overlap of a pair of atoms with same type was found. */
 /* 0: No overlap of atoms was found. */
-int cel_layer_any_overlap_with_same_type(const Cell *cell,
-                                         const int periodic_axes[2],
-                                         const double symprec) {
+int cel_layer_any_overlap_with_same_type(Cell const *cell,
+                                         int const periodic_axes[2],
+                                         double const symprec) {
     int i, j;
 
     for (i = 0; i < cell->size; i++) {
@@ -334,14 +334,14 @@ int cel_layer_any_overlap_with_same_type(const Cell *cell,
 /// `trimmed_lattice` is created.
 /// @param[in] symprec tolerance parameter.
 /// @return smaller cell having basis vectors of `trimmed_lattice`.
-Cell *cel_trim_cell(int *mapping_table, const double trimmed_lattice[3][3],
-                    const Cell *cell, const double symprec) {
+Cell *cel_trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
+                    Cell const *cell, double const symprec) {
     return trim_cell(mapping_table, trimmed_lattice, cell, symprec);
 }
 
 /* Return NULL if failed */
-static Cell *trim_cell(int *mapping_table, const double trimmed_lattice[3][3],
-                       const Cell *cell, const double symprec) {
+static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
+                       Cell const *cell, double const symprec) {
     int i, index_atom, ratio;
     Cell *trimmed_cell;
     VecDBL *position;
@@ -432,11 +432,11 @@ err:
 /// @brief Set trimmed_cell->position and trimmed_cell->tensors by averaging
 /// over overlapped atoms
 static void set_positions_and_tensors(Cell *trimmed_cell,
-                                      const VecDBL *position,
-                                      const SiteTensorType tensor_rank,
-                                      const double *tensors,
-                                      const int *mapping_table,
-                                      const int *overlap_table) {
+                                      VecDBL const *position,
+                                      SiteTensorType const tensor_rank,
+                                      double const *tensors,
+                                      int const *mapping_table,
+                                      int const *overlap_table) {
     int i, j, k, l, multi, atom_idx;
 
     for (i = 0; i < trimmed_cell->size; i++) {
@@ -505,8 +505,8 @@ static void set_positions_and_tensors(Cell *trimmed_cell,
 }
 
 /* Return NULL if failed */
-static VecDBL *translate_atoms_in_trimmed_lattice(const Cell *cell,
-                                                  const int tmat_p_i[3][3]) {
+static VecDBL *translate_atoms_in_trimmed_lattice(Cell const *cell,
+                                                  int const tmat_p_i[3][3]) {
     int i, j;
     VecDBL *position;
 
@@ -541,9 +541,9 @@ static VecDBL *translate_atoms_in_trimmed_lattice(const Cell *cell,
 /// @return array (cell_size, ) If `position[i]` and `position[j]` with `i` <=
 /// `j` are equivalent, `overlap_table[i]` = `overlap_table[j]` = `i`. Return
 /// NULL if failed.
-static int *get_overlap_table(const VecDBL *position, const int cell_size,
-                              const int *cell_types, const Cell *trimmed_cell,
-                              const double symprec) {
+static int *get_overlap_table(VecDBL const *position, int const cell_size,
+                              int const *cell_types, Cell const *trimmed_cell,
+                              double const symprec) {
     int i, j, attempt, num_overlap, ratio, lattice_rank;
     double trim_tolerance;
     int *overlap_table;

--- a/src/cell.h
+++ b/src/cell.h
@@ -63,39 +63,39 @@ typedef struct {
     double *tensors;
 } Cell;
 
-SPG_API_TEST Cell *cel_alloc_cell(const int size,
-                                  const SiteTensorType tensor_rank);
+SPG_API_TEST Cell *cel_alloc_cell(int const size,
+                                  SiteTensorType const tensor_rank);
 SPG_API_TEST void cel_free_cell(Cell *cell);
-void cel_set_cell(Cell *cell, const double lattice[3][3],
-                  const double position[][3], const int types[]);
-SPG_API_TEST void cel_set_layer_cell(Cell *cell, const double lattice[3][3],
-                                     const double position[][3],
-                                     const int types[],
-                                     const int aperiodic_axis);
-void cel_set_cell_with_tensors(Cell *cell, const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const double *tensors);
-Cell *cel_copy_cell(const Cell *cell);
-int cel_is_overlap(const double a[3], const double b[3],
-                   const double lattice[3][3], const double symprec);
-int cel_is_overlap_with_same_type(const double a[3], const double b[3],
-                                  const int type_a, const int type_b,
-                                  const double lattice[3][3],
-                                  const double symprec);
-int cel_any_overlap(const Cell *cell, const double symprec);
-int cel_any_overlap_with_same_type(const Cell *cell, const double symprec);
-Cell *cel_trim_cell(int *mapping_table, const double trimmed_lattice[3][3],
-                    const Cell *cell, const double symprec);
-int cel_layer_is_overlap(const double a[3], const double b[3],
-                         const double lattice[3][3], const int periodic_axes[2],
-                         const double symprec);
-int cel_layer_is_overlap_with_same_type(const double a[3], const double b[3],
-                                        const int type_a, const int type_b,
-                                        const double lattice[3][3],
-                                        const int periodic_axes[2],
-                                        const double symprec);
-int cel_layer_any_overlap_with_same_type(const Cell *cell,
-                                         const int periodic_axes[2],
-                                         const double symprec);
+void cel_set_cell(Cell *cell, double const lattice[3][3],
+                  double const position[][3], int const types[]);
+SPG_API_TEST void cel_set_layer_cell(Cell *cell, double const lattice[3][3],
+                                     double const position[][3],
+                                     int const types[],
+                                     int const aperiodic_axis);
+void cel_set_cell_with_tensors(Cell *cell, double const lattice[3][3],
+                               double const position[][3], int const types[],
+                               double const *tensors);
+Cell *cel_copy_cell(Cell const *cell);
+int cel_is_overlap(double const a[3], double const b[3],
+                   double const lattice[3][3], double const symprec);
+int cel_is_overlap_with_same_type(double const a[3], double const b[3],
+                                  int const type_a, int const type_b,
+                                  double const lattice[3][3],
+                                  double const symprec);
+int cel_any_overlap(Cell const *cell, double const symprec);
+int cel_any_overlap_with_same_type(Cell const *cell, double const symprec);
+Cell *cel_trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
+                    Cell const *cell, double const symprec);
+int cel_layer_is_overlap(double const a[3], double const b[3],
+                         double const lattice[3][3], int const periodic_axes[2],
+                         double const symprec);
+int cel_layer_is_overlap_with_same_type(double const a[3], double const b[3],
+                                        int const type_a, int const type_b,
+                                        double const lattice[3][3],
+                                        int const periodic_axes[2],
+                                        double const symprec);
+int cel_layer_any_overlap_with_same_type(Cell const *cell,
+                                         int const periodic_axes[2],
+                                         double const symprec);
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -36,32 +36,32 @@
 
 #include "debug.h"
 
-void dbg_print_matrix_d3(const double a[3][3]) {
+void dbg_print_matrix_d3(double const a[3][3]) {
     int i;
     for (i = 0; i < 3; i++) {
         printf("%f %f %f\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_matrix_i3(const int a[3][3]) {
+void dbg_print_matrix_i3(int const a[3][3]) {
     int i;
     for (i = 0; i < 3; i++) {
         printf("%d %d %d\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vectors_d3(const double a[][3], int size) {
+void dbg_print_vectors_d3(double const a[][3], int size) {
     int i;
     for (i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vector_d3(const double a[3]) {
+void dbg_print_vector_d3(double const a[3]) {
     printf("%f %f %f\n", a[0], a[1], a[2]);
 }
 
-void dbg_print_vectors_with_label(const double a[][3], const int b[],
+void dbg_print_vectors_with_label(double const a[][3], int const b[],
                                   int size) {
     int i;
     for (i = 0; i < size; i++) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -39,13 +39,13 @@
 
 // Macros to either print or do nothing if in debug mode or not
 #ifdef SPGDEBUG
-#define debug_print(...) printf(__VA_ARGS__)
-#define debug_print_matrix_d3(a) dbg_print_matrix_d3(a)
-#define debug_print_matrix_i3(a) dbg_print_matrix_i3(a)
-#define debug_print_vector_d3(a) dbg_print_vector_d3(a)
-#define debug_print_vectors_d3(...) dbg_print_vectors_d3(__VA_ARGS__)
-#define debug_print_vectors_with_label(...) \
-    dbg_print_vectors_with_label(__VA_ARGS__)
+    #define debug_print(...) printf(__VA_ARGS__)
+    #define debug_print_matrix_d3(a) dbg_print_matrix_d3(a)
+    #define debug_print_matrix_i3(a) dbg_print_matrix_i3(a)
+    #define debug_print_vector_d3(a) dbg_print_vector_d3(a)
+    #define debug_print_vectors_d3(...) dbg_print_vectors_d3(__VA_ARGS__)
+    #define debug_print_vectors_with_label(...) \
+        dbg_print_vectors_with_label(__VA_ARGS__)
 
 // Just to make sure these are never used, these definitions are #ifdef guarded
 void dbg_print_matrix_d3(double const a[3][3]);
@@ -55,17 +55,17 @@ void dbg_print_vectors_d3(double const a[][3], int size);
 void dbg_print_vectors_with_label(double const a[][3], int const b[], int size);
 
 #else
-#define debug_print(...)
-#define debug_print_matrix_d3(a)
-#define debug_print_matrix_i3(a)
-#define debug_print_vector_d3(a)
-#define debug_print_vectors_d3(...)
-#define debug_print_vectors_with_label(...)
+    #define debug_print(...)
+    #define debug_print_matrix_d3(a)
+    #define debug_print_matrix_i3(a)
+    #define debug_print_vector_d3(a)
+    #define debug_print_vectors_d3(...)
+    #define debug_print_vectors_with_label(...)
 #endif
 
 #ifdef SPGWARNING
-#define warning_print(...) fprintf(stderr, __VA_ARGS__)
+    #define warning_print(...) fprintf(stderr, __VA_ARGS__)
 #else
-#define warning_print(...)
+    #define warning_print(...)
 #endif
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -48,11 +48,11 @@
     dbg_print_vectors_with_label(__VA_ARGS__)
 
 // Just to make sure these are never used, these definitions are #ifdef guarded
-void dbg_print_matrix_d3(const double a[3][3]);
-void dbg_print_matrix_i3(const int a[3][3]);
-void dbg_print_vector_d3(const double a[3]);
-void dbg_print_vectors_d3(const double a[][3], int size);
-void dbg_print_vectors_with_label(const double a[][3], const int b[], int size);
+void dbg_print_matrix_d3(double const a[3][3]);
+void dbg_print_matrix_i3(int const a[3][3]);
+void dbg_print_vector_d3(double const a[3]);
+void dbg_print_vectors_d3(double const a[][3], int size);
+void dbg_print_vectors_with_label(double const a[][3], int const b[], int size);
 
 #else
 #define debug_print(...)

--- a/src/delaunay.c
+++ b/src/delaunay.c
@@ -46,26 +46,26 @@
 
 static int get_num_attempts();
 
-static int delaunay_reduce(double red_lattice[3][3], const double lattice[3][3],
-                           const int aperiodic_axis, const double symprec);
-static int delaunay_reduce_basis(double basis[4][3], const int lattice_rank,
-                                 const double symprec);
+static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
+                           int const aperiodic_axis, double const symprec);
+static int delaunay_reduce_basis(double basis[4][3], int const lattice_rank,
+                                 double const symprec);
 static void get_delaunay_shortest_vectors(double basis[4][3],
-                                          const int lattice_rank,
-                                          const double symprec);
-static int get_extended_basis(double basis[4][3], const double lattice[3][3],
-                              const int aperiodic_axis);
-static int delaunay_reduce_basis_2D(double basis[3][3], const int lattice_rank,
-                                    const double symprec);
+                                          int const lattice_rank,
+                                          double const symprec);
+static int get_extended_basis(double basis[4][3], double const lattice[3][3],
+                              int const aperiodic_axis);
+static int delaunay_reduce_basis_2D(double basis[3][3], int const lattice_rank,
+                                    double const symprec);
 static void get_delaunay_shortest_vectors_2D(double basis[3][3],
-                                             const double unique_vec[3],
-                                             const int lattice_rank,
-                                             const double symprec);
+                                             double const unique_vec[3],
+                                             int const lattice_rank,
+                                             double const symprec);
 static void get_extended_basis_2D(double basis[3][3],
-                                  const double lattice[3][2]);
+                                  double const lattice[3][2]);
 
 int get_num_attempts() {
-    const char *num_attempts_str = getenv("SPGLIB_NUM_ATTEMPTS");
+    char const *num_attempts_str = getenv("SPGLIB_NUM_ATTEMPTS");
     if (num_attempts_str != NULL) {
         // Try to parse the string as an integer
         char *end;
@@ -82,8 +82,8 @@ int get_num_attempts() {
 }
 
 /* Return 0 if failed */
-int del_delaunay_reduce(double min_lattice[3][3], const double lattice[3][3],
-                        const double symprec) {
+int del_delaunay_reduce(double min_lattice[3][3], double const lattice[3][3],
+                        double const symprec) {
     debug_print("del_delaunay_reduce (tolerance = %f):\n", symprec);
 
     return delaunay_reduce(min_lattice, lattice, -1, symprec);
@@ -91,8 +91,8 @@ int del_delaunay_reduce(double min_lattice[3][3], const double lattice[3][3],
 
 /* Return 0 if failed */
 int del_layer_delaunay_reduce(double min_lattice[3][3],
-                              const double lattice[3][3],
-                              const int aperiodic_axis, const double symprec) {
+                              double const lattice[3][3],
+                              int const aperiodic_axis, double const symprec) {
     debug_print("del_layer_delaunay_reduce (tolerance = %f):\n", symprec);
 
     return delaunay_reduce(min_lattice, lattice, aperiodic_axis, symprec);
@@ -101,8 +101,8 @@ int del_layer_delaunay_reduce(double min_lattice[3][3],
 /* Delaunay reduction */
 /* Reference can be found in International table A. */
 /* Return 0 if failed */
-static int delaunay_reduce(double red_lattice[3][3], const double lattice[3][3],
-                           const int aperiodic_axis, const double symprec) {
+static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
+                           int const aperiodic_axis, double const symprec) {
     int succeeded, lattice_rank;
     int tmp_mat_int[3][3];
     double volume;
@@ -182,8 +182,8 @@ err:
 //        exists, find the shortest two vectors inside period plane and the
 //        shortest one outside.
 static void get_delaunay_shortest_vectors(double basis[4][3],
-                                          const int lattice_rank,
-                                          const double symprec) {
+                                          int const lattice_rank,
+                                          double const symprec) {
     int i, j;
     double tmpmat[3][3], b[7][3], tmpvec[3];
 
@@ -279,8 +279,8 @@ static void get_delaunay_shortest_vectors(double basis[4][3],
 
 // If `lattice_rank==2`, assume `basis[2]` (b3) is along aperiodic axis.
 // TODO: Change `lattice_rank` to a more informative variable
-static int delaunay_reduce_basis(double basis[4][3], const int lattice_rank,
-                                 const double symprec) {
+static int delaunay_reduce_basis(double basis[4][3], int const lattice_rank,
+                                 double const symprec) {
     int i, j, k, l;
     double dot_product;
 
@@ -327,8 +327,8 @@ static int delaunay_reduce_basis(double basis[4][3], const int lattice_rank,
 // @brief Get extended basis for three-dimensional Delaunay reduction.
 //        If exists, `aperiodic_axis` is temporarily moved to b3 (`basis[2]`).
 // @return lattice_rank Rank of `lattice`
-static int get_extended_basis(double basis[4][3], const double lattice[3][3],
-                              const int aperiodic_axis) {
+static int get_extended_basis(double basis[4][3], double const lattice[3][3],
+                              int const aperiodic_axis) {
     int i, j, lattice_rank;
 
     if (aperiodic_axis == -1) {
@@ -362,10 +362,10 @@ static int get_extended_basis(double basis[4][3], const double lattice[3][3],
 }
 
 int del_layer_delaunay_reduce_2D(double red_lattice[3][3],
-                                 const double lattice[3][3],
-                                 const int unique_axis,
-                                 const int aperiodic_axis,
-                                 const double symprec) {
+                                 double const lattice[3][3],
+                                 int const unique_axis,
+                                 int const aperiodic_axis,
+                                 double const symprec) {
     int succeeded, lattice_rank;
     double volume;
     double basis[3][3], lattice_2D[3][2], unique_vec[3];
@@ -448,8 +448,8 @@ err:
     return 0;
 }
 
-static int delaunay_reduce_basis_2D(double basis[3][3], const int lattice_rank,
-                                    const double symprec) {
+static int delaunay_reduce_basis_2D(double basis[3][3], int const lattice_rank,
+                                    double const symprec) {
     int i, j, k, l;
     double dot_product;
 
@@ -488,9 +488,9 @@ static int delaunay_reduce_basis_2D(double basis[3][3], const int lattice_rank,
 }
 
 static void get_delaunay_shortest_vectors_2D(double basis[3][3],
-                                             const double unique_vec[3],
-                                             const int lattice_rank,
-                                             const double symprec) {
+                                             double const unique_vec[3],
+                                             int const lattice_rank,
+                                             double const symprec) {
     int i, j;
     double b[4][3], tmpmat[3][3];
     double tmpvec[3];
@@ -538,7 +538,7 @@ static void get_delaunay_shortest_vectors_2D(double basis[3][3],
 }
 
 static void get_extended_basis_2D(double basis[3][3],
-                                  const double lattice[3][2]) {
+                                  double const lattice[3][2]) {
     int i, j;
 
     for (i = 0; i < 2; i++) {

--- a/src/delaunay.h
+++ b/src/delaunay.h
@@ -39,12 +39,12 @@
 #include "mathfunc.h"
 
 SPG_API_TEST int del_delaunay_reduce(double lattice_new[3][3],
-                                     const double lattice[3][3],
-                                     const double symprec);
+                                     double const lattice[3][3],
+                                     double const symprec);
 SPG_API_TEST int del_layer_delaunay_reduce(double min_lattice[3][3],
-                                           const double lattice[3][3],
-                                           const int aperiodic_axis,
-                                           const double symprec);
+                                           double const lattice[3][3],
+                                           int const aperiodic_axis,
+                                           double const symprec);
 
 // @brief Delaunay reduction for monoclinic/oblique or monoclinic/rectangular
 // @param[out] red_lattice
@@ -59,9 +59,9 @@ SPG_API_TEST int del_layer_delaunay_reduce(double min_lattice[3][3],
 //       k(=aperiodic_axis)}. j and k are delaunay reduced, which can be
 //       incomplete for Monoclinic/Rectangular
 int del_layer_delaunay_reduce_2D(double min_lattice[3][3],
-                                 const double lattice[3][3],
-                                 const int unique_axis,
-                                 const int aperiodic_axis,
-                                 const double symprec);
+                                 double const lattice[3][3],
+                                 int const unique_axis,
+                                 int const aperiodic_axis,
+                                 double const symprec);
 
 #endif

--- a/src/determination.c
+++ b/src/determination.c
@@ -48,14 +48,14 @@
 #define ANGLE_REDUCE_RATE 0.95
 #define NUM_ATTEMPT 20
 
-static DataContainer *get_spacegroup_and_primitive(const Cell *cell,
-                                                   const int hall_number,
-                                                   const double symprec,
-                                                   const double angle_symprec);
+static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
+                                                   int const hall_number,
+                                                   double const symprec,
+                                                   double const angle_symprec);
 
-DataContainer *det_determine_all(const Cell *cell, const int hall_number,
-                                 const double symprec,
-                                 const double angle_symprec) {
+DataContainer *det_determine_all(Cell const *cell, int const hall_number,
+                                 double const symprec,
+                                 double const angle_symprec) {
     int attempt;
     double tolerance;
     DataContainer *container;
@@ -109,10 +109,10 @@ void det_free_container(DataContainer *container) {
 }
 
 /* NULL is returned if failed */
-static DataContainer *get_spacegroup_and_primitive(const Cell *cell,
-                                                   const int hall_number,
-                                                   const double symprec,
-                                                   const double angle_symprec) {
+static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
+                                                   int const hall_number,
+                                                   double const symprec,
+                                                   double const angle_symprec) {
     int attempt;
     double tolerance, angle_tolerance;
     DataContainer *container;

--- a/src/determination.h
+++ b/src/determination.h
@@ -46,9 +46,9 @@ typedef struct {
     ExactStructure *exact_structure;
 } DataContainer;
 
-DataContainer *det_determine_all(const Cell *cell, const int hall_number,
-                                 const double symprec,
-                                 const double angle_symprec);
+DataContainer *det_determine_all(Cell const *cell, int const hall_number,
+                                 double const symprec,
+                                 double const angle_symprec);
 void det_free_container(DataContainer *container);
 
 #endif

--- a/src/hall_symbol.c
+++ b/src/hall_symbol.c
@@ -8522,80 +8522,80 @@ static int cubic_generators[][3][9] = {
 };
 
 static int find_hall_symbol(double origin_shift[3],
-                            const double bravais_lattice[3][3],
-                            const int hall_number, const Centering centering,
-                            const Symmetry *symmetry, const double symprec);
-static int is_hall_symbol(double shift[3], const int hall_number,
-                          const double primitive_lattice[3][3],
-                          const Symmetry *symmetry, const Centering centering,
-                          const int generators[3][9], const double VSpU[3][9],
-                          const double symprec);
-static int is_hall_symbol_cubic(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec);
-static int is_hall_symbol_hexa(double shift[3], const int hall_number,
-                               const double primitive_lattice[3][3],
-                               const Symmetry *symmetry, const double symprec);
-static int is_hall_symbol_rhombo(double shift[3], const int hall_number,
-                                 const double primitive_lattice[3][3],
-                                 const Symmetry *symmetry,
-                                 const double symprec);
-static int is_hall_symbol_trigonal(double shift[3], const int hall_number,
-                                   const double primitive_lattice[3][3],
-                                   const Symmetry *symmetry,
-                                   const double symprec);
-static int is_hall_symbol_tetra(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec);
-static int is_hall_symbol_ortho(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec);
-static int is_hall_symbol_monocli(double shift[3], const int hall_number,
-                                  const double primitive_lattice[3][3],
-                                  const Symmetry *symmetry,
-                                  const Centering centering,
-                                  const double symprec);
-static int is_hall_symbol_tricli(double shift[3], const int hall_number,
-                                 const double primitive_lattice[3][3],
-                                 const Symmetry *symmetry,
-                                 const double symprec);
-static int get_translations(double trans[3][3], const Symmetry *symmetry,
-                            const int rot[3][3][3]);
+                            double const bravais_lattice[3][3],
+                            int const hall_number, Centering const centering,
+                            Symmetry const *symmetry, double const symprec);
+static int is_hall_symbol(double shift[3], int const hall_number,
+                          double const primitive_lattice[3][3],
+                          Symmetry const *symmetry, Centering const centering,
+                          int const generators[3][9], double const VSpU[3][9],
+                          double const symprec);
+static int is_hall_symbol_cubic(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec);
+static int is_hall_symbol_hexa(double shift[3], int const hall_number,
+                               double const primitive_lattice[3][3],
+                               Symmetry const *symmetry, double const symprec);
+static int is_hall_symbol_rhombo(double shift[3], int const hall_number,
+                                 double const primitive_lattice[3][3],
+                                 Symmetry const *symmetry,
+                                 double const symprec);
+static int is_hall_symbol_trigonal(double shift[3], int const hall_number,
+                                   double const primitive_lattice[3][3],
+                                   Symmetry const *symmetry,
+                                   double const symprec);
+static int is_hall_symbol_tetra(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec);
+static int is_hall_symbol_ortho(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec);
+static int is_hall_symbol_monocli(double shift[3], int const hall_number,
+                                  double const primitive_lattice[3][3],
+                                  Symmetry const *symmetry,
+                                  Centering const centering,
+                                  double const symprec);
+static int is_hall_symbol_tricli(double shift[3], int const hall_number,
+                                 double const primitive_lattice[3][3],
+                                 Symmetry const *symmetry,
+                                 double const symprec);
+static int get_translations(double trans[3][3], Symmetry const *symmetry,
+                            int const rot[3][3][3]);
 static void transform_translation(double trans_reduced[3],
-                                  const Centering centering,
-                                  const double trans[3]);
+                                  Centering const centering,
+                                  double const trans[3]);
 static void transform_rotation(double rot_reduced[3][3],
-                               const Centering centering, const int rot[3][3]);
-static int get_origin_shift(double shift[3], const int hall_number,
-                            const int rot[3][3][3], const double trans[3][3],
-                            const Centering centering, const double VSpU[3][9]);
-static void unpack_generators(int rot[3][3][3], const int generators[3][9]);
-static int set_dw(double dw[3], const int operation_index[2],
-                  const int rot[3][3], const double trans[3],
-                  const Centering centering);
-static int is_match_database(const int hall_number, const double shift[3],
-                             const double primitive_lattice[3][3],
-                             const Centering centering,
-                             const Symmetry *symmetry, const double symprec);
+                               Centering const centering, int const rot[3][3]);
+static int get_origin_shift(double shift[3], int const hall_number,
+                            int const rot[3][3][3], double const trans[3][3],
+                            Centering const centering, double const VSpU[3][9]);
+static void unpack_generators(int rot[3][3][3], int const generators[3][9]);
+static int set_dw(double dw[3], int const operation_index[2],
+                  int const rot[3][3], double const trans[3],
+                  Centering const centering);
+static int is_match_database(int const hall_number, double const shift[3],
+                             double const primitive_lattice[3][3],
+                             Centering const centering,
+                             Symmetry const *symmetry, double const symprec);
 
 int hal_match_hall_symbol_db(double origin_shift[3],
-                             const double bravais_lattice[3][3],
-                             const int hall_number, const Centering centering,
-                             const Symmetry *symmetry, const double symprec) {
+                             double const bravais_lattice[3][3],
+                             int const hall_number, Centering const centering,
+                             Symmetry const *symmetry, double const symprec) {
     return find_hall_symbol(origin_shift, bravais_lattice, hall_number,
                             centering, symmetry, symprec);
 }
 
 static int find_hall_symbol(double origin_shift[3],
-                            const double bravais_lattice[3][3],
-                            const int hall_number, const Centering centering,
-                            const Symmetry *symmetry, const double symprec) {
+                            double const bravais_lattice[3][3],
+                            int const hall_number, Centering const centering,
+                            Symmetry const *symmetry, double const symprec) {
     double primitive_lattice[3][3];
 
     switch (centering) {
@@ -8741,11 +8741,11 @@ found:
     return 1;
 }
 
-static int is_hall_symbol_cubic(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec) {
+static int is_hall_symbol_cubic(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec) {
     int i;
 
     for (i = 0; i < 10; i++) {
@@ -8780,9 +8780,9 @@ found:
     return 1;
 }
 
-static int is_hall_symbol_hexa(double shift[3], const int hall_number,
-                               const double primitive_lattice[3][3],
-                               const Symmetry *symmetry, const double symprec) {
+static int is_hall_symbol_hexa(double shift[3], int const hall_number,
+                               double const primitive_lattice[3][3],
+                               Symmetry const *symmetry, double const symprec) {
     int i;
 
     for (i = 0; i < 8; i++) {
@@ -8796,10 +8796,10 @@ static int is_hall_symbol_hexa(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_trigonal(double shift[3], const int hall_number,
-                                   const double primitive_lattice[3][3],
-                                   const Symmetry *symmetry,
-                                   const double symprec) {
+static int is_hall_symbol_trigonal(double shift[3], int const hall_number,
+                                   double const primitive_lattice[3][3],
+                                   Symmetry const *symmetry,
+                                   double const symprec) {
     int i;
 
     for (i = 0; i < 13; i++) {
@@ -8813,10 +8813,10 @@ static int is_hall_symbol_trigonal(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_rhombo(double shift[3], const int hall_number,
-                                 const double primitive_lattice[3][3],
-                                 const Symmetry *symmetry,
-                                 const double symprec) {
+static int is_hall_symbol_rhombo(double shift[3], int const hall_number,
+                                 double const primitive_lattice[3][3],
+                                 Symmetry const *symmetry,
+                                 double const symprec) {
     int i;
 
     if (hall_number == 433 || hall_number == 436 || hall_number == 444 ||
@@ -8844,11 +8844,11 @@ static int is_hall_symbol_rhombo(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_tetra(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec) {
+static int is_hall_symbol_tetra(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec) {
     int i;
 
     for (i = 0; i < 8; i++) {
@@ -8872,11 +8872,11 @@ static int is_hall_symbol_tetra(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_ortho(double shift[3], const int hall_number,
-                                const double primitive_lattice[3][3],
-                                const Symmetry *symmetry,
-                                const Centering centering,
-                                const double symprec) {
+static int is_hall_symbol_ortho(double shift[3], int const hall_number,
+                                double const primitive_lattice[3][3],
+                                Symmetry const *symmetry,
+                                Centering const centering,
+                                double const symprec) {
     int i;
 
     for (i = 0; i < 5; i++) {
@@ -8932,11 +8932,11 @@ static int is_hall_symbol_ortho(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_monocli(double shift[3], const int hall_number,
-                                  const double primitive_lattice[3][3],
-                                  const Symmetry *symmetry,
-                                  const Centering centering,
-                                  const double symprec) {
+static int is_hall_symbol_monocli(double shift[3], int const hall_number,
+                                  double const primitive_lattice[3][3],
+                                  Symmetry const *symmetry,
+                                  Centering const centering,
+                                  double const symprec) {
     int i;
 
     for (i = 0; i < 9; i++) {
@@ -8984,10 +8984,10 @@ static int is_hall_symbol_monocli(double shift[3], const int hall_number,
     return 0;
 }
 
-static int is_hall_symbol_tricli(double shift[3], const int hall_number,
-                                 const double primitive_lattice[3][3],
-                                 const Symmetry *symmetry,
-                                 const double symprec) {
+static int is_hall_symbol_tricli(double shift[3], int const hall_number,
+                                 double const primitive_lattice[3][3],
+                                 Symmetry const *symmetry,
+                                 double const symprec) {
     int i;
 
     for (i = 0; i < 2; i++) {
@@ -9001,7 +9001,7 @@ static int is_hall_symbol_tricli(double shift[3], const int hall_number,
     return 0;
 }
 
-static void unpack_generators(int rot[3][3][3], const int generators[3][9]) {
+static void unpack_generators(int rot[3][3][3], int const generators[3][9]) {
     int i, j, k;
     for (i = 0; i < 3; i++) {
         for (j = 0; j < 3; j++) {
@@ -9012,11 +9012,11 @@ static void unpack_generators(int rot[3][3][3], const int generators[3][9]) {
     }
 }
 
-static int is_hall_symbol(double shift[3], const int hall_number,
-                          const double primitive_lattice[3][3],
-                          const Symmetry *symmetry, const Centering centering,
-                          const int generators[3][9], const double VSpU[3][9],
-                          const double symprec) {
+static int is_hall_symbol(double shift[3], int const hall_number,
+                          double const primitive_lattice[3][3],
+                          Symmetry const *symmetry, Centering const centering,
+                          int const generators[3][9], double const VSpU[3][9],
+                          double const symprec) {
     int is_origin_shift;
     int operation_index[2];
     int rot[3][3][3];
@@ -9058,11 +9058,11 @@ found:
     return 1;
 }
 
-static int get_translations(double trans[3][3], const Symmetry *symmetry,
-                            const int rot[3][3][3]) {
+static int get_translations(double trans[3][3], Symmetry const *symmetry,
+                            int const rot[3][3][3]) {
     int i, j;
     int is_found;
-    static const int zero[3][3] = {
+    static int const zero[3][3] = {
         {0, 0, 0},
         {0, 0, 0},
         {0, 0, 0},
@@ -9099,8 +9099,8 @@ not_found:
 }
 
 static void transform_translation(double trans_reduced[3],
-                                  const Centering centering,
-                                  const double trans[3]) {
+                                  Centering const centering,
+                                  double const trans[3]) {
     /* This is done in get_origin_shift
     int i;
     */
@@ -9139,7 +9139,7 @@ static void transform_translation(double trans_reduced[3],
 }
 
 static void transform_rotation(double rot_reduced[3][3],
-                               const Centering centering, const int rot[3][3]) {
+                               Centering const centering, int const rot[3][3]) {
     mat_cast_matrix_3i_to_3d(rot_reduced, rot);
     if (centering != PRIMITIVE) {
         switch (centering) {
@@ -9173,10 +9173,10 @@ static void transform_rotation(double rot_reduced[3][3],
     }
 }
 
-static int get_origin_shift(double shift[3], const int hall_number,
-                            const int rot[3][3][3], const double trans[3][3],
-                            const Centering centering,
-                            const double VSpU[3][9]) {
+static int get_origin_shift(double shift[3], int const hall_number,
+                            int const rot[3][3][3], double const trans[3][3],
+                            Centering const centering,
+                            double const VSpU[3][9]) {
     int i, j;
     int operation_index[2];
     double dw[9], tmp_dw[3];
@@ -9220,9 +9220,9 @@ not_found:
     return 0;
 }
 
-static int set_dw(double dw[3], const int operation_index[2],
-                  const int rot[3][3], const double trans[3],
-                  const Centering centering) {
+static int set_dw(double dw[3], int const operation_index[2],
+                  int const rot[3][3], double const trans[3],
+                  Centering const centering) {
     int i, j;
     int rot_db[3][3];
     double trans_db[3], trans_prim[3], trans_db_prim[3];
@@ -9247,11 +9247,11 @@ found:
     return 1;
 }
 
-static int is_match_database(const int hall_number,
-                             const double origin_shift[3],
-                             const double primitive_lattice[3][3],
-                             const Centering centering,
-                             const Symmetry *symmetry, const double symprec) {
+static int is_match_database(int const hall_number,
+                             double const origin_shift[3],
+                             double const primitive_lattice[3][3],
+                             Centering const centering,
+                             Symmetry const *symmetry, double const symprec) {
     int i, j, k, is_found;
     int operation_index[2];
     int rot_db[3][3];

--- a/src/hall_symbol.h
+++ b/src/hall_symbol.h
@@ -40,8 +40,8 @@
 #include "symmetry.h"
 
 int hal_match_hall_symbol_db(double origin_shift[3],
-                             const double bravais_lattice[3][3],
-                             const int hall_number, const Centering centering,
-                             const Symmetry *symmetry, const double symprec);
+                             double const bravais_lattice[3][3],
+                             int const hall_number, Centering const centering,
+                             Symmetry const *symmetry, double const symprec);
 
 #endif

--- a/src/kgrid.c
+++ b/src/kgrid.c
@@ -37,32 +37,32 @@
 #include <assert.h>
 #include <stddef.h>
 
-static void get_all_grid_addresses(int grid_address[][3], const int mesh[3]);
-static size_t get_grid_point_double_mesh(const int address_double[3],
-                                         const int mesh[3]);
-static size_t get_grid_point_single_mesh(const int address[3],
-                                         const int mesh[3]);
-static void modulo_i3(int v[3], const int m[3]);
-static void reduce_grid_address(int address[3], const int mesh[3]);
-static void reduce_grid_address_double(int address[3], const int mesh[3]);
+static void get_all_grid_addresses(int grid_address[][3], int const mesh[3]);
+static size_t get_grid_point_double_mesh(int const address_double[3],
+                                         int const mesh[3]);
+static size_t get_grid_point_single_mesh(int const address[3],
+                                         int const mesh[3]);
+static void modulo_i3(int v[3], int const m[3]);
+static void reduce_grid_address(int address[3], int const mesh[3]);
+static void reduce_grid_address_double(int address[3], int const mesh[3]);
 
-void kgd_get_all_grid_addresses(int grid_address[][3], const int mesh[3]) {
+void kgd_get_all_grid_addresses(int grid_address[][3], int const mesh[3]) {
     get_all_grid_addresses(grid_address, mesh);
 }
 
-int kgd_get_grid_point_double_mesh(const int address_double[3],
-                                   const int mesh[3]) {
+int kgd_get_grid_point_double_mesh(int const address_double[3],
+                                   int const mesh[3]) {
     return get_grid_point_double_mesh(address_double, mesh);
 }
 
-size_t kgd_get_dense_grid_point_double_mesh(const int address_double[3],
-                                            const int mesh[3]) {
+size_t kgd_get_dense_grid_point_double_mesh(int const address_double[3],
+                                            int const mesh[3]) {
     return get_grid_point_double_mesh(address_double, mesh);
 }
 
 void kgd_get_grid_address_double_mesh(int address_double[3],
-                                      const int address[3], const int mesh[3],
-                                      const int is_shift[3]) {
+                                      int const address[3], int const mesh[3],
+                                      int const is_shift[3]) {
     int i;
 
     for (i = 0; i < 3; i++) {
@@ -71,7 +71,7 @@ void kgd_get_grid_address_double_mesh(int address_double[3],
     reduce_grid_address_double(address_double, mesh);
 }
 
-static void get_all_grid_addresses(int grid_address[][3], const int mesh[3]) {
+static void get_all_grid_addresses(int grid_address[][3], int const mesh[3]) {
     int i, j, k;
     size_t grid_point;
     int address[3];
@@ -95,8 +95,8 @@ static void get_all_grid_addresses(int grid_address[][3], const int mesh[3]) {
     }
 }
 
-static size_t get_grid_point_double_mesh(const int address_double[3],
-                                         const int mesh[3]) {
+static size_t get_grid_point_double_mesh(int const address_double[3],
+                                         int const mesh[3]) {
     int i;
     int address[3];
 
@@ -112,8 +112,8 @@ static size_t get_grid_point_double_mesh(const int address_double[3],
     return get_grid_point_single_mesh(address, mesh);
 }
 
-static size_t get_grid_point_single_mesh(const int address[3],
-                                         const int mesh[3]) {
+static size_t get_grid_point_single_mesh(int const address[3],
+                                         int const mesh[3]) {
 #ifndef GRID_ORDER_XYZ
     return (address[2] * mesh[0] * (size_t)(mesh[1]) + address[1] * mesh[0] +
             address[0]);
@@ -123,7 +123,7 @@ static size_t get_grid_point_single_mesh(const int address[3],
 #endif
 }
 
-static void modulo_i3(int v[3], const int m[3]) {
+static void modulo_i3(int v[3], int const m[3]) {
     int i;
 
     for (i = 0; i < 3; i++) {
@@ -135,7 +135,7 @@ static void modulo_i3(int v[3], const int m[3]) {
     }
 }
 
-static void reduce_grid_address(int address[3], const int mesh[3]) {
+static void reduce_grid_address(int address[3], int const mesh[3]) {
     int i;
 
     for (i = 0; i < 3; i++) {
@@ -147,7 +147,7 @@ static void reduce_grid_address(int address[3], const int mesh[3]) {
     }
 }
 
-static void reduce_grid_address_double(int address[3], const int mesh[3]) {
+static void reduce_grid_address_double(int address[3], int const mesh[3]) {
     int i;
 
     for (i = 0; i < 3; i++) {

--- a/src/kgrid.h
+++ b/src/kgrid.h
@@ -72,13 +72,13 @@
 /* without GRID_BOUNDARY_AS_NEGATIVE, e.g., [-2, -1, 0, 1, 2, 3]. */
 /* with GRID_BOUNDARY_AS_NEGATIVE, e.g., [-3, -2, -1, 0, 1, 2]. */
 
-void kgd_get_all_grid_addresses(int grid_address[][3], const int mesh[3]);
-int kgd_get_grid_point_double_mesh(const int address_double[3],
-                                   const int mesh[3]);
-size_t kgd_get_dense_grid_point_double_mesh(const int address_double[3],
-                                            const int mesh[3]);
+void kgd_get_all_grid_addresses(int grid_address[][3], int const mesh[3]);
+int kgd_get_grid_point_double_mesh(int const address_double[3],
+                                   int const mesh[3]);
+size_t kgd_get_dense_grid_point_double_mesh(int const address_double[3],
+                                            int const mesh[3]);
 void kgd_get_grid_address_double_mesh(int address_double[3],
-                                      const int address[3], const int mesh[3],
-                                      const int is_shift[3]);
+                                      int const address[3], int const mesh[3],
+                                      int const is_shift[3]);
 
 #endif

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -77,33 +77,33 @@ static int bz_search_space[KPT_NUM_BZ_SEARCH_SPACE][3] = {
     {-1, -2, 0}, {-1, -2, 1}, {-1, -2, 2}, {-1, -2, -2}, {-1, -2, -1},
     {-1, -1, 0}, {-1, -1, 1}, {-1, -1, 2}, {-1, -1, -2}, {-1, -1, -1}};
 
-static MatINT *get_point_group_reciprocal(const MatINT *rotations,
-                                          const int is_time_reversal);
-static MatINT *get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
-                                                 const double symprec,
-                                                 const size_t num_q,
-                                                 const double qpoints[][3]);
+static MatINT *get_point_group_reciprocal(MatINT const *rotations,
+                                          int const is_time_reversal);
+static MatINT *get_point_group_reciprocal_with_q(MatINT const *rot_reciprocal,
+                                                 double const symprec,
+                                                 size_t const num_q,
+                                                 double const qpoints[][3]);
 static size_t get_dense_ir_reciprocal_mesh(int grid_address[][3],
                                            size_t ir_mapping_table[],
-                                           const int mesh[3],
-                                           const int is_shift[3],
-                                           const MatINT *rot_reciprocal);
+                                           int const mesh[3],
+                                           int const is_shift[3],
+                                           MatINT const *rot_reciprocal);
 static size_t get_dense_ir_reciprocal_mesh_normal(int grid_address[][3],
                                                   size_t ir_mapping_table[],
-                                                  const int mesh[3],
-                                                  const int is_shift[3],
-                                                  const MatINT *rot_reciprocal);
+                                                  int const mesh[3],
+                                                  int const is_shift[3],
+                                                  MatINT const *rot_reciprocal);
 static size_t get_dense_ir_reciprocal_mesh_distortion(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const MatINT *rot_reciprocal);
-static size_t get_dense_num_ir(size_t ir_mapping_table[], const int mesh[3]);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], MatINT const *rot_reciprocal);
+static size_t get_dense_num_ir(size_t ir_mapping_table[], int const mesh[3]);
 static size_t relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]);
-static double get_tolerance_for_BZ_reduction(const double rec_lattice[3][3],
-                                             const int mesh[3]);
-static int check_mesh_symmetry(const int mesh[3], const int is_shift[3],
-                               const MatINT *rot_reciprocal);
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]);
+static double get_tolerance_for_BZ_reduction(double const rec_lattice[3][3],
+                                             int const mesh[3]);
+static int check_mesh_symmetry(int const mesh[3], int const is_shift[3],
+                               MatINT const *rot_reciprocal);
 
 /* grid_address (e.g. 4x4x4 mesh, unless GRID_ORDER_XYZ is defined) */
 /*    [[ 0  0  0]                                                   */
@@ -119,9 +119,9 @@ static int check_mesh_symmetry(const int mesh[3], const int is_shift[3],
 /* Each value of 'map' corresponds to the index of grid_point.      */
 int kpt_get_irreducible_reciprocal_mesh(int grid_address[][3],
                                         int ir_mapping_table[],
-                                        const int mesh[3],
-                                        const int is_shift[3],
-                                        const MatINT *rot_reciprocal) {
+                                        int const mesh[3],
+                                        int const is_shift[3],
+                                        MatINT const *rot_reciprocal) {
     int num_ir;
     size_t i;
     size_t *dense_ir_mapping_table;
@@ -147,9 +147,9 @@ int kpt_get_irreducible_reciprocal_mesh(int grid_address[][3],
 
 size_t kpt_get_dense_irreducible_reciprocal_mesh(int grid_address[][3],
                                                  size_t ir_mapping_table[],
-                                                 const int mesh[3],
-                                                 const int is_shift[3],
-                                                 const MatINT *rot_reciprocal) {
+                                                 int const mesh[3],
+                                                 int const is_shift[3],
+                                                 MatINT const *rot_reciprocal) {
     size_t num_ir;
 
     num_ir = get_dense_ir_reciprocal_mesh(grid_address, ir_mapping_table, mesh,
@@ -159,9 +159,9 @@ size_t kpt_get_dense_irreducible_reciprocal_mesh(int grid_address[][3],
 }
 
 int kpt_get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const MatINT *rotations,
-    const size_t num_q, const double qpoints[][3]) {
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, MatINT const *rotations,
+    size_t const num_q, double const qpoints[][3]) {
     int num_ir;
     size_t i;
     size_t *dense_ir_mapping_table;
@@ -187,9 +187,9 @@ int kpt_get_stabilized_reciprocal_mesh(
 }
 
 size_t kpt_get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const MatINT *rotations,
-    const size_t num_q, const double qpoints[][3]) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, MatINT const *rotations,
+    size_t const num_q, double const qpoints[][3]) {
     size_t num_ir;
     MatINT *rot_reciprocal, *rot_reciprocal_q;
     double tolerance;
@@ -213,11 +213,11 @@ size_t kpt_get_dense_stabilized_reciprocal_mesh(
 }
 
 void kpt_get_dense_grid_points_by_rotations(size_t rot_grid_points[],
-                                            const int address_orig[3],
-                                            const int (*rot_reciprocal)[3][3],
-                                            const int num_rot,
-                                            const int mesh[3],
-                                            const int is_shift[3]) {
+                                            int const address_orig[3],
+                                            int const (*rot_reciprocal)[3][3],
+                                            int const num_rot,
+                                            int const mesh[3],
+                                            int const is_shift[3]) {
     int i;
     int address_double_orig[3], address_double[3];
 
@@ -233,9 +233,9 @@ void kpt_get_dense_grid_points_by_rotations(size_t rot_grid_points[],
 }
 
 void kpt_get_dense_BZ_grid_points_by_rotations(
-    size_t rot_grid_points[], const int address_orig[3],
-    const int (*rot_reciprocal)[3][3], const int num_rot, const int mesh[3],
-    const int is_shift[3], const size_t bz_map[]) {
+    size_t rot_grid_points[], int const address_orig[3],
+    int const (*rot_reciprocal)[3][3], int const num_rot, int const mesh[3],
+    int const is_shift[3], size_t const bz_map[]) {
     int i;
     int address_double_orig[3], address_double[3], bzmesh[3];
 
@@ -252,9 +252,9 @@ void kpt_get_dense_BZ_grid_points_by_rotations(
 }
 
 int kpt_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
-                                 const int grid_address[][3], const int mesh[3],
-                                 const double rec_lattice[3][3],
-                                 const int is_shift[3]) {
+                                 int const grid_address[][3], int const mesh[3],
+                                 double const rec_lattice[3][3],
+                                 int const is_shift[3]) {
     int num_bzgp;
     size_t i, num_bz_map;
     size_t *dense_bz_map;
@@ -286,32 +286,32 @@ int kpt_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
 }
 
 size_t kpt_relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]) {
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]) {
     return relocate_dense_BZ_grid_address(bz_grid_address, bz_map, grid_address,
                                           mesh, rec_lattice, is_shift);
 }
 
-MatINT *kpt_get_point_group_reciprocal(const MatINT *rotations,
-                                       const int is_time_reversal) {
+MatINT *kpt_get_point_group_reciprocal(MatINT const *rotations,
+                                       int const is_time_reversal) {
     return get_point_group_reciprocal(rotations, is_time_reversal);
 }
 
-MatINT *kpt_get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
-                                              const double symprec,
-                                              const size_t num_q,
-                                              const double qpoints[][3]) {
+MatINT *kpt_get_point_group_reciprocal_with_q(MatINT const *rot_reciprocal,
+                                              double const symprec,
+                                              size_t const num_q,
+                                              double const qpoints[][3]) {
     return get_point_group_reciprocal_with_q(rot_reciprocal, symprec, num_q,
                                              qpoints);
 }
 
 /* Return NULL if failed */
-static MatINT *get_point_group_reciprocal(const MatINT *rotations,
-                                          const int is_time_reversal) {
+static MatINT *get_point_group_reciprocal(MatINT const *rotations,
+                                          int const is_time_reversal) {
     int i, j, num_rot;
     MatINT *rot_reciprocal, *rot_return;
     int *unique_rot;
-    const int inversion[3][3] = {{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}};
+    int const inversion[3][3] = {{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}};
 
     rot_reciprocal = NULL;
     rot_return = NULL;
@@ -377,10 +377,10 @@ static MatINT *get_point_group_reciprocal(const MatINT *rotations,
 }
 
 /* Return NULL if failed */
-static MatINT *get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
-                                                 const double symprec,
-                                                 const size_t num_q,
-                                                 const double qpoints[][3]) {
+static MatINT *get_point_group_reciprocal_with_q(MatINT const *rot_reciprocal,
+                                                 double const symprec,
+                                                 size_t const num_q,
+                                                 double const qpoints[][3]) {
     int i, l, is_all_ok, num_rot;
     size_t j, k;
     int *ir_rot;
@@ -446,9 +446,9 @@ static MatINT *get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
 
 static size_t get_dense_ir_reciprocal_mesh(int grid_address[][3],
                                            size_t ir_mapping_table[],
-                                           const int mesh[3],
-                                           const int is_shift[3],
-                                           const MatINT *rot_reciprocal) {
+                                           int const mesh[3],
+                                           int const is_shift[3],
+                                           MatINT const *rot_reciprocal) {
     if (check_mesh_symmetry(mesh, is_shift, rot_reciprocal)) {
         return get_dense_ir_reciprocal_mesh_normal(
             grid_address, ir_mapping_table, mesh, is_shift, rot_reciprocal);
@@ -459,8 +459,8 @@ static size_t get_dense_ir_reciprocal_mesh(int grid_address[][3],
 }
 
 static size_t get_dense_ir_reciprocal_mesh_normal(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const MatINT *rot_reciprocal) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], MatINT const *rot_reciprocal) {
     /* In the following loop, mesh is doubled. */
     /* Even and odd mesh numbers correspond to */
     /* is_shift[i] are 0 or 1, respectively. */
@@ -500,8 +500,8 @@ static size_t get_dense_ir_reciprocal_mesh_normal(
 }
 
 static size_t get_dense_ir_reciprocal_mesh_distortion(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const MatINT *rot_reciprocal) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], MatINT const *rot_reciprocal) {
     size_t i, grid_point_rot;
     int j, k, indivisible;
     int address_double[3], address_double_rot[3];
@@ -567,7 +567,7 @@ static size_t get_dense_ir_reciprocal_mesh_distortion(
     return get_dense_num_ir(ir_mapping_table, mesh);
 }
 
-static size_t get_dense_num_ir(size_t ir_mapping_table[], const int mesh[3]) {
+static size_t get_dense_num_ir(size_t ir_mapping_table[], int const mesh[3]) {
     size_t i, num_ir;
 
     num_ir = 0;
@@ -589,8 +589,8 @@ static size_t get_dense_num_ir(size_t ir_mapping_table[], const int mesh[3]) {
 }
 
 static size_t relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]) {
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]) {
     double tolerance, min_distance;
     double q_vector[3], distance[KPT_NUM_BZ_SEARCH_SPACE];
     int bzmesh[3], bz_address_double[3];
@@ -660,8 +660,8 @@ static size_t relocate_dense_BZ_grid_address(
     return boundary_num_gp + total_num_gp;
 }
 
-static double get_tolerance_for_BZ_reduction(const double rec_lattice[3][3],
-                                             const int mesh[3]) {
+static double get_tolerance_for_BZ_reduction(double const rec_lattice[3][3],
+                                             int const mesh[3]) {
     int i, j;
     double tolerance;
     double length[3];
@@ -684,8 +684,8 @@ static double get_tolerance_for_BZ_reduction(const double rec_lattice[3][3],
     return tolerance;
 }
 
-static int check_mesh_symmetry(const int mesh[3], const int is_shift[3],
-                               const MatINT *rot_reciprocal) {
+static int check_mesh_symmetry(int const mesh[3], int const is_shift[3],
+                               MatINT const *rot_reciprocal) {
     int i, j, k, sum;
     int eq[3];
 

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -42,10 +42,10 @@
 #include "mathfunc.h"
 
 #ifdef KPTWARNING
-#include <stdio.h>
-#define warning_print(...) fprintf(stderr, __VA_ARGS__)
+    #include <stdio.h>
+    #define warning_print(...) fprintf(stderr, __VA_ARGS__)
 #else
-#define warning_print(...)
+    #define warning_print(...)
 #endif
 
 #define KPT_NUM_BZ_SEARCH_SPACE 125

--- a/src/kpoint.h
+++ b/src/kpoint.h
@@ -41,44 +41,44 @@
 
 int kpt_get_irreducible_reciprocal_mesh(int grid_address[][3],
                                         int ir_mapping_table[],
-                                        const int mesh[3],
-                                        const int is_shift[3],
-                                        const MatINT *rot_reciprocal);
+                                        int const mesh[3],
+                                        int const is_shift[3],
+                                        MatINT const *rot_reciprocal);
 size_t kpt_get_dense_irreducible_reciprocal_mesh(int grid_address[][3],
                                                  size_t ir_mapping_table[],
-                                                 const int mesh[3],
-                                                 const int is_shift[3],
-                                                 const MatINT *rot_reciprocal);
+                                                 int const mesh[3],
+                                                 int const is_shift[3],
+                                                 MatINT const *rot_reciprocal);
 int kpt_get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const MatINT *rotations,
-    const size_t num_q, const double qpoints[][3]);
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, MatINT const *rotations,
+    size_t const num_q, double const qpoints[][3]);
 size_t kpt_get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const MatINT *rotations,
-    const size_t num_q, const double qpoints[][3]);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, MatINT const *rotations,
+    size_t const num_q, double const qpoints[][3]);
 void kpt_get_dense_grid_points_by_rotations(size_t rot_grid_points[],
-                                            const int address_orig[3],
-                                            const int (*rot_reciprocal)[3][3],
-                                            const int num_rot,
-                                            const int mesh[3],
-                                            const int is_shift[3]);
+                                            int const address_orig[3],
+                                            int const (*rot_reciprocal)[3][3],
+                                            int const num_rot,
+                                            int const mesh[3],
+                                            int const is_shift[3]);
 void kpt_get_dense_BZ_grid_points_by_rotations(
-    size_t rot_grid_points[], const int address_orig[3],
-    const int (*rot_reciprocal)[3][3], const int num_rot, const int mesh[3],
-    const int is_shift[3], const size_t bz_map[]);
+    size_t rot_grid_points[], int const address_orig[3],
+    int const (*rot_reciprocal)[3][3], int const num_rot, int const mesh[3],
+    int const is_shift[3], size_t const bz_map[]);
 int kpt_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
-                                 const int grid_address[][3], const int mesh[3],
-                                 const double rec_lattice[3][3],
-                                 const int is_shift[3]);
+                                 int const grid_address[][3], int const mesh[3],
+                                 double const rec_lattice[3][3],
+                                 int const is_shift[3]);
 size_t kpt_relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]);
-MatINT *kpt_get_point_group_reciprocal(const MatINT *rotations,
-                                       const int is_time_reversal);
-MatINT *kpt_get_point_group_reciprocal_with_q(const MatINT *rot_reciprocal,
-                                              const double symprec,
-                                              const size_t num_q,
-                                              const double qpoints[][3]);
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]);
+MatINT *kpt_get_point_group_reciprocal(MatINT const *rotations,
+                                       int const is_time_reversal);
+MatINT *kpt_get_point_group_reciprocal_with_q(MatINT const *rot_reciprocal,
+                                              double const symprec,
+                                              size_t const num_q,
+                                              double const qpoints[][3]);
 
 #endif

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -48,49 +48,49 @@
 static int get_reference_space_group(Spacegroup **ref_sg,
                                      MagneticSymmetry **changed_symmetry,
                                      double tmat[3][3], double shift[3],
-                                     const MagneticSymmetry *magnetic_symmetry,
-                                     const double symprec);
+                                     MagneticSymmetry const *magnetic_symmetry,
+                                     double const symprec);
 static Symmetry *get_family_space_group_with_magnetic_symmetry(
-    Spacegroup **fsg, const MagneticSymmetry *magnetic_symmetry,
-    const double symprec);
+    Spacegroup **fsg, MagneticSymmetry const *magnetic_symmetry,
+    double const symprec);
 static Symmetry *get_maximal_subspace_group_with_magnetic_symmetry(
-    Spacegroup **xsg, const MagneticSymmetry *magnetic_symmetry,
-    const double symprec);
+    Spacegroup **xsg, MagneticSymmetry const *magnetic_symmetry,
+    double const symprec);
 static Symmetry *get_space_group_with_magnetic_symmetry(
-    Spacegroup **spacegroup, const MagneticSymmetry *magnetic_symmetry,
-    const int ignore_time_reversal, const double symprec);
+    Spacegroup **spacegroup, MagneticSymmetry const *magnetic_symmetry,
+    int const ignore_time_reversal, double const symprec);
 static int get_magnetic_space_group_type(
     MagneticSymmetry **representative,
-    const MagneticSymmetry *magnetic_symmetry, const int num_sym_fsg,
-    const int num_sym_xsg);
+    MagneticSymmetry const *magnetic_symmetry, int const num_sym_fsg,
+    int const num_sym_xsg);
 static MagneticSymmetry *get_representative(
-    const MagneticSymmetry *magnetic_symmetry);
+    MagneticSymmetry const *magnetic_symmetry);
 static MagneticSymmetry *get_changed_magnetic_symmetry(
-    const double tmat[3][3], const double shift[3],
-    const MagneticSymmetry *representative, const Symmetry *sym_xsg,
-    const MagneticSymmetry *magnetic_symmetry, const double symprec);
-static VecDBL *get_changed_pure_translations(const double tmat[3][3],
-                                             const VecDBL *pure_trans,
-                                             const double symprec);
-static int is_contained_vec(const double v[3], const VecDBL *trans,
-                            const int size, const double symprec);
-static int is_contained_mat(const int a[3][3], const MagneticSymmetry *sym_msg,
-                            const int size);
+    double const tmat[3][3], double const shift[3],
+    MagneticSymmetry const *representative, Symmetry const *sym_xsg,
+    MagneticSymmetry const *magnetic_symmetry, double const symprec);
+static VecDBL *get_changed_pure_translations(double const tmat[3][3],
+                                             VecDBL const *pure_trans,
+                                             double const symprec);
+static int is_contained_vec(double const v[3], VecDBL const *trans,
+                            int const size, double const symprec);
+static int is_contained_mat(int const a[3][3], MagneticSymmetry const *sym_msg,
+                            int const size);
 static MagneticSymmetry *get_distinct_changed_magnetic_symmetry(
-    const double tmat[3][3], const double shift[3],
-    const MagneticSymmetry *sym_msg);
-static int is_equal(const MagneticSymmetry *sym1, const MagneticSymmetry *sym2,
-                    const double symprec);
-void get_rigid_rotation(double rigid_rot[3][3], const double lattice[3][3],
-                        const double tmat[3][3], const Spacegroup *ref_sg);
+    double const tmat[3][3], double const shift[3],
+    MagneticSymmetry const *sym_msg);
+static int is_equal(MagneticSymmetry const *sym1, MagneticSymmetry const *sym2,
+                    double const symprec);
+void get_rigid_rotation(double rigid_rot[3][3], double const lattice[3][3],
+                        double const tmat[3][3], Spacegroup const *ref_sg);
 
 /******************************************************************************/
 
 /// @brief Identify magnetic space-group type with database
 /// If failed, return NULL.
 MagneticDataset *msg_identify_magnetic_space_group_type(
-    const double lattice[3][3], const MagneticSymmetry *magnetic_symmetry,
-    const double symprec) {
+    double const lattice[3][3], MagneticSymmetry const *magnetic_symmetry,
+    double const symprec) {
     int i, j, s, hall_number, uni_number, type, same;
     Spacegroup *ref_sg;
     Symmetry *transformations;
@@ -259,12 +259,12 @@ err:
 /*   1. transform `cell` to primitive */
 /*   2. compute pure translations after given transformation */
 /*   3. apply the pure translations to the primitive */
-Cell *msg_get_transformed_cell(const Cell *cell, const double tmat[3][3],
-                               const double origin_shift[3],
-                               const double rigid_rot[3][3],
-                               const MagneticSymmetry *magnetic_symmetry,
-                               const double symprec,
-                               const double angle_tolerance) {
+Cell *msg_get_transformed_cell(Cell const *cell, double const tmat[3][3],
+                               double const origin_shift[3],
+                               double const rigid_rot[3][3],
+                               MagneticSymmetry const *magnetic_symmetry,
+                               double const symprec,
+                               double const angle_tolerance) {
     int i, p, ip, s, changed_num_atoms;
     VecDBL *pure_trans, *prm_pure_trans, *changed_pure_trans;
     Primitive *primitive;
@@ -414,8 +414,8 @@ err:
 static int get_reference_space_group(Spacegroup **ref_sg,
                                      MagneticSymmetry **changed_symmetry,
                                      double tmat[3][3], double shift[3],
-                                     const MagneticSymmetry *magnetic_symmetry,
-                                     const double symprec) {
+                                     MagneticSymmetry const *magnetic_symmetry,
+                                     double const symprec) {
     int type;
     Symmetry *sym_fsg, *sym_xsg;
     Spacegroup *fsg, *xsg;
@@ -510,8 +510,8 @@ err:
  */
 /* If failed, return NULL. */
 static Symmetry *get_family_space_group_with_magnetic_symmetry(
-    Spacegroup **fsg, const MagneticSymmetry *magnetic_symmetry,
-    const double symprec) {
+    Spacegroup **fsg, MagneticSymmetry const *magnetic_symmetry,
+    double const symprec) {
     return get_space_group_with_magnetic_symmetry(fsg, magnetic_symmetry, 1,
                                                   symprec);
 }
@@ -520,8 +520,8 @@ static Symmetry *get_family_space_group_with_magnetic_symmetry(
 /* XSG is a space group obtained by removing primed operations. */
 /* If failed, return NULL. */
 static Symmetry *get_maximal_subspace_group_with_magnetic_symmetry(
-    Spacegroup **xsg, const MagneticSymmetry *magnetic_symmetry,
-    const double symprec) {
+    Spacegroup **xsg, MagneticSymmetry const *magnetic_symmetry,
+    double const symprec) {
     return get_space_group_with_magnetic_symmetry(xsg, magnetic_symmetry, 0,
                                                   symprec);
 }
@@ -534,8 +534,8 @@ static Symmetry *get_maximal_subspace_group_with_magnetic_symmetry(
 /*    (a_std, b_std, c_std) = (a, b, c) @ P */
 /* where P := spacegroup->bravais_lattice, p := spacegroup->origin_shift. */
 static Symmetry *get_space_group_with_magnetic_symmetry(
-    Spacegroup **spacegroup, const MagneticSymmetry *magnetic_symmetry,
-    const int ignore_time_reversal, const double symprec) {
+    Spacegroup **spacegroup, MagneticSymmetry const *magnetic_symmetry,
+    int const ignore_time_reversal, double const symprec) {
     int i, num_sym_msg, num_sym, is_type2;
     Symmetry *sym, *prim_sym;
     int identity[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
@@ -617,8 +617,8 @@ static Symmetry *get_space_group_with_magnetic_symmetry(
 /* Return type of MSG. If failed, return 0. */
 static int get_magnetic_space_group_type(
     MagneticSymmetry **representative,
-    const MagneticSymmetry *magnetic_symmetry, const int num_sym_fsg,
-    const int num_sym_xsg) {
+    MagneticSymmetry const *magnetic_symmetry, int const num_sym_fsg,
+    int const num_sym_xsg) {
     int num_sym_msg;
     int identity[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 
@@ -668,7 +668,7 @@ static int get_magnetic_space_group_type(
 /* Assume magnetic_symmetry is type-III or type-IV. */
 /* If failed, return NULL. */
 static MagneticSymmetry *get_representative(
-    const MagneticSymmetry *magnetic_symmetry) {
+    MagneticSymmetry const *magnetic_symmetry) {
     int i;
     MagneticSymmetry *representative;
     int identity[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
@@ -718,9 +718,9 @@ static MagneticSymmetry *get_representative(
 /* If failed, return NULL. */
 /* Be careful the correspondence: tmat = spacegroup->bravais_lattice^-1 */
 static MagneticSymmetry *get_changed_magnetic_symmetry(
-    const double tmat[3][3], const double shift[3],
-    const MagneticSymmetry *representatives, const Symmetry *sym_xsg,
-    const MagneticSymmetry *magnetic_symmetry, const double symprec) {
+    double const tmat[3][3], double const shift[3],
+    MagneticSymmetry const *representatives, Symmetry const *sym_xsg,
+    MagneticSymmetry const *magnetic_symmetry, double const symprec) {
     int size, num_factors, num_sym, i, j, k;
     VecDBL *pure_trans, *changed_pure_trans;
     MagneticSymmetry *changed, *factors, *changed_factors,
@@ -836,9 +836,9 @@ err:
 
 /* (I, w) = (tmat, shift)^-1 (I, w_std) (tmat, shift) */
 /* w_std = tmat @ w */
-static VecDBL *get_changed_pure_translations(const double tmat[3][3],
-                                             const VecDBL *pure_trans,
-                                             const double symprec) {
+static VecDBL *get_changed_pure_translations(double const tmat[3][3],
+                                             VecDBL const *pure_trans,
+                                             double const symprec) {
     int size, count, denominator, i, n0, n1, n2, s, t, ok;
     double det;
     double trans_tmp[3], trans_shifted[3];
@@ -925,8 +925,8 @@ err:
 }
 
 /* Return 1 iff `v` is contained in `trans`. */
-static int is_contained_vec(const double v[3], const VecDBL *trans,
-                            const int size, const double symprec) {
+static int is_contained_vec(double const v[3], VecDBL const *trans,
+                            int const size, double const symprec) {
     int i, s, equivalent;
 
     for (i = 0; i < size; i++) {
@@ -944,8 +944,8 @@ static int is_contained_vec(const double v[3], const VecDBL *trans,
 }
 
 /* Return 1 iff `a` is contained in `sym_msg->rot`. */
-static int is_contained_mat(const int a[3][3], const MagneticSymmetry *sym_msg,
-                            const int size) {
+static int is_contained_mat(int const a[3][3], MagneticSymmetry const *sym_msg,
+                            int const size) {
     int i;
     for (i = 0; i < size; i++) {
         if (mat_check_identity_matrix_i3(a, sym_msg->rot[i])) {
@@ -960,8 +960,8 @@ static int is_contained_mat(const int a[3][3], const MagneticSymmetry *sym_msg,
 /* x_std = (tmat, shift) x */
 /* (W, w) -> (tmat, shift) (W, w) (tmat, shift)^-1 */
 static MagneticSymmetry *get_distinct_changed_magnetic_symmetry(
-    const double tmat[3][3], const double shift[3],
-    const MagneticSymmetry *sym_msg) {
+    double const tmat[3][3], double const shift[3],
+    MagneticSymmetry const *sym_msg) {
     int i;
     MagneticSymmetry *changed;
     double tmatinv[3][3];
@@ -1001,8 +1001,8 @@ static MagneticSymmetry *get_distinct_changed_magnetic_symmetry(
 }
 
 /* Return 1 if sym1 is isomorphic to sym2 */
-static int is_equal(const MagneticSymmetry *sym1, const MagneticSymmetry *sym2,
-                    const double symprec) {
+static int is_equal(MagneticSymmetry const *sym1, MagneticSymmetry const *sym2,
+                    double const symprec) {
     int i, j, found;
 
     if (sym1->size != sym2->size) return 0;
@@ -1030,8 +1030,8 @@ static int is_equal(const MagneticSymmetry *sym1, const MagneticSymmetry *sym2,
     return 1;
 }
 
-void get_rigid_rotation(double rigid_rot[3][3], const double lattice[3][3],
-                        const double tmat[3][3], const Spacegroup *ref_sg) {
+void get_rigid_rotation(double rigid_rot[3][3], double const lattice[3][3],
+                        double const tmat[3][3], Spacegroup const *ref_sg) {
     double ideal_latt[3][3], inv_ideal_latt[3][3], inv_latt[3][3];
     double tmat_bravais[3][3], inv_tmat_bravais[3][3];
 

--- a/src/magnetic_spacegroup.h
+++ b/src/magnetic_spacegroup.h
@@ -52,13 +52,13 @@ typedef struct {
 } MagneticDataset;
 
 MagneticDataset *msg_identify_magnetic_space_group_type(
-    const double lattice[3][3], const MagneticSymmetry *magnetic_symmetry,
-    const double symprec);
-Cell *msg_get_transformed_cell(const Cell *cell, const double tmat[3][3],
-                               const double origin_shift[3],
-                               const double rigid_rot[3][3],
-                               const MagneticSymmetry *magnetic_symmetry,
-                               const double symprec,
-                               const double angle_tolerance);
+    double const lattice[3][3], MagneticSymmetry const *magnetic_symmetry,
+    double const symprec);
+Cell *msg_get_transformed_cell(Cell const *cell, double const tmat[3][3],
+                               double const origin_shift[3],
+                               double const rigid_rot[3][3],
+                               MagneticSymmetry const *magnetic_symmetry,
+                               double const symprec,
+                               double const angle_tolerance);
 
 #endif /*__msg_H__ */

--- a/src/mathfunc.c
+++ b/src/mathfunc.c
@@ -41,21 +41,21 @@
 
 #define ZERO_PREC 1e-10
 
-double mat_get_determinant_d3(const double a[3][3]) {
+double mat_get_determinant_d3(double const a[3][3]) {
     return a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1]) +
            a[0][1] * (a[1][2] * a[2][0] - a[1][0] * a[2][2]) +
            a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0]);
 }
 
-int mat_get_determinant_i3(const int a[3][3]) {
+int mat_get_determinant_i3(int const a[3][3]) {
     return a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1]) +
            a[0][1] * (a[1][2] * a[2][0] - a[1][0] * a[2][2]) +
            a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0]);
 }
 
-int mat_get_trace_i3(const int a[3][3]) { return a[0][0] + a[1][1] + a[2][2]; }
+int mat_get_trace_i3(int const a[3][3]) { return a[0][0] + a[1][1] + a[2][2]; }
 
-void mat_copy_matrix_d3(double a[3][3], const double b[3][3]) {
+void mat_copy_matrix_d3(double a[3][3], double const b[3][3]) {
     a[0][0] = b[0][0];
     a[0][1] = b[0][1];
     a[0][2] = b[0][2];
@@ -67,7 +67,7 @@ void mat_copy_matrix_d3(double a[3][3], const double b[3][3]) {
     a[2][2] = b[2][2];
 }
 
-void mat_copy_matrix_i3(int a[3][3], const int b[3][3]) {
+void mat_copy_matrix_i3(int a[3][3], int const b[3][3]) {
     a[0][0] = b[0][0];
     a[0][1] = b[0][1];
     a[0][2] = b[0][2];
@@ -79,19 +79,19 @@ void mat_copy_matrix_i3(int a[3][3], const int b[3][3]) {
     a[2][2] = b[2][2];
 }
 
-void mat_copy_vector_d3(double a[3], const double b[3]) {
+void mat_copy_vector_d3(double a[3], double const b[3]) {
     a[0] = b[0];
     a[1] = b[1];
     a[2] = b[2];
 }
 
-void mat_copy_vector_i3(int a[3], const int b[3]) {
+void mat_copy_vector_i3(int a[3], int const b[3]) {
     a[0] = b[0];
     a[1] = b[1];
     a[2] = b[2];
 }
 
-int mat_check_identity_matrix_i3(const int a[3][3], const int b[3][3]) {
+int mat_check_identity_matrix_i3(int const a[3][3], int const b[3][3]) {
     if (a[0][0] - b[0][0] || a[0][1] - b[0][1] || a[0][2] - b[0][2] ||
         a[1][0] - b[1][0] || a[1][1] - b[1][1] || a[1][2] - b[1][2] ||
         a[2][0] - b[2][0] || a[2][1] - b[2][1] || a[2][2] - b[2][2]) {
@@ -101,8 +101,8 @@ int mat_check_identity_matrix_i3(const int a[3][3], const int b[3][3]) {
     }
 }
 
-int mat_check_identity_matrix_d3(const double a[3][3], const double b[3][3],
-                                 const double symprec) {
+int mat_check_identity_matrix_d3(double const a[3][3], double const b[3][3],
+                                 double const symprec) {
     if (mat_Dabs(a[0][0] - b[0][0]) > symprec ||
         mat_Dabs(a[0][1] - b[0][1]) > symprec ||
         mat_Dabs(a[0][2] - b[0][2]) > symprec ||
@@ -118,8 +118,8 @@ int mat_check_identity_matrix_d3(const double a[3][3], const double b[3][3],
     }
 }
 
-int mat_check_identity_matrix_id3(const int a[3][3], const double b[3][3],
-                                  const double symprec) {
+int mat_check_identity_matrix_id3(int const a[3][3], double const b[3][3],
+                                  double const symprec) {
     if (mat_Dabs(a[0][0] - b[0][0]) > symprec ||
         mat_Dabs(a[0][1] - b[0][1]) > symprec ||
         mat_Dabs(a[0][2] - b[0][2]) > symprec ||
@@ -136,8 +136,8 @@ int mat_check_identity_matrix_id3(const int a[3][3], const double b[3][3],
 }
 
 /* m=axb */
-void mat_multiply_matrix_d3(double m[3][3], const double a[3][3],
-                            const double b[3][3]) {
+void mat_multiply_matrix_d3(double m[3][3], double const a[3][3],
+                            double const b[3][3]) {
     int i, j; /* a_ij */
     double c[3][3];
     for (i = 0; i < 3; i++) {
@@ -148,7 +148,7 @@ void mat_multiply_matrix_d3(double m[3][3], const double a[3][3],
     mat_copy_matrix_d3(m, c);
 }
 
-void mat_multiply_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]) {
+void mat_multiply_matrix_i3(int m[3][3], int const a[3][3], int const b[3][3]) {
     int i, j; /* a_ij */
     int c[3][3];
     for (i = 0; i < 3; i++) {
@@ -159,8 +159,8 @@ void mat_multiply_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]) {
     mat_copy_matrix_i3(m, c);
 }
 
-void mat_multiply_matrix_di3(double m[3][3], const double a[3][3],
-                             const int b[3][3]) {
+void mat_multiply_matrix_di3(double m[3][3], double const a[3][3],
+                             int const b[3][3]) {
     int i, j; /* a_ij */
     double c[3][3];
     for (i = 0; i < 3; i++) {
@@ -171,8 +171,8 @@ void mat_multiply_matrix_di3(double m[3][3], const double a[3][3],
     mat_copy_matrix_d3(m, c);
 }
 
-void mat_multiply_matrix_id3(double m[3][3], const int a[3][3],
-                             const double b[3][3]) {
+void mat_multiply_matrix_id3(double m[3][3], int const a[3][3],
+                             double const b[3][3]) {
     int i, j; /* a_ij */
     double c[3][3];
     for (i = 0; i < 3; i++) {
@@ -183,8 +183,8 @@ void mat_multiply_matrix_id3(double m[3][3], const int a[3][3],
     mat_copy_matrix_d3(m, c);
 }
 
-void mat_multiply_matrix_vector_i3(int v[3], const int a[3][3],
-                                   const int b[3]) {
+void mat_multiply_matrix_vector_i3(int v[3], int const a[3][3],
+                                   int const b[3]) {
     int i;
     int c[3];
     for (i = 0; i < 3; i++)
@@ -193,8 +193,8 @@ void mat_multiply_matrix_vector_i3(int v[3], const int a[3][3],
 }
 
 /* v[3] <- a[3][3] * b[3] */
-void mat_multiply_matrix_vector_d3(double v[3], const double a[3][3],
-                                   const double b[3]) {
+void mat_multiply_matrix_vector_d3(double v[3], double const a[3][3],
+                                   double const b[3]) {
     int i;
     double c[3];
     for (i = 0; i < 3; i++)
@@ -202,8 +202,8 @@ void mat_multiply_matrix_vector_d3(double v[3], const double a[3][3],
     for (i = 0; i < 3; i++) v[i] = c[i];
 }
 
-void mat_multiply_matrix_vector_id3(double v[3], const int a[3][3],
-                                    const double b[3]) {
+void mat_multiply_matrix_vector_id3(double v[3], int const a[3][3],
+                                    double const b[3]) {
     int i;
     double c[3];
     for (i = 0; i < 3; i++)
@@ -211,8 +211,8 @@ void mat_multiply_matrix_vector_id3(double v[3], const int a[3][3],
     for (i = 0; i < 3; i++) v[i] = c[i];
 }
 
-void mat_multiply_matrix_vector_di3(double v[3], const double a[3][3],
-                                    const int b[3]) {
+void mat_multiply_matrix_vector_di3(double v[3], double const a[3][3],
+                                    int const b[3]) {
     int i;
     double c[3];
     for (i = 0; i < 3; i++)
@@ -220,7 +220,7 @@ void mat_multiply_matrix_vector_di3(double v[3], const double a[3][3],
     for (i = 0; i < 3; i++) v[i] = c[i];
 }
 
-void mat_add_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]) {
+void mat_add_matrix_i3(int m[3][3], int const a[3][3], int const b[3][3]) {
     int i, j;
     for (i = 0; i < 3; i++) {
         for (j = 0; j < 3; j++) {
@@ -229,7 +229,7 @@ void mat_add_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]) {
     }
 }
 
-void mat_cast_matrix_3i_to_3d(double m[3][3], const int a[3][3]) {
+void mat_cast_matrix_3i_to_3d(double m[3][3], int const a[3][3]) {
     m[0][0] = a[0][0];
     m[0][1] = a[0][1];
     m[0][2] = a[0][2];
@@ -241,7 +241,7 @@ void mat_cast_matrix_3i_to_3d(double m[3][3], const int a[3][3]) {
     m[2][2] = a[2][2];
 }
 
-void mat_cast_matrix_3d_to_3i(int m[3][3], const double a[3][3]) {
+void mat_cast_matrix_3d_to_3i(int m[3][3], double const a[3][3]) {
     m[0][0] = mat_Nint(a[0][0]);
     m[0][1] = mat_Nint(a[0][1]);
     m[0][2] = mat_Nint(a[0][2]);
@@ -260,8 +260,8 @@ void mat_cast_matrix_3d_to_3i(int m[3][3], const double a[3][3]) {
  * "m[#{j}][#{i}]=(a[#{(i+1)%3}][#{(j+1)%3}]*a[#{(i+2)%3}][#{(j+2)%3}] */
 /*       -a[#{(i+1)%3}][#{(j+2)%3}]*a[#{(i+2)%3}][#{(j+1)%3}])/det;" */
 /* }} */
-int mat_inverse_matrix_d3(double m[3][3], const double a[3][3],
-                          const double precision) {
+int mat_inverse_matrix_d3(double m[3][3], double const a[3][3],
+                          double const precision) {
     double det;
     double c[3][3];
     det = mat_get_determinant_d3(a);
@@ -284,8 +284,8 @@ int mat_inverse_matrix_d3(double m[3][3], const double a[3][3],
 }
 
 /* m = b^-1 a b */
-int mat_get_similar_matrix_d3(double m[3][3], const double a[3][3],
-                              const double b[3][3], const double precision) {
+int mat_get_similar_matrix_d3(double m[3][3], double const a[3][3],
+                              double const b[3][3], double const precision) {
     double c[3][3];
     if (!mat_inverse_matrix_d3(c, b, precision)) {
         warning_print("spglib: No similar matrix due to 0 determinant.\n");
@@ -296,7 +296,7 @@ int mat_get_similar_matrix_d3(double m[3][3], const double a[3][3],
     return 1;
 }
 
-void mat_transpose_matrix_d3(double a[3][3], const double b[3][3]) {
+void mat_transpose_matrix_d3(double a[3][3], double const b[3][3]) {
     double c[3][3];
     c[0][0] = b[0][0];
     c[0][1] = b[1][0];
@@ -310,7 +310,7 @@ void mat_transpose_matrix_d3(double a[3][3], const double b[3][3]) {
     mat_copy_matrix_d3(a, c);
 }
 
-void mat_transpose_matrix_i3(int a[3][3], const int b[3][3]) {
+void mat_transpose_matrix_i3(int a[3][3], int const b[3][3]) {
     int c[3][3];
     c[0][0] = b[0][0];
     c[0][1] = b[1][0];
@@ -324,27 +324,27 @@ void mat_transpose_matrix_i3(int a[3][3], const int b[3][3]) {
     mat_copy_matrix_i3(a, c);
 }
 
-void mat_get_metric(double metric[3][3], const double lattice[3][3]) {
+void mat_get_metric(double metric[3][3], double const lattice[3][3]) {
     double lattice_t[3][3];
     mat_transpose_matrix_d3(lattice_t, lattice);
     mat_multiply_matrix_d3(metric, lattice_t, lattice);
 }
 
-double mat_norm_squared_d3(const double a[3]) {
+double mat_norm_squared_d3(double const a[3]) {
     return a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
 }
 
-int mat_norm_squared_i3(const int a[3]) {
+int mat_norm_squared_i3(int const a[3]) {
     return a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
 }
 
-void mat_cross_product_d3(double v[3], const double a[3], const double b[3]) {
+void mat_cross_product_d3(double v[3], double const a[3], double const b[3]) {
     v[0] = a[1] * b[2] - a[2] * b[1];
     v[1] = a[2] * b[0] - a[0] * b[2];
     v[2] = a[0] * b[1] - a[1] * b[0];
 }
 
-double mat_Dabs(const double a) {
+double mat_Dabs(double const a) {
     if (a < 0.0)
         return -a;
     else
@@ -352,14 +352,14 @@ double mat_Dabs(const double a) {
 }
 
 /* Round to a nearest integer */
-int mat_Nint(const double a) {
+int mat_Nint(double const a) {
     if (a < 0.0)
         return (int)(a - 0.5);
     else
         return (int)(a + 0.5);
 }
 
-double mat_Dmod1(const double a) {
+double mat_Dmod1(double const a) {
     double b;
     b = a - mat_Nint(a);
 
@@ -372,9 +372,9 @@ double mat_Dmod1(const double a) {
 /// @brief Return the remainder of a divided by 1.
 /// @param a
 /// @return Remainder between -0.5 and 0.5
-double mat_rem1(const double a) { return a - mat_Nint(a); }
+double mat_rem1(double const a) { return a - mat_Nint(a); }
 
-MatINT *mat_alloc_MatINT(const int size) {
+MatINT *mat_alloc_MatINT(int const size) {
     MatINT *matint;
 
     matint = NULL;
@@ -406,7 +406,7 @@ void mat_free_MatINT(MatINT *matint) {
     free(matint);
 }
 
-VecDBL *mat_alloc_VecDBL(const int size) {
+VecDBL *mat_alloc_VecDBL(int const size) {
     VecDBL *vecdbl;
 
     vecdbl = NULL;
@@ -438,7 +438,7 @@ void mat_free_VecDBL(VecDBL *vecdbl) {
     free(vecdbl);
 }
 
-int mat_is_int_matrix(const double mat[3][3], const double symprec) {
+int mat_is_int_matrix(double const mat[3][3], double const symprec) {
     int i, j;
     for (i = 0; i < 3; i++) {
         for (j = 0; j < 3; j++) {

--- a/src/mathfunc.h
+++ b/src/mathfunc.h
@@ -47,54 +47,54 @@ typedef struct {
     double (*vec)[3];
 } VecDBL;
 
-double mat_get_determinant_d3(const double a[3][3]);
-int mat_get_determinant_i3(const int a[3][3]);
-int mat_get_trace_i3(const int a[3][3]);
-SPG_API_TEST void mat_copy_matrix_d3(double a[3][3], const double b[3][3]);
-void mat_copy_matrix_i3(int a[3][3], const int b[3][3]);
-void mat_copy_vector_d3(double a[3], const double b[3]);
-void mat_copy_vector_i3(int a[3], const int b[3]);
-int mat_check_identity_matrix_i3(const int a[3][3], const int b[3][3]);
-int mat_check_identity_matrix_d3(const double a[3][3], const double b[3][3],
-                                 const double symprec);
-int mat_check_identity_matrix_id3(const int a[3][3], const double b[3][3],
-                                  const double symprec);
-SPG_API_TEST void mat_multiply_matrix_d3(double m[3][3], const double a[3][3],
-                                         const double b[3][3]);
-void mat_multiply_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]);
-void mat_multiply_matrix_di3(double m[3][3], const double a[3][3],
-                             const int b[3][3]);
-void mat_multiply_matrix_id3(double m[3][3], const int a[3][3],
-                             const double b[3][3]);
-void mat_multiply_matrix_vector_i3(int v[3], const int a[3][3], const int b[3]);
-void mat_multiply_matrix_vector_d3(double v[3], const double a[3][3],
-                                   const double b[3]);
-void mat_multiply_matrix_vector_id3(double v[3], const int a[3][3],
-                                    const double b[3]);
-void mat_multiply_matrix_vector_di3(double v[3], const double a[3][3],
-                                    const int b[3]);
-void mat_add_matrix_i3(int m[3][3], const int a[3][3], const int b[3][3]);
-void mat_cast_matrix_3i_to_3d(double m[3][3], const int a[3][3]);
-SPG_API_TEST void mat_cast_matrix_3d_to_3i(int m[3][3], const double a[3][3]);
-SPG_API_TEST int mat_inverse_matrix_d3(double m[3][3], const double a[3][3],
-                                       const double precision);
-int mat_get_similar_matrix_d3(double m[3][3], const double a[3][3],
-                              const double b[3][3], const double precision);
-void mat_transpose_matrix_d3(double a[3][3], const double b[3][3]);
-void mat_transpose_matrix_i3(int a[3][3], const int b[3][3]);
+double mat_get_determinant_d3(double const a[3][3]);
+int mat_get_determinant_i3(int const a[3][3]);
+int mat_get_trace_i3(int const a[3][3]);
+SPG_API_TEST void mat_copy_matrix_d3(double a[3][3], double const b[3][3]);
+void mat_copy_matrix_i3(int a[3][3], int const b[3][3]);
+void mat_copy_vector_d3(double a[3], double const b[3]);
+void mat_copy_vector_i3(int a[3], int const b[3]);
+int mat_check_identity_matrix_i3(int const a[3][3], int const b[3][3]);
+int mat_check_identity_matrix_d3(double const a[3][3], double const b[3][3],
+                                 double const symprec);
+int mat_check_identity_matrix_id3(int const a[3][3], double const b[3][3],
+                                  double const symprec);
+SPG_API_TEST void mat_multiply_matrix_d3(double m[3][3], double const a[3][3],
+                                         double const b[3][3]);
+void mat_multiply_matrix_i3(int m[3][3], int const a[3][3], int const b[3][3]);
+void mat_multiply_matrix_di3(double m[3][3], double const a[3][3],
+                             int const b[3][3]);
+void mat_multiply_matrix_id3(double m[3][3], int const a[3][3],
+                             double const b[3][3]);
+void mat_multiply_matrix_vector_i3(int v[3], int const a[3][3], int const b[3]);
+void mat_multiply_matrix_vector_d3(double v[3], double const a[3][3],
+                                   double const b[3]);
+void mat_multiply_matrix_vector_id3(double v[3], int const a[3][3],
+                                    double const b[3]);
+void mat_multiply_matrix_vector_di3(double v[3], double const a[3][3],
+                                    int const b[3]);
+void mat_add_matrix_i3(int m[3][3], int const a[3][3], int const b[3][3]);
+void mat_cast_matrix_3i_to_3d(double m[3][3], int const a[3][3]);
+SPG_API_TEST void mat_cast_matrix_3d_to_3i(int m[3][3], double const a[3][3]);
+SPG_API_TEST int mat_inverse_matrix_d3(double m[3][3], double const a[3][3],
+                                       double const precision);
+int mat_get_similar_matrix_d3(double m[3][3], double const a[3][3],
+                              double const b[3][3], double const precision);
+void mat_transpose_matrix_d3(double a[3][3], double const b[3][3]);
+void mat_transpose_matrix_i3(int a[3][3], int const b[3][3]);
 SPG_API_TEST void mat_get_metric(double metric[3][3],
-                                 const double lattice[3][3]);
-double mat_norm_squared_d3(const double a[3]);
-int mat_norm_squared_i3(const int a[3]);
-void mat_cross_product_d3(double v[3], const double a[3], const double b[3]);
-double mat_Dabs(const double a);
-int mat_Nint(const double a);
-double mat_Dmod1(const double a);
-double mat_rem1(const double a);
-MatINT* mat_alloc_MatINT(const int size);
+                                 double const lattice[3][3]);
+double mat_norm_squared_d3(double const a[3]);
+int mat_norm_squared_i3(int const a[3]);
+void mat_cross_product_d3(double v[3], double const a[3], double const b[3]);
+double mat_Dabs(double const a);
+int mat_Nint(double const a);
+double mat_Dmod1(double const a);
+double mat_rem1(double const a);
+MatINT* mat_alloc_MatINT(int const size);
 void mat_free_MatINT(MatINT* matint);
-VecDBL* mat_alloc_VecDBL(const int size);
+VecDBL* mat_alloc_VecDBL(int const size);
 void mat_free_VecDBL(VecDBL* vecdbl);
-int mat_is_int_matrix(const double mat[3][3], const double symprec);
+int mat_is_int_matrix(double const mat[3][3], double const symprec);
 
 #endif

--- a/src/msg_database.h
+++ b/src/msg_database.h
@@ -46,11 +46,11 @@ typedef struct {
     int type;
 } MagneticSpacegroupType;
 
-MagneticSpacegroupType msgdb_get_magnetic_spacegroup_type(const int uni_number);
-MagneticSymmetry *msgdb_get_spacegroup_operations(const int uni_number,
-                                                  const int hall_number);
-void msgdb_get_uni_candidates(int uni_number_range[2], const int hall_number);
-Symmetry *msgdb_get_std_transformations(const int uni_number,
-                                        const int hall_number);
+MagneticSpacegroupType msgdb_get_magnetic_spacegroup_type(int const uni_number);
+MagneticSymmetry *msgdb_get_spacegroup_operations(int const uni_number,
+                                                  int const hall_number);
+void msgdb_get_uni_candidates(int uni_number_range[2], int const hall_number);
+Symmetry *msgdb_get_std_transformations(int const uni_number,
+                                        int const hall_number);
 
 #endif /* __msg_database_H__ */

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -96,7 +96,7 @@ static void debug_show(int const j, NiggliParams const *p) {
     /* } */
 }
 #else
-#define debug_show(...)
+    #define debug_show(...)
 #endif
 
 int get_num_attempts() {

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -58,7 +58,7 @@ typedef struct {
 } NiggliParams;
 
 static int get_num_attempts();
-static NiggliParams *initialize(const double *lattice_, const double eps_);
+static NiggliParams *initialize(double const *lattice_, double const eps_);
 static void finalize(double *lattice_, NiggliParams *p);
 static int reset(NiggliParams *p);
 static int step1(NiggliParams *p);
@@ -71,14 +71,14 @@ static int step7(NiggliParams *p);
 static int step8(NiggliParams *p);
 static int set_parameters(NiggliParams *p);
 static void set_angle_types(NiggliParams *p);
-static double *get_transpose(const double *M);
-static double *get_metric(const double *M);
-static double *multiply_matrices(const double *A, const double *B);
-static int layer_swap_axis(NiggliParams *p, const int aperiodic_axis);
+static double *get_transpose(double const *M);
+static double *get_metric(double const *M);
+static double *multiply_matrices(double const *A, double const *B);
+static int layer_swap_axis(NiggliParams *p, int const aperiodic_axis);
 static int step2_for_layer(NiggliParams *p);
 
 #ifdef SPGDEBUG
-static void debug_show(const int j, const NiggliParams *p) {
+static void debug_show(int const j, NiggliParams const *p) {
     /* int i; */
 
     if (j < 0) {
@@ -100,7 +100,7 @@ static void debug_show(const int j, const NiggliParams *p) {
 #endif
 
 int get_num_attempts() {
-    const char *num_attempts_str = getenv("SPGLIB_NUM_ATTEMPTS");
+    char const *num_attempts_str = getenv("SPGLIB_NUM_ATTEMPTS");
     if (num_attempts_str != NULL) {
         // Try to parse the string as an integer
         char *end;
@@ -133,8 +133,8 @@ int niggli_get_micro_version(void) { return NIGGLI_MICRO_VERSION; }
 //       - Step 2 is skipped
 //       - (Steps 5 and 6 are not modified because axis c is perpendicular to
 //       the plane)
-int niggli_reduce(double *lattice_, const double eps_,
-                  const int aperiodic_axis) {
+int niggli_reduce(double *lattice_, double const eps_,
+                  int const aperiodic_axis) {
     int succeeded;
     NiggliParams *p;
     int (*steps[8])(NiggliParams *p) = {step1, step2, step3, step4,
@@ -186,7 +186,7 @@ ret:
     return succeeded;
 }
 
-static NiggliParams *initialize(const double *lattice_, const double eps_) {
+static NiggliParams *initialize(double const *lattice_, double const eps_) {
     NiggliParams *p;
 
     p = NULL;
@@ -232,7 +232,7 @@ static NiggliParams *initialize(const double *lattice_, const double eps_) {
 }
 
 /* move aperiodic axis to c. */
-static int layer_swap_axis(NiggliParams *p, const int aperiodic_axis) {
+static int layer_swap_axis(NiggliParams *p, int const aperiodic_axis) {
     if (aperiodic_axis == 0) {
         p->tmat[0] = 0, p->tmat[1] = 0, p->tmat[2] = -1;
         p->tmat[3] = 0, p->tmat[4] = -1, p->tmat[5] = 0;
@@ -504,7 +504,7 @@ static int step8(NiggliParams *p) {
     }
 }
 
-static double *get_transpose(const double *M) {
+static double *get_transpose(double const *M) {
     int i, j;
     double *M_T;
 
@@ -524,7 +524,7 @@ static double *get_transpose(const double *M) {
     return M_T;
 }
 
-static double *get_metric(const double *M) {
+static double *get_metric(double const *M) {
     double *G, *M_T;
 
     G = NULL;
@@ -543,7 +543,7 @@ static double *get_metric(const double *M) {
     return G;
 }
 
-static double *multiply_matrices(const double *L, const double *R) {
+static double *multiply_matrices(double const *L, double const *R) {
     int i, j, k;
     double *M;
 

--- a/src/niggli.h
+++ b/src/niggli.h
@@ -44,7 +44,7 @@
 int niggli_get_major_version(void);
 int niggli_get_minor_version(void);
 int niggli_get_micro_version(void);
-SPG_API_TEST int niggli_reduce(double* lattice_, const double eps_,
-                               const int aperiodic_axis);
+SPG_API_TEST int niggli_reduce(double* lattice_, double const eps_,
+                               int const aperiodic_axis);
 
 #endif

--- a/src/overlap.c
+++ b/src/overlap.c
@@ -63,48 +63,48 @@
 #endif
 
 /* Note: data_out and data_in MUST NOT ALIAS. */
-static void permute(void *data_out, const void *data_in, const int *perm,
+static void permute(void *data_out, void const *data_in, int const *perm,
                     int value_size, int n);
 
-static void permute_int(int *data_out, const int *data_in, const int *perm,
-                        const int n);
+static void permute_int(int *data_out, int const *data_in, int const *perm,
+                        int const n);
 
-static void permute_double_3(double (*data_out)[3], const double (*data_in)[3],
-                             const int *perm, const int n);
+static void permute_double_3(double (*data_out)[3], double const (*data_in)[3],
+                             int const *perm, int const n);
 
-static int ValueWithIndex_comparator(const void *pa, const void *pb);
+static int ValueWithIndex_comparator(void const *pa, void const *pb);
 
 static void *perm_argsort_work_malloc(int n);
 
 static void perm_argsort_work_free(void *work);
 
-static int perm_argsort(int *perm, const int *types, const double *values,
-                        void *provided_work, const int n);
+static int perm_argsort(int *perm, int const *types, double const *values,
+                        void *provided_work, int const n);
 
 static int check_possible_overlap(OverlapChecker *checker,
-                                  const double test_trans[3],
-                                  const int rot[3][3], const double symprec);
+                                  double const test_trans[3],
+                                  int const rot[3][3], double const symprec);
 
 static int argsort_by_lattice_point_distance(
-    int *perm, const double lattice[3][3], const double (*positions)[3],
-    const int *types, double *distance_temp, void *argsort_work,
-    const int size);
+    int *perm, double const lattice[3][3], double const (*positions)[3],
+    int const *types, double *distance_temp, void *argsort_work,
+    int const size);
 
 static OverlapChecker *overlap_checker_alloc(int size);
 
 static int check_total_overlap_for_sorted(
-    const double lattice[3][3], const double (*pos_original)[3],
-    const double (*pos_rotated)[3], const int types_original[],
-    const int types_rotated[], const int num_pos, const double symprec);
+    double const lattice[3][3], double const (*pos_original)[3],
+    double const (*pos_rotated)[3], int const types_original[],
+    int const types_rotated[], int const num_pos, double const symprec);
 /* ovl_check_total_overlap ,check_total_overlap_for_sorted, layer_has_overlap */
 /* and layer_has_overlap_with_same_type are copied to get rid of some if
  * statement */
 /* I have not tested if it is better in efficiency. */
 static int check_layer_total_overlap_for_sorted(
-    const double lattice[3][3], const double (*pos_original)[3],
-    const double (*pos_rotated)[3], const int types_original[],
-    const int types_rotated[], const int num_pos, const int periodic_axes[3],
-    const double symprec);
+    double const lattice[3][3], double const (*pos_original)[3],
+    double const (*pos_rotated)[3], int const types_original[],
+    int const types_rotated[], int const num_pos, int const periodic_axes[3],
+    double const symprec);
 
 /* Note that some compilers apparently don't like it
  * when you have a separate prototype with a function
@@ -113,8 +113,8 @@ static int check_layer_total_overlap_for_sorted(
  * As an aside, yes, significant performance is lost
  * for large structures if these functions aren't inlined. */
 
-static OVL_INLINE double cartesian_norm(const double lat[3][3],
-                                        const double v[3]) {
+static OVL_INLINE double cartesian_norm(double const lat[3][3],
+                                        double const v[3]) {
     double temp[3];
     temp[0] = lat[0][0] * v[0] + lat[0][1] * v[1] + lat[0][2] * v[2];
     temp[1] = lat[1][0] * v[0] + lat[1][1] * v[1] + lat[1][2] * v[2];
@@ -123,16 +123,16 @@ static OVL_INLINE double cartesian_norm(const double lat[3][3],
     return sqrt(temp[0] * temp[0] + temp[1] * temp[1] + temp[2] * temp[2]);
 }
 
-static OVL_INLINE int Nint(const double a) {
+static OVL_INLINE int Nint(double const a) {
     if (a < 0.0)
         return (int)(a - 0.5);
     else
         return (int)(a + 0.5);
 }
 
-static OVL_INLINE int has_overlap(const double a[3], const double b[3],
-                                  const double lattice[3][3],
-                                  const double symprec) {
+static OVL_INLINE int has_overlap(double const a[3], double const b[3],
+                                  double const lattice[3][3],
+                                  double const symprec) {
     double v_diff[3];
     v_diff[0] = a[0] - b[0];
     v_diff[2] = a[2] - b[2];
@@ -150,8 +150,8 @@ static OVL_INLINE int has_overlap(const double a[3], const double b[3],
 }
 
 static OVL_INLINE int has_overlap_with_same_type(
-    const double a[3], const double b[3], const int type_a, const int type_b,
-    const double lattice[3][3], const double symprec) {
+    double const a[3], double const b[3], int const type_a, int const type_b,
+    double const lattice[3][3], double const symprec) {
     if (type_a == type_b) {
         return has_overlap(a, b, lattice, symprec);
     } else {
@@ -160,10 +160,10 @@ static OVL_INLINE int has_overlap_with_same_type(
 }
 
 /* Modified from has_overlap */
-static OVL_INLINE int layer_has_overlap(const double a[3], const double b[3],
-                                        const double lattice[3][3],
-                                        const int periodic_axes[2],
-                                        const double symprec) {
+static OVL_INLINE int layer_has_overlap(double const a[3], double const b[3],
+                                        double const lattice[3][3],
+                                        int const periodic_axes[2],
+                                        double const symprec) {
     double v_diff[3];
     v_diff[0] = a[0] - b[0];
     v_diff[1] = a[1] - b[1];
@@ -180,9 +180,9 @@ static OVL_INLINE int layer_has_overlap(const double a[3], const double b[3],
 }
 
 static OVL_INLINE int layer_has_overlap_with_same_type(
-    const double a[3], const double b[3], const int type_a, const int type_b,
-    const double lattice[3][3], const int periodic_axes[2],
-    const double symprec) {
+    double const a[3], double const b[3], int const type_a, int const type_b,
+    double const lattice[3][3], int const periodic_axes[2],
+    double const symprec) {
     if (type_a == type_b) {
         return layer_has_overlap(a, b, lattice, periodic_axes, symprec);
     } else {
@@ -214,7 +214,7 @@ void ovl_overlap_checker_free(OverlapChecker *checker) {
     }
 }
 
-OverlapChecker *ovl_overlap_checker_init(const Cell *cell) {
+OverlapChecker *ovl_overlap_checker_init(Cell const *cell) {
     int i, lattice_rank;
     OverlapChecker *checker;
     checker = NULL;
@@ -260,9 +260,9 @@ OverlapChecker *ovl_overlap_checker_init(const Cell *cell) {
 /* you can create one OverlapChecker from the Cell and call this function many
  * times. */
 /* -1: Error.  0:  Not a symmetry.   1. Is a symmetry. */
-int ovl_check_total_overlap(OverlapChecker *checker, const double test_trans[3],
-                            const int rot[3][3], const double symprec,
-                            const int is_identity) {
+int ovl_check_total_overlap(OverlapChecker *checker, double const test_trans[3],
+                            int const rot[3][3], double const symprec,
+                            int const is_identity) {
     int i, k, check;
 
     /* Check a few atoms by brute force before continuing. */
@@ -322,9 +322,9 @@ int ovl_check_total_overlap(OverlapChecker *checker, const double test_trans[3],
  * times. */
 /* -1: Error.  0:  Not a symmetry.   1. Is a symmetry. */
 int ovl_check_layer_total_overlap(OverlapChecker *checker,
-                                  const double test_trans[3],
-                                  const int rot[3][3], const double symprec,
-                                  const int is_identity) {
+                                  double const test_trans[3],
+                                  int const rot[3][3], double const symprec,
+                                  int const is_identity) {
     int i, k, check;
 
     /* Check a few atoms by brute force before continuing. */
@@ -376,7 +376,7 @@ int ovl_check_layer_total_overlap(OverlapChecker *checker,
     return check;
 }
 
-static int ValueWithIndex_comparator(const void *pa, const void *pb) {
+static int ValueWithIndex_comparator(void const *pa, void const *pb) {
     int cmp;
     ValueWithIndex a, b;
 
@@ -413,8 +413,8 @@ static void perm_argsort_work_free(void *work) { free(work); }
 /* to have the same type. */
 /* */
 /* Returns 0 on failure. */
-static int perm_argsort(int *perm, const int *types, const double *values,
-                        void *provided_work, const int n) {
+static int perm_argsort(int *perm, int const *types, double const *values,
+                        void *provided_work, int const n) {
     int i;
     ValueWithIndex *work;
 
@@ -451,10 +451,10 @@ static int perm_argsort(int *perm, const int *types, const double *values,
 
 /* Permute an array. */
 /* data_out and data_in MUST NOT ALIAS. */
-static void permute(void *data_out, const void *data_in, const int *perm,
+static void permute(void *data_out, void const *data_in, int const *perm,
                     int value_size, int n) {
     int i;
-    const void *read;
+    void const *read;
     void *write;
 
     for (i = 0; i < n; i++) {
@@ -467,13 +467,13 @@ static void permute(void *data_out, const void *data_in, const int *perm,
 /* ***************************************** */
 /*             OverlapChecker                */
 
-static void permute_int(int *data_out, const int *data_in, const int *perm,
-                        const int n) {
+static void permute_int(int *data_out, int const *data_in, int const *perm,
+                        int const n) {
     permute(data_out, data_in, perm, sizeof(int), n);
 }
 
-static void permute_double_3(double (*data_out)[3], const double (*data_in)[3],
-                             const int *perm, const int n) {
+static void permute_double_3(double (*data_out)[3], double const (*data_in)[3],
+                             int const *perm, int const n) {
     permute(data_out, data_in, perm, sizeof(double[3]), n);
 }
 
@@ -541,9 +541,9 @@ static OverlapChecker *overlap_checker_alloc(int size) {
 }
 
 static int argsort_by_lattice_point_distance(
-    int *perm, const double lattice[3][3], const double (*positions)[3],
-    const int *types, double *distance_temp, void *argsort_work,
-    const int size) {
+    int *perm, double const lattice[3][3], double const (*positions)[3],
+    int const *types, double *distance_temp, void *argsort_work,
+    int const size) {
     double diff[3];
     int i, k;
     double x;
@@ -569,8 +569,8 @@ static int argsort_by_lattice_point_distance(
 /* It only inspects a few atoms. */
 /* 0:  Not a symmetry.   1. Possible symmetry. */
 static int check_possible_overlap(OverlapChecker *checker,
-                                  const double test_trans[3],
-                                  const int rot[3][3], const double symprec) {
+                                  double const test_trans[3],
+                                  int const rot[3][3], double const symprec) {
     double pos_rot[3];
     int i, i_test, k, max_search_num, search_num;
     int type_rot, is_found;
@@ -617,9 +617,9 @@ static int check_possible_overlap(OverlapChecker *checker,
 /* between pos_original and pos_rotated is small. */
 /* -1: Error.  0: False.  1:  True. */
 static int check_total_overlap_for_sorted(
-    const double lattice[3][3], const double (*pos_original)[3],
-    const double (*pos_rotated)[3], const int types_original[],
-    const int types_rotated[], const int num_pos, const double symprec) {
+    double const lattice[3][3], double const (*pos_original)[3],
+    double const (*pos_rotated)[3], int const types_original[],
+    int const types_rotated[], int const num_pos, double const symprec) {
     int *found;
     int i, i_orig, i_rot;
     int search_start;
@@ -679,10 +679,10 @@ static int check_total_overlap_for_sorted(
 /* between pos_original and pos_rotated is small. */
 /* -1: Error.  0: False.  1:  True. */
 static int check_layer_total_overlap_for_sorted(
-    const double lattice[3][3], const double (*pos_original)[3],
-    const double (*pos_rotated)[3], const int types_original[],
-    const int types_rotated[], const int num_pos, const int periodic_axes[3],
-    const double symprec) {
+    double const lattice[3][3], double const (*pos_original)[3],
+    double const (*pos_rotated)[3], int const types_original[],
+    int const types_rotated[], int const num_pos, int const periodic_axes[3],
+    double const symprec) {
     int *found;
     int i, i_orig, i_rot;
     int search_start;

--- a/src/overlap.c
+++ b/src/overlap.c
@@ -45,21 +45,21 @@
 /* 'a++' generalized to an arbitrary increment. */
 /* Performs 'a += b' and returns the old value of a. */
 #ifndef SPG_POST_INCREMENT
-#define SPG_POST_INCREMENT(a, b) ((a) += (b), (a) - (b))
+    #define SPG_POST_INCREMENT(a, b) ((a) += (b), (a) - (b))
 #endif
 
 /* deal with inline */
 #if defined(_MSC_VER)
-#define OVL_INLINE __forceinline
+    #define OVL_INLINE __forceinline
 #elif defined(__clang__)
-#define OVL_INLINE __inline__ __attribute__((__always_inline__))
+    #define OVL_INLINE __inline__ __attribute__((__always_inline__))
 #elif defined(__GNUC__) &&                                   \
     (defined(__GNUC_STDC_INLINE__) ||                        \
      (defined(__STDC__) && (__STDC_VERSION__ >= 199901L)) || \
      (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)))
-#define OVL_INLINE __inline__ __attribute__((__always_inline__))
+    #define OVL_INLINE __inline__ __attribute__((__always_inline__))
 #else
-#define OVL_INLINE /* empty */
+    #define OVL_INLINE /* empty */
 #endif
 
 /* Note: data_out and data_in MUST NOT ALIAS. */

--- a/src/overlap.h
+++ b/src/overlap.h
@@ -62,15 +62,15 @@ typedef struct {
     int *periodic_axes;
 } OverlapChecker;
 
-OverlapChecker *ovl_overlap_checker_init(const Cell *cell);
+OverlapChecker *ovl_overlap_checker_init(Cell const *cell);
 
-int ovl_check_total_overlap(OverlapChecker *checker, const double test_trans[3],
-                            const int rot[3][3], const double symprec,
-                            const int is_identity);
+int ovl_check_total_overlap(OverlapChecker *checker, double const test_trans[3],
+                            int const rot[3][3], double const symprec,
+                            int const is_identity);
 
 int ovl_check_layer_total_overlap(OverlapChecker *checker,
-                                  const double test_trans[3],
-                                  const int rot[3][3], const double symprec,
-                                  const int is_identity);
+                                  double const test_trans[3],
+                                  int const rot[3][3], double const symprec,
+                                  int const is_identity);
 
 void ovl_overlap_checker_free(OverlapChecker *checker);

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -349,35 +349,35 @@ static int rot_axes[][3] = {
     {3, 1, -1},  {3, -1, 1},  {3, -1, -1},
 };
 
-static int get_pointgroup_number_by_rotations(const int rotations[][3][3],
-                                              const int num_rotations);
-static int get_pointgroup_number(const PointSymmetry* pointsym);
+static int get_pointgroup_number_by_rotations(int const rotations[][3][3],
+                                              int const num_rotations);
+static int get_pointgroup_number(PointSymmetry const* pointsym);
 static int get_pointgroup_class_table(int table[10],
-                                      const PointSymmetry* pointsym);
-static int get_rotation_type(const int rot[3][3]);
-static int get_rotation_axis(const int rot[3][3]);
-static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
-                               const int rot_order);
-static int laue2m(int axes[3], const PointSymmetry* pointsym);
-static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
-                        const int aperiodic_axis);
+                                      PointSymmetry const* pointsym);
+static int get_rotation_type(int const rot[3][3]);
+static int get_rotation_axis(int const rot[3][3]);
+static int get_orthogonal_axis(int ortho_axes[], int const proper_rot[3][3],
+                               int const rot_order);
+static int laue2m(int axes[3], PointSymmetry const* pointsym);
+static int layer_laue2m(int axes[3], PointSymmetry const* pointsym,
+                        int const aperiodic_axis);
 
-static int laue_one_axis(int axes[3], const PointSymmetry* pointsym,
-                         const int rot_order);
-static int lauennn(int axes[3], const PointSymmetry* pointsym,
-                   const int rot_order, const int aperiodic_axis);
-static int get_axes(int axes[3], const Laue laue, const PointSymmetry* pointsym,
-                    const int aperiodic_axis);
-static void get_proper_rotation(int prop_rot[3][3], const int rot[3][3]);
-static void set_transformation_matrix(int tmat[3][3], const int axes[3]);
-static int is_exist_axis(const int axis_vec[3], const int axis_index);
+static int laue_one_axis(int axes[3], PointSymmetry const* pointsym,
+                         int const rot_order);
+static int lauennn(int axes[3], PointSymmetry const* pointsym,
+                   int const rot_order, int const aperiodic_axis);
+static int get_axes(int axes[3], Laue const laue, PointSymmetry const* pointsym,
+                    int const aperiodic_axis);
+static void get_proper_rotation(int prop_rot[3][3], int const rot[3][3]);
+static void set_transformation_matrix(int tmat[3][3], int const axes[3]);
+static int is_exist_axis(int const axis_vec[3], int const axis_index);
 static void sort_axes(int axes[3]);
-static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis);
+static void layer_check_and_sort_axes(int axes[3], int const aperiodic_axis);
 
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
-                                         const int rotations[][3][3],
-                                         const int num_rotations,
-                                         const int aperiodic_axis) {
+                                         int const rotations[][3][3],
+                                         int const num_rotations,
+                                         int const aperiodic_axis) {
     int i, j, pg_num;
     int axes[3];
     PointSymmetry pointsym;
@@ -409,7 +409,7 @@ Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
     return pointgroup;
 }
 
-Pointgroup ptg_get_pointgroup(const int pointgroup_number) {
+Pointgroup ptg_get_pointgroup(int const pointgroup_number) {
     int i;
     Pointgroup pointgroup;
     PointgroupType pointgroup_type;
@@ -437,8 +437,8 @@ Pointgroup ptg_get_pointgroup(const int pointgroup_number) {
 }
 
 // @brief Construct PointSymmetry from given `rotations`
-PointSymmetry ptg_get_pointsymmetry(const int rotations[][3][3],
-                                    const int num_rotations) {
+PointSymmetry ptg_get_pointsymmetry(int const rotations[][3][3],
+                                    int const num_rotations) {
     int i, j;
     PointSymmetry pointsym;
 
@@ -457,15 +457,15 @@ PointSymmetry ptg_get_pointsymmetry(const int rotations[][3][3],
     return pointsym;
 }
 
-static int get_pointgroup_number_by_rotations(const int rotations[][3][3],
-                                              const int num_rotations) {
+static int get_pointgroup_number_by_rotations(int const rotations[][3][3],
+                                              int const num_rotations) {
     PointSymmetry pointsym;
 
     pointsym = ptg_get_pointsymmetry(rotations, num_rotations);
     return get_pointgroup_number(&pointsym);
 }
 
-static int get_pointgroup_number(const PointSymmetry* pointsym) {
+static int get_pointgroup_number(PointSymmetry const* pointsym) {
     int i, j, pg_num, counter;
     int table[10];
     PointgroupType pointgroup_type;
@@ -503,7 +503,7 @@ end:
 // or roto-rotations
 // @param[in] pointsym
 static int get_pointgroup_class_table(int table[10],
-                                      const PointSymmetry* pointsym) {
+                                      PointSymmetry const* pointsym) {
     /* Look-up table */
     /* Operation   -6 -4 -3 -2 -1  1  2  3  4  6 */
     /* Trace     -  2 -1  0  1 -3  3 -1  0  1  2 */
@@ -542,7 +542,7 @@ err:
     return 0;
 }
 
-static int get_rotation_type(const int rot[3][3]) {
+static int get_rotation_type(int const rot[3][3]) {
     int rot_type;
 
     if (mat_get_determinant_i3(rot) == -1) {
@@ -599,8 +599,8 @@ static int get_rotation_type(const int rot[3][3]) {
 // @param[in] laue
 // @param[in] pointsym
 // @param[in] aperiodic_axis
-static int get_axes(int axes[3], const Laue laue, const PointSymmetry* pointsym,
-                    const int aperiodic_axis) {
+static int get_axes(int axes[3], Laue const laue, PointSymmetry const* pointsym,
+                    int const aperiodic_axis) {
     switch (laue) {
         case LAUE1:
             axes[0] = 0;  // {1, 0, 0}
@@ -648,7 +648,7 @@ static int get_axes(int axes[3], const Laue laue, const PointSymmetry* pointsym,
     return 1;
 }
 
-static int laue2m(int axes[3], const PointSymmetry* pointsym) {
+static int laue2m(int axes[3], PointSymmetry const* pointsym) {
     int i, num_ortho_axis, norm, min_norm, is_found;
     int prop_rot[3][3];
     int ortho_axes[NUM_ROT_AXES];
@@ -725,8 +725,8 @@ err:
 
 // @note The two-fold axis is set to axis-a. Axes b and c forms the periodic
 // plane.
-static int layer_laue2m(int axes[3], const PointSymmetry* pointsym,
-                        const int aperiodic_axis) {
+static int layer_laue2m(int axes[3], PointSymmetry const* pointsym,
+                        int const aperiodic_axis) {
     int i, num_ortho_axis, norm, min_norm, is_found;
     int prop_rot[3][3];
     int ortho_axes[NUM_ROT_AXES];
@@ -832,8 +832,8 @@ err:
 }
 
 // For Laue classes 4/m, 4/mmm, -3, -3/m, 6/m, 6/mmm
-static int laue_one_axis(int axes[3], const PointSymmetry* pointsym,
-                         const int rot_order) {
+static int laue_one_axis(int axes[3], PointSymmetry const* pointsym,
+                         int const rot_order) {
     int i, j, num_ortho_axis, det, is_found, tmpval;
     int axis_vec[3], tmp_axes[3];
     int prop_rot[3][3], t_mat[3][3];
@@ -922,8 +922,8 @@ end:
 }
 
 // For Laue classes mmm, m-3, m-3m
-static int lauennn(int axes[3], const PointSymmetry* pointsym,
-                   const int rot_order, const int aperiodic_axis) {
+static int lauennn(int axes[3], PointSymmetry const* pointsym,
+                   int const rot_order, int const aperiodic_axis) {
     int i, count, axis;
     int prop_rot[3][3];
 
@@ -956,7 +956,7 @@ static int lauennn(int axes[3], const PointSymmetry* pointsym,
     return 1;
 }
 
-static int get_rotation_axis(const int proper_rot[3][3]) {
+static int get_rotation_axis(int const proper_rot[3][3]) {
     int i, axis = -1;
     int vec[3];
 
@@ -988,8 +988,8 @@ end:
 // @param[in] proper_rot Proper rotation
 // @param[in] rot_order
 // @return Size of orthogonal axes
-static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
-                               const int rot_order) {
+static int get_orthogonal_axis(int ortho_axes[], int const proper_rot[3][3],
+                               int const rot_order) {
     int i, num_ortho_axis;
     int vec[3];
     int sum_rot[3][3], rot[3][3];
@@ -1017,7 +1017,7 @@ static int get_orthogonal_axis(int ortho_axes[], const int proper_rot[3][3],
 }
 
 // @brief If `rot` is improper, output `rot` with inversion.
-static void get_proper_rotation(int prop_rot[3][3], const int rot[3][3]) {
+static void get_proper_rotation(int prop_rot[3][3], int const rot[3][3]) {
     if (mat_get_determinant_i3(rot) == -1) {
         mat_multiply_matrix_i3(prop_rot, inversion, rot);
     } else {
@@ -1026,7 +1026,7 @@ static void get_proper_rotation(int prop_rot[3][3], const int rot[3][3]) {
 }
 
 // @brief Construct `tmat` from given indices corresponding to `rot_axes`
-static void set_transformation_matrix(int tmat[3][3], const int axes[3]) {
+static void set_transformation_matrix(int tmat[3][3], int const axes[3]) {
     int i, j, s[3];
 
     for (i = 0; i < 3; i++) {
@@ -1045,7 +1045,7 @@ static void set_transformation_matrix(int tmat[3][3], const int axes[3]) {
 
 // @brief Return 1 if axis_vec == rot_axes[axis_index],
 //        -1 if axis_vec == -rot_axes[axis_index], otherwise return 0.
-static int is_exist_axis(const int axis_vec[3], const int axis_index) {
+static int is_exist_axis(int const axis_vec[3], int const axis_index) {
     if ((axis_vec[0] == rot_axes[axis_index][0]) &&
         (axis_vec[1] == rot_axes[axis_index][1]) &&
         (axis_vec[2] == rot_axes[axis_index][2])) {
@@ -1091,7 +1091,7 @@ static void sort_axes(int axes[3]) {
 
 // Sort two-fold axes for Laue class mmm for layer group.
 // Non-periodic axis is maintained to be c-axis.
-static void layer_check_and_sort_axes(int axes[3], const int aperiodic_axis) {
+static void layer_check_and_sort_axes(int axes[3], int const aperiodic_axis) {
     int i, lattice_rank, arank, axis, axis_i;
     int t_mat[3][3];
 

--- a/src/pointgroup.h
+++ b/src/pointgroup.h
@@ -78,10 +78,10 @@ typedef struct {
 // @param[in] num_rotations
 // @param[in] aperiodic_axis Use `aperiodic_axis=-1` for space group.
 Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
-                                         const int rotations[][3][3],
-                                         const int num_rotations,
-                                         const int aperiodic_axis);
-Pointgroup ptg_get_pointgroup(const int pointgroup_number);
-PointSymmetry ptg_get_pointsymmetry(const int rotations[][3][3],
-                                    const int num_rotations);
+                                         int const rotations[][3][3],
+                                         int const num_rotations,
+                                         int const aperiodic_axis);
+Pointgroup ptg_get_pointgroup(int const pointgroup_number);
+PointSymmetry ptg_get_pointsymmetry(int const rotations[][3][3],
+                                    int const num_rotations);
 #endif

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -46,33 +46,33 @@
 #define REDUCE_RATE 0.95
 #define NUM_ATTEMPT 20
 
-static Primitive *get_primitive(const Cell *cell, const double symprec,
-                                const double angle_tolerance);
-static Cell *get_cell_with_smallest_lattice(const Cell *cell,
-                                            const double symprec);
-static Cell *get_primitive_cell(int *mapping_table, const Cell *cell,
-                                const VecDBL *pure_trans, const double symprec,
-                                const double angle_tolerance);
+static Primitive *get_primitive(Cell const *cell, double const symprec,
+                                double const angle_tolerance);
+static Cell *get_cell_with_smallest_lattice(Cell const *cell,
+                                            double const symprec);
+static Cell *get_primitive_cell(int *mapping_table, Cell const *cell,
+                                VecDBL const *pure_trans, double const symprec,
+                                double const angle_tolerance);
 static int get_primitive_lattice_vectors(double prim_lattice[3][3],
-                                         const Cell *cell,
-                                         const VecDBL *pure_trans,
-                                         const double symprec,
-                                         const double angle_tolerance);
+                                         Cell const *cell,
+                                         VecDBL const *pure_trans,
+                                         double const symprec,
+                                         double const angle_tolerance);
 static int find_primitive_lattice_vectors(double prim_lattice[3][3],
-                                          const VecDBL *vectors,
-                                          const Cell *cell,
-                                          const double symprec);
-static VecDBL *get_translation_candidates(const VecDBL *pure_trans);
-static VecDBL *collect_pure_translations(const Symmetry *symmetry);
+                                          VecDBL const *vectors,
+                                          Cell const *cell,
+                                          double const symprec);
+static VecDBL *get_translation_candidates(VecDBL const *pure_trans);
+static VecDBL *collect_pure_translations(Symmetry const *symmetry);
 static int get_primitive_in_translation_space(double t_mat[3][3],
-                                              const VecDBL *pure_trans,
-                                              const int symmetry_size,
-                                              const double symprec);
-static Symmetry *collect_primitive_symmetry(const Symmetry *symmetry,
-                                            const int primsym_size);
+                                              VecDBL const *pure_trans,
+                                              int const symmetry_size,
+                                              double const symprec);
+static Symmetry *collect_primitive_symmetry(Symmetry const *symmetry,
+                                            int const primsym_size);
 
 /* return NULL if failed */
-Primitive *prm_alloc_primitive(const int size) {
+Primitive *prm_alloc_primitive(int const size) {
     Primitive *primitive;
     int i;
 
@@ -130,17 +130,17 @@ void prm_free_primitive(Primitive *primitive) {
 }
 
 /* Return NULL if failed */
-Primitive *prm_get_primitive(const Cell *cell, const double symprec,
-                             const double angle_tolerance) {
+Primitive *prm_get_primitive(Cell const *cell, double const symprec,
+                             double const angle_tolerance) {
     return get_primitive(cell, symprec, angle_tolerance);
 }
 
 /* Return primitive cell from given pure translations. */
 /* If failed, return 0. */
-int prm_get_primitive_with_pure_trans(Primitive *primitive, const Cell *cell,
-                                      const VecDBL *pure_trans,
-                                      const double symprec,
-                                      const double angle_tolerance) {
+int prm_get_primitive_with_pure_trans(Primitive *primitive, Cell const *cell,
+                                      VecDBL const *pure_trans,
+                                      double const symprec,
+                                      double const angle_tolerance) {
     int i;
 
     if (pure_trans->size == 1) {
@@ -174,8 +174,8 @@ int prm_get_primitive_with_pure_trans(Primitive *primitive, const Cell *cell,
 /* t_mat transforms primitive cell to conventional: */
 /* (a_p, b_p, c_p) t_mat = (a_c, b_c, c_c) */
 Symmetry *prm_get_primitive_symmetry(double t_mat[3][3],
-                                     const Symmetry *symmetry,
-                                     const double symprec) {
+                                     Symmetry const *symmetry,
+                                     double const symprec) {
     int i, primsym_size;
     VecDBL *pure_trans;
     Symmetry *prim_symmetry;
@@ -234,10 +234,10 @@ Symmetry *prm_get_primitive_symmetry(double t_mat[3][3],
 }
 
 int prm_get_primitive_lattice_vectors(double prim_lattice[3][3],
-                                      const Cell *cell,
-                                      const VecDBL *pure_trans,
-                                      const double symprec,
-                                      const double angle_tolerance) {
+                                      Cell const *cell,
+                                      VecDBL const *pure_trans,
+                                      double const symprec,
+                                      double const angle_tolerance) {
     return get_primitive_lattice_vectors(prim_lattice, cell, pure_trans,
                                          symprec, angle_tolerance);
 }
@@ -247,8 +247,8 @@ int prm_get_primitive_lattice_vectors(double prim_lattice[3][3],
 /*=======*/
 
 /* Return NULL if failed */
-static Primitive *get_primitive(const Cell *cell, const double symprec,
-                                const double angle_tolerance) {
+static Primitive *get_primitive(Cell const *cell, double const symprec,
+                                double const angle_tolerance) {
     int attempt;
     double tolerance;
     Primitive *primitive;
@@ -294,8 +294,8 @@ found:
 }
 
 /* Return NULL if failed */
-static Cell *get_cell_with_smallest_lattice(const Cell *cell,
-                                            const double symprec) {
+static Cell *get_cell_with_smallest_lattice(Cell const *cell,
+                                            double const symprec) {
     int i, j, aperiodic_axis;
     double min_lat[3][3], trans_mat[3][3], inv_lat[3][3];
     Cell *smallest_cell;
@@ -340,9 +340,9 @@ static Cell *get_cell_with_smallest_lattice(const Cell *cell,
 }
 
 /* Return NULL if failed */
-static Cell *get_primitive_cell(int *mapping_table, const Cell *cell,
-                                const VecDBL *pure_trans, const double symprec,
-                                const double angle_tolerance) {
+static Cell *get_primitive_cell(int *mapping_table, Cell const *cell,
+                                VecDBL const *pure_trans, double const symprec,
+                                double const angle_tolerance) {
     int multi;
     double prim_lattice[3][3];
     Cell *primitive_cell;
@@ -377,10 +377,10 @@ not_found:
 
 /* Return 0 if failed */
 static int get_primitive_lattice_vectors(double prim_lattice[3][3],
-                                         const Cell *cell,
-                                         const VecDBL *pure_trans,
-                                         const double symprec,
-                                         const double angle_tolerance) {
+                                         Cell const *cell,
+                                         VecDBL const *pure_trans,
+                                         double const symprec,
+                                         double const angle_tolerance) {
     int i, multi, attempt;
     double tolerance;
     VecDBL *vectors, *pure_trans_reduced, *tmp_vec;
@@ -474,9 +474,9 @@ found:
 
 /* Return 0 if failed */
 static int find_primitive_lattice_vectors(double prim_lattice[3][3],
-                                          const VecDBL *vectors,
-                                          const Cell *cell,
-                                          const double symprec) {
+                                          VecDBL const *vectors,
+                                          Cell const *cell,
+                                          double const symprec) {
     int i, j, k, size, aperiodic_axis;
     double initial_volume, volume;
     double relative_lattice[3][3], min_vectors[3][3], tmp_lattice[3][3];
@@ -575,7 +575,7 @@ ret:
     return 1;
 }
 
-static VecDBL *get_translation_candidates(const VecDBL *pure_trans) {
+static VecDBL *get_translation_candidates(VecDBL const *pure_trans) {
     int i, j, multi;
     VecDBL *vectors;
 
@@ -607,7 +607,7 @@ static VecDBL *get_translation_candidates(const VecDBL *pure_trans) {
     return vectors;
 }
 
-static VecDBL *collect_pure_translations(const Symmetry *symmetry) {
+static VecDBL *collect_pure_translations(Symmetry const *symmetry) {
     int i, num_pure_trans;
     VecDBL *pure_trans;
     VecDBL *ret_pure_trans;
@@ -645,9 +645,9 @@ static VecDBL *collect_pure_translations(const Symmetry *symmetry) {
 }
 
 static int get_primitive_in_translation_space(double t_mat_inv[3][3],
-                                              const VecDBL *pure_trans,
-                                              const int symmetry_size,
-                                              const double symprec) {
+                                              VecDBL const *pure_trans,
+                                              int const symmetry_size,
+                                              double const symprec) {
     int i, j, primsym_size;
     Primitive *primitive;
     Cell *cell;
@@ -700,8 +700,8 @@ static int get_primitive_in_translation_space(double t_mat_inv[3][3],
     return 1;
 }
 
-static Symmetry *collect_primitive_symmetry(const Symmetry *symmetry,
-                                            const int primsym_size) {
+static Symmetry *collect_primitive_symmetry(Symmetry const *symmetry,
+                                            int const primsym_size) {
     int i, j, num_psym, is_found;
     Symmetry *prim_symmetry;
 

--- a/src/primitive.h
+++ b/src/primitive.h
@@ -48,21 +48,21 @@ typedef struct {
     double (*orig_lattice)[3]; /* 3x3 matrix */
 } Primitive;
 
-Primitive *prm_alloc_primitive(const int size);
+Primitive *prm_alloc_primitive(int const size);
 void prm_free_primitive(Primitive *primitive);
-Primitive *prm_get_primitive(const Cell *cell, const double symprec,
-                             const double angle_tolerance);
-int prm_get_primitive_with_pure_trans(Primitive *primitive, const Cell *cell,
-                                      const VecDBL *pure_trans,
-                                      const double symprec,
-                                      const double angle_tolerance);
+Primitive *prm_get_primitive(Cell const *cell, double const symprec,
+                             double const angle_tolerance);
+int prm_get_primitive_with_pure_trans(Primitive *primitive, Cell const *cell,
+                                      VecDBL const *pure_trans,
+                                      double const symprec,
+                                      double const angle_tolerance);
 Symmetry *prm_get_primitive_symmetry(double t_mat[3][3],
-                                     const Symmetry *symmetry,
-                                     const double symprec);
+                                     Symmetry const *symmetry,
+                                     double const symprec);
 int prm_get_primitive_lattice_vectors(double prim_lattice[3][3],
-                                      const Cell *cell,
-                                      const VecDBL *pure_trans,
-                                      const double symprec,
-                                      const double angle_tolerance);
+                                      Cell const *cell,
+                                      VecDBL const *pure_trans,
+                                      double const symprec,
+                                      double const angle_tolerance);
 
 #endif

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -53,80 +53,80 @@
 static Cell *get_Wyckoff_positions(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
     int *crystallographic_orbits, int *std_mapping_to_primitive,
-    const Cell *primitive, const Cell *cell, const Spacegroup *spacegroup,
-    const Symmetry *symmetry, const int *mapping_table, const double symprec);
+    Cell const *primitive, Cell const *cell, Spacegroup const *spacegroup,
+    Symmetry const *symmetry, int const *mapping_table, double const symprec);
 static Cell *get_bravais_exact_positions_and_lattice(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
-    int *std_mapping_to_primitive, const Spacegroup *spacegroup,
-    const Cell *primitive, const double symprec);
+    int *std_mapping_to_primitive, Spacegroup const *spacegroup,
+    Cell const *primitive, double const symprec);
 static Cell *expand_positions_in_bravais(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
-    int *std_mapping_to_primitive, const Cell *conv_prim,
-    const Symmetry *conv_sym, const int num_pure_trans,
-    const int *wyckoffs_prim, const char (*site_symmetry_symbols_prim)[7],
-    const int *equiv_atoms_prim);
-static Cell *get_conventional_primitive(const Spacegroup *spacegroup,
-                                        const Cell *primitive);
-static int get_number_of_pure_translation(const Symmetry *conv_sym);
-static void set_tricli(double lattice[3][3], const double metric[3][3]);
-static void set_monocli(double lattice[3][3], const double metric[3][3],
-                        const char choice[6]);
-static void set_layer_monocli(double lattice[3][3], const double metric[3][3],
-                              const char choice[6]);
-static void set_ortho(double lattice[3][3], const double metric[3][3]);
-static void set_tetra(double lattice[3][3], const double metric[3][3]);
-static void set_trigo(double lattice[3][3], const double metric[3][3]);
-static void set_rhomb(double lattice[3][3], const double metric[3][3]);
-static void set_cubic(double lattice[3][3], const double metric[3][3]);
+    int *std_mapping_to_primitive, Cell const *conv_prim,
+    Symmetry const *conv_sym, int const num_pure_trans,
+    int const *wyckoffs_prim, char const (*site_symmetry_symbols_prim)[7],
+    int const *equiv_atoms_prim);
+static Cell *get_conventional_primitive(Spacegroup const *spacegroup,
+                                        Cell const *primitive);
+static int get_number_of_pure_translation(Symmetry const *conv_sym);
+static void set_tricli(double lattice[3][3], double const metric[3][3]);
+static void set_monocli(double lattice[3][3], double const metric[3][3],
+                        char const choice[6]);
+static void set_layer_monocli(double lattice[3][3], double const metric[3][3],
+                              char const choice[6]);
+static void set_ortho(double lattice[3][3], double const metric[3][3]);
+static void set_tetra(double lattice[3][3], double const metric[3][3]);
+static void set_trigo(double lattice[3][3], double const metric[3][3]);
+static void set_rhomb(double lattice[3][3], double const metric[3][3]);
+static void set_cubic(double lattice[3][3], double const metric[3][3]);
 
-static Symmetry *get_refined_symmetry_operations(const Cell *cell,
-                                                 const Cell *primitive,
-                                                 const Spacegroup *spacegroup,
-                                                 const double symprec);
+static Symmetry *get_refined_symmetry_operations(Cell const *cell,
+                                                 Cell const *primitive,
+                                                 Spacegroup const *spacegroup,
+                                                 double const symprec);
 static void set_translation_with_origin_shift(Symmetry *conv_sym,
-                                              const double origin_shift[3]);
-static Symmetry *get_primitive_db_symmetry(const double t_mat[3][3],
-                                           const Symmetry *conv_sym);
-static void get_corners(int corners[3][8], const int t_mat[3][3]);
-static void get_surrounding_frame(int frame[3], const int t_mat[3][3]);
+                                              double const origin_shift[3]);
+static Symmetry *get_primitive_db_symmetry(double const t_mat[3][3],
+                                           Symmetry const *conv_sym);
+static void get_corners(int corners[3][8], int const t_mat[3][3]);
+static void get_surrounding_frame(int frame[3], int const t_mat[3][3]);
 static int set_crystallographic_orbits(int *equiv_atoms_cell,
-                                       const Cell *primitive, const Cell *cell,
-                                       const int *equiv_atoms_prim,
-                                       const int *mapping_table);
+                                       Cell const *primitive, Cell const *cell,
+                                       int const *equiv_atoms_prim,
+                                       int const *mapping_table);
 static void set_equivalent_atoms_broken_symmetry(int *equiv_atoms_cell,
-                                                 const Cell *cell,
-                                                 const Symmetry *symmetry,
-                                                 const int *mapping_table,
-                                                 const double symprec);
-static int search_equivalent_atom(const int atom_index, const Cell *cell,
-                                  const Symmetry *symmetry,
-                                  const double symprec);
-static int search_layer_equivalent_atom(const int atom_index, const Cell *cell,
-                                        const Symmetry *symmetry,
-                                        const int periodic_axes[2],
-                                        const double symprec);
+                                                 Cell const *cell,
+                                                 Symmetry const *symmetry,
+                                                 int const *mapping_table,
+                                                 double const symprec);
+static int search_equivalent_atom(int const atom_index, Cell const *cell,
+                                  Symmetry const *symmetry,
+                                  double const symprec);
+static int search_layer_equivalent_atom(int const atom_index, Cell const *cell,
+                                        Symmetry const *symmetry,
+                                        int const periodic_axes[2],
+                                        double const symprec);
 static Symmetry *recover_symmetry_in_original_cell(
-    const Symmetry *prim_sym, const int t_mat[3][3], const double lattice[3][3],
-    const int multiplicity, const int aperiodic_axis, const double symprec);
-static VecDBL *get_lattice_translations(const int frame[3],
-                                        const double inv_tmat[3][3]);
-static VecDBL *remove_overlapping_lattice_points(const double lattice[3][3],
-                                                 const VecDBL *lattice_trans,
-                                                 const double symprec);
-static Symmetry *get_symmetry_in_original_cell(const int t_mat[3][3],
-                                               const double inv_tmat[3][3],
-                                               const double lattice[3][3],
-                                               const Symmetry *prim_sym,
-                                               const double symprec);
-static Symmetry *copy_symmetry_upon_lattice_points(const VecDBL *pure_trans,
-                                                   const Symmetry *t_sym,
-                                                   const int aperiodic_axis);
+    Symmetry const *prim_sym, int const t_mat[3][3], double const lattice[3][3],
+    int const multiplicity, int const aperiodic_axis, double const symprec);
+static VecDBL *get_lattice_translations(int const frame[3],
+                                        double const inv_tmat[3][3]);
+static VecDBL *remove_overlapping_lattice_points(double const lattice[3][3],
+                                                 VecDBL const *lattice_trans,
+                                                 double const symprec);
+static Symmetry *get_symmetry_in_original_cell(int const t_mat[3][3],
+                                               double const inv_tmat[3][3],
+                                               double const lattice[3][3],
+                                               Symmetry const *prim_sym,
+                                               double const symprec);
+static Symmetry *copy_symmetry_upon_lattice_points(VecDBL const *pure_trans,
+                                                   Symmetry const *t_sym,
+                                                   int const aperiodic_axis);
 static void measure_rigid_rotation(double rotation[3][3],
-                                   const double bravais_lattice[3][3],
-                                   const double std_lattice[3][3]);
+                                   double const bravais_lattice[3][3],
+                                   double const std_lattice[3][3]);
 static void get_orthonormal_basis(double basis[3][3],
-                                  const double lattice[3][3]);
-static const int identity[3][3] = {
+                                  double const lattice[3][3]);
+static int const identity[3][3] = {
     {1, 0, 0},
     {0, 1, 0},
     {0, 0, 1},
@@ -136,10 +136,10 @@ static const int identity[3][3] = {
 /* spacegroup->bravais_lattice and spacegroup->origin_shift are overwritten */
 /* by refined ones. */
 ExactStructure *ref_get_exact_structure_and_symmetry(Spacegroup *spacegroup,
-                                                     const Cell *primitive,
-                                                     const Cell *cell,
-                                                     const int *mapping_table,
-                                                     const double symprec) {
+                                                     Cell const *primitive,
+                                                     Cell const *cell,
+                                                     int const *mapping_table,
+                                                     double const symprec) {
     int *std_mapping_to_primitive, *wyckoffs, *equivalent_atoms;
     int *crystallographic_orbits;
     double rotation[3][3];
@@ -291,8 +291,8 @@ void ref_free_exact_structure(ExactStructure *exstr) {
 static Cell *get_Wyckoff_positions(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
     int *crystallographic_orbits, int *std_mapping_to_primitive,
-    const Cell *primitive, const Cell *cell, const Spacegroup *spacegroup,
-    const Symmetry *symmetry, const int *mapping_table, const double symprec) {
+    Cell const *primitive, Cell const *cell, Spacegroup const *spacegroup,
+    Symmetry const *symmetry, int const *mapping_table, double const symprec) {
     Cell *bravais;
     int i, j, num_prim_sym;
     int *wyckoffs_bravais, *equiv_atoms_bravais;
@@ -395,8 +395,8 @@ ret:
 /* Return NULL if failed */
 static Cell *get_bravais_exact_positions_and_lattice(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
-    int *std_mapping_to_primitive, const Spacegroup *spacegroup,
-    const Cell *primitive, const double symprec) {
+    int *std_mapping_to_primitive, Spacegroup const *spacegroup,
+    Cell const *primitive, double const symprec) {
     int i, j, num_pure_trans;
     int *wyckoffs_prim, *equiv_atoms_prim;
     char(*site_symmetry_symbols_prim)[7];
@@ -514,10 +514,10 @@ err:
 /* Return NULL if failed */
 static Cell *expand_positions_in_bravais(
     int *wyckoffs, char (*site_symmetry_symbols)[7], int *equiv_atoms,
-    int *std_mapping_to_primitive, const Cell *conv_prim,
-    const Symmetry *conv_sym, const int num_pure_trans,
-    const int *wyckoffs_prim, const char (*site_symmetry_symbols_prim)[7],
-    const int *equiv_atoms_prim) {
+    int *std_mapping_to_primitive, Cell const *conv_prim,
+    Symmetry const *conv_sym, int const num_pure_trans,
+    int const *wyckoffs_prim, char const (*site_symmetry_symbols_prim)[7],
+    int const *equiv_atoms_prim) {
     int i, j, k, lattice_rank;
     int num_atom;
     Cell *bravais;
@@ -570,7 +570,7 @@ static Cell *expand_positions_in_bravais(
     return bravais;
 }
 
-static int get_number_of_pure_translation(const Symmetry *conv_sym) {
+static int get_number_of_pure_translation(Symmetry const *conv_sym) {
     int i, num_pure_trans = 0;
 
     for (i = 0; i < conv_sym->size; i++) {
@@ -582,8 +582,8 @@ static int get_number_of_pure_translation(const Symmetry *conv_sym) {
     return num_pure_trans;
 }
 
-static Cell *get_conventional_primitive(const Spacegroup *spacegroup,
-                                        const Cell *primitive) {
+static Cell *get_conventional_primitive(Spacegroup const *spacegroup,
+                                        Cell const *primitive) {
     int i, j;
     double inv_brv[3][3], trans_mat[3][3];
     Cell *conv_prim;
@@ -617,7 +617,7 @@ static Cell *get_conventional_primitive(const Spacegroup *spacegroup,
 /* Return standardized transformation matrix for given space-group type and
  * settings. */
 void ref_get_conventional_lattice(double lattice[3][3],
-                                  const Spacegroup *spacegroup) {
+                                  Spacegroup const *spacegroup) {
     int i, j;
     double metric[3][3];
     Pointgroup pointgroup;
@@ -674,7 +674,7 @@ void ref_get_conventional_lattice(double lattice[3][3],
 
 /* The conversion refers the wikipedia, */
 /* http://en.wikipedia.org/wiki/Fractional_coordinates */
-static void set_tricli(double lattice[3][3], const double metric[3][3]) {
+static void set_tricli(double lattice[3][3], double const metric[3][3]) {
     double a, b, c, alpha, beta, gamma, cg, cb, ca, sg;
 
     a = sqrt(metric[0][0]);
@@ -698,8 +698,8 @@ static void set_tricli(double lattice[3][3], const double metric[3][3]) {
         c * sqrt(1 - ca * ca - cb * cb - cg * cg + 2 * ca * cb * cg) / sg;
 }
 
-static void set_monocli(double lattice[3][3], const double metric[3][3],
-                        const char choice[6]) {
+static void set_monocli(double lattice[3][3], double const metric[3][3],
+                        char const choice[6]) {
     double a, b, c, angle;
     int pos_char;
 
@@ -745,8 +745,8 @@ static void set_monocli(double lattice[3][3], const double metric[3][3],
 
 /* Monoclinic/Rectangular: a-axis is the unique axis */
 /* Monoclinic/Oblique: c-axis is the unique axis */
-static void set_layer_monocli(double lattice[3][3], const double metric[3][3],
-                              const char choice[6]) {
+static void set_layer_monocli(double lattice[3][3], double const metric[3][3],
+                              char const choice[6]) {
     double a, b, c, angle;
 
     debug_print("set_layer_monocli:\n");
@@ -783,7 +783,7 @@ static void set_layer_monocli(double lattice[3][3], const double metric[3][3],
     }
 }
 
-static void set_ortho(double lattice[3][3], const double metric[3][3]) {
+static void set_ortho(double lattice[3][3], double const metric[3][3]) {
     double a, b, c;
     a = sqrt(metric[0][0]);
     b = sqrt(metric[1][1]);
@@ -793,7 +793,7 @@ static void set_ortho(double lattice[3][3], const double metric[3][3]) {
     lattice[2][2] = c;
 }
 
-static void set_tetra(double lattice[3][3], const double metric[3][3]) {
+static void set_tetra(double lattice[3][3], double const metric[3][3]) {
     double a, b, c;
     a = sqrt(metric[0][0]);
     b = sqrt(metric[1][1]);
@@ -803,7 +803,7 @@ static void set_tetra(double lattice[3][3], const double metric[3][3]) {
     lattice[2][2] = c;
 }
 
-static void set_rhomb(double lattice[3][3], const double metric[3][3]) {
+static void set_rhomb(double lattice[3][3], double const metric[3][3]) {
     double a, b, c, angle, ahex, chex;
 
     a = sqrt(metric[0][0]);
@@ -843,7 +843,7 @@ static void set_rhomb(double lattice[3][3], const double metric[3][3]) {
 #endif
 }
 
-static void set_trigo(double lattice[3][3], const double metric[3][3]) {
+static void set_trigo(double lattice[3][3], double const metric[3][3]) {
     double a, b, c;
 
     a = sqrt(metric[0][0]);
@@ -855,7 +855,7 @@ static void set_trigo(double lattice[3][3], const double metric[3][3]) {
     lattice[2][2] = c;
 }
 
-static void set_cubic(double lattice[3][3], const double metric[3][3]) {
+static void set_cubic(double lattice[3][3], double const metric[3][3]) {
     double a, b, c;
 
     a = sqrt(metric[0][0]);
@@ -867,10 +867,10 @@ static void set_cubic(double lattice[3][3], const double metric[3][3]) {
 }
 
 /* Return NULL if failed */
-static Symmetry *get_refined_symmetry_operations(const Cell *cell,
-                                                 const Cell *primitive,
-                                                 const Spacegroup *spacegroup,
-                                                 const double symprec) {
+static Symmetry *get_refined_symmetry_operations(Cell const *cell,
+                                                 Cell const *primitive,
+                                                 Spacegroup const *spacegroup,
+                                                 double const symprec) {
     int t_mat_int[3][3];
     double inv_prim_lat[3][3], t_mat[3][3];
     Symmetry *conv_sym, *prim_sym, *symmetry;
@@ -914,9 +914,9 @@ static Symmetry *get_refined_symmetry_operations(const Cell *cell,
 }
 
 static int set_crystallographic_orbits(int *equiv_atoms_cell,
-                                       const Cell *primitive, const Cell *cell,
-                                       const int *equiv_atoms_prim,
-                                       const int *mapping_table) {
+                                       Cell const *primitive, Cell const *cell,
+                                       int const *equiv_atoms_prim,
+                                       int const *mapping_table) {
     int i, j;
     int *equiv_atoms;
 
@@ -946,10 +946,10 @@ static int set_crystallographic_orbits(int *equiv_atoms_cell,
 }
 
 static void set_equivalent_atoms_broken_symmetry(int *equiv_atoms_cell,
-                                                 const Cell *cell,
-                                                 const Symmetry *symmetry,
-                                                 const int *mapping_table,
-                                                 const double symprec) {
+                                                 Cell const *cell,
+                                                 Symmetry const *symmetry,
+                                                 int const *mapping_table,
+                                                 double const symprec) {
     int i, j;
     int periodic_axes[2];
 
@@ -995,9 +995,9 @@ static void set_equivalent_atoms_broken_symmetry(int *equiv_atoms_cell,
     }
 }
 
-static int search_equivalent_atom(const int atom_index, const Cell *cell,
-                                  const Symmetry *symmetry,
-                                  const double symprec) {
+static int search_equivalent_atom(int const atom_index, Cell const *cell,
+                                  Symmetry const *symmetry,
+                                  double const symprec) {
     int i, j;
     double pos_rot[3];
 
@@ -1018,10 +1018,10 @@ static int search_equivalent_atom(const int atom_index, const Cell *cell,
     return atom_index;
 }
 
-static int search_layer_equivalent_atom(const int atom_index, const Cell *cell,
-                                        const Symmetry *symmetry,
-                                        const int periodic_axes[2],
-                                        const double symprec) {
+static int search_layer_equivalent_atom(int const atom_index, Cell const *cell,
+                                        Symmetry const *symmetry,
+                                        int const periodic_axes[2],
+                                        double const symprec) {
     int i, j;
     double pos_rot[3];
 
@@ -1044,7 +1044,7 @@ static int search_layer_equivalent_atom(const int atom_index, const Cell *cell,
 }
 
 static void set_translation_with_origin_shift(Symmetry *conv_sym,
-                                              const double origin_shift[3]) {
+                                              double const origin_shift[3]) {
     int i, j;
     double tmp_vec[3];
     int tmp_mat[3][3];
@@ -1062,8 +1062,8 @@ static void set_translation_with_origin_shift(Symmetry *conv_sym,
     }
 }
 
-static Symmetry *get_primitive_db_symmetry(const double t_mat[3][3],
-                                           const Symmetry *conv_sym) {
+static Symmetry *get_primitive_db_symmetry(double const t_mat[3][3],
+                                           Symmetry const *conv_sym) {
     int i, j, num_op;
     double inv_mat[3][3], tmp_mat[3][3];
     MatINT *r_prim;
@@ -1129,7 +1129,7 @@ ret:
     return prim_sym;
 }
 
-static void get_surrounding_frame(int frame[3], const int t_mat[3][3]) {
+static void get_surrounding_frame(int frame[3], int const t_mat[3][3]) {
     int i, j, max, min;
     int corners[3][8];
 
@@ -1150,7 +1150,7 @@ static void get_surrounding_frame(int frame[3], const int t_mat[3][3]) {
     }
 }
 
-static void get_corners(int corners[3][8], const int t_mat[3][3]) {
+static void get_corners(int corners[3][8], int const t_mat[3][3]) {
     int i, j;
 
     /* O */
@@ -1179,8 +1179,8 @@ static void get_corners(int corners[3][8], const int t_mat[3][3]) {
 }
 
 static Symmetry *recover_symmetry_in_original_cell(
-    const Symmetry *prim_sym, const int t_mat[3][3], const double lattice[3][3],
-    const int multiplicity, const int aperiodic_axis, const double symprec) {
+    Symmetry const *prim_sym, int const t_mat[3][3], double const lattice[3][3],
+    int const multiplicity, int const aperiodic_axis, double const symprec) {
     Symmetry *symmetry, *t_sym;
     int frame[3];
     double inv_tmat[3][3], tmp_mat[3][3];
@@ -1231,8 +1231,8 @@ static Symmetry *recover_symmetry_in_original_cell(
 }
 
 /* Return NULL if failed */
-static VecDBL *get_lattice_translations(const int frame[3],
-                                        const double inv_tmat[3][3]) {
+static VecDBL *get_lattice_translations(int const frame[3],
+                                        double const inv_tmat[3][3]) {
     int i, j, k, l, num_trans;
     VecDBL *lattice_trans;
 
@@ -1267,9 +1267,9 @@ static VecDBL *get_lattice_translations(const int frame[3],
     return lattice_trans;
 }
 
-static VecDBL *remove_overlapping_lattice_points(const double lattice[3][3],
-                                                 const VecDBL *lattice_trans,
-                                                 const double symprec) {
+static VecDBL *remove_overlapping_lattice_points(double const lattice[3][3],
+                                                 VecDBL const *lattice_trans,
+                                                 double const symprec) {
     int i, j, is_found, num_pure_trans;
     VecDBL *pure_trans, *t;
 
@@ -1313,11 +1313,11 @@ static VecDBL *remove_overlapping_lattice_points(const double lattice[3][3],
 }
 
 /* Return NULL if failed */
-static Symmetry *get_symmetry_in_original_cell(const int t_mat[3][3],
-                                               const double inv_tmat[3][3],
-                                               const double lattice[3][3],
-                                               const Symmetry *prim_sym,
-                                               const double symprec) {
+static Symmetry *get_symmetry_in_original_cell(int const t_mat[3][3],
+                                               double const inv_tmat[3][3],
+                                               double const lattice[3][3],
+                                               Symmetry const *prim_sym,
+                                               double const symprec) {
     int i, size_sym_orig;
     double tmp_rot_d[3][3], tmp_lat_d[3][3], tmp_lat_i[3][3], tmp_mat[3][3];
     int tmp_rot_i[3][3];
@@ -1378,9 +1378,9 @@ static Symmetry *get_symmetry_in_original_cell(const int t_mat[3][3],
 }
 
 /* Return NULL if failed */
-static Symmetry *copy_symmetry_upon_lattice_points(const VecDBL *pure_trans,
-                                                   const Symmetry *t_sym,
-                                                   const int aperiodic_axis) {
+static Symmetry *copy_symmetry_upon_lattice_points(VecDBL const *pure_trans,
+                                                   Symmetry const *t_sym,
+                                                   int const aperiodic_axis) {
     int i, j, k, size_sym_orig;
     Symmetry *symmetry;
 
@@ -1416,7 +1416,7 @@ static Symmetry *copy_symmetry_upon_lattice_points(const VecDBL *pure_trans,
 /* spacegroup->bravais_lattice and spacegroup->origin_shift are overwritten */
 /* by refined ones. Return 0 if failed. */
 int ref_find_similar_bravais_lattice(Spacegroup *spacegroup,
-                                     const double symprec) {
+                                     double const symprec) {
     int i, j, k, rot_i, lattice_rank;
     Symmetry *conv_sym;
     double min_length2, length2, diff, min_length, length;
@@ -1523,8 +1523,8 @@ int ref_find_similar_bravais_lattice(Spacegroup *spacegroup,
 
 /* Calculate `rotation` s.t. std_lattice = rotation @ bravais_lattice */
 static void measure_rigid_rotation(double rotation[3][3],
-                                   const double bravais_lattice[3][3],
-                                   const double std_lattice[3][3]) {
+                                   double const bravais_lattice[3][3],
+                                   double const std_lattice[3][3]) {
     /* (a_s^ideal, b_s^ideal, c_s^ideal) = R(a_s, b_s, c_s) */
     double brv_basis[3][3], std_basis[3][3], inv_brv_basis[3][3];
 
@@ -1535,7 +1535,7 @@ static void measure_rigid_rotation(double rotation[3][3],
 }
 
 static void get_orthonormal_basis(double basis[3][3],
-                                  const double lattice[3][3]) {
+                                  double const lattice[3][3]) {
     int i, j;
     double length;
     double basis_T[3][3], lattice_T[3][3];

--- a/src/refinement.h
+++ b/src/refinement.h
@@ -51,14 +51,14 @@ typedef struct {
 } ExactStructure;
 
 ExactStructure *ref_get_exact_structure_and_symmetry(Spacegroup *spacegroup,
-                                                     const Cell *primitive,
-                                                     const Cell *cell,
-                                                     const int *mapping_table,
-                                                     const double symprec);
+                                                     Cell const *primitive,
+                                                     Cell const *cell,
+                                                     int const *mapping_table,
+                                                     double const symprec);
 void ref_free_exact_structure(ExactStructure *exstr);
 int ref_find_similar_bravais_lattice(Spacegroup *spacegroup,
-                                     const double symprec);
+                                     double const symprec);
 void ref_get_conventional_lattice(double lattice[3][3],
-                                  const Spacegroup *spacegroup);
+                                  Spacegroup const *spacegroup);
 
 #endif

--- a/src/site_symmetry.c
+++ b/src/site_symmetry.c
@@ -49,48 +49,48 @@
 /* set_exact_location, set_equivalent_atom and get_Wyckoff_notation */
 /* are duplicated to get the if statement outside the nested loops */
 /* I have not tested if it is better in efficiency. */
-static VecDBL *get_exact_positions(int *equiv_atoms, const Cell *conv_prim,
-                                   const Symmetry *conv_sym,
-                                   const double symprec);
-static void set_exact_location(double position[3], const Symmetry *conv_sym,
-                               const double bravais_lattice[3][3],
-                               const double symprec);
-static int set_equivalent_atom(VecDBL *positions, int *equiv_atoms, const int i,
-                               const int num_indep_atoms,
-                               const int *indep_atoms, const Cell *conv_prim,
-                               const Symmetry *conv_sym, const double symprec);
+static VecDBL *get_exact_positions(int *equiv_atoms, Cell const *conv_prim,
+                                   Symmetry const *conv_sym,
+                                   double const symprec);
+static void set_exact_location(double position[3], Symmetry const *conv_sym,
+                               double const bravais_lattice[3][3],
+                               double const symprec);
+static int set_equivalent_atom(VecDBL *positions, int *equiv_atoms, int const i,
+                               int const num_indep_atoms,
+                               int const *indep_atoms, Cell const *conv_prim,
+                               Symmetry const *conv_sym, double const symprec);
 static void set_layer_exact_location(double position[3],
-                                     const Symmetry *conv_sym,
-                                     const double bravais_lattice[3][3],
-                                     const double symprec);
+                                     Symmetry const *conv_sym,
+                                     double const bravais_lattice[3][3],
+                                     double const symprec);
 static int set_layer_equivalent_atom(VecDBL *positions, int *equiv_atoms,
-                                     const int i, const int num_indep_atoms,
-                                     const int *indep_atoms,
-                                     const Cell *conv_prim,
-                                     const Symmetry *conv_sym,
-                                     const double symprec);
+                                     int const i, int const num_indep_atoms,
+                                     int const *indep_atoms,
+                                     Cell const *conv_prim,
+                                     Symmetry const *conv_sym,
+                                     double const symprec);
 static int set_Wyckoffs_labels(int *wyckoffs, char (*site_symmetry_symbols)[7],
-                               const VecDBL *positions, const int *equiv_atoms,
-                               const Cell *conv_prim, const Symmetry *conv_sym,
-                               const int num_pure_trans, const int hall_number,
-                               const double symprec);
+                               VecDBL const *positions, int const *equiv_atoms,
+                               Cell const *conv_prim, Symmetry const *conv_sym,
+                               int const num_pure_trans, int const hall_number,
+                               double const symprec);
 static int get_Wyckoff_notation(char site_sym_symbol[7],
-                                const double position[3],
-                                const Symmetry *conv_sym,
-                                const int ref_multiplicity,
-                                const double bravais_lattice[3][3],
-                                const int hall_number, const double symprec);
+                                double const position[3],
+                                Symmetry const *conv_sym,
+                                int const ref_multiplicity,
+                                double const bravais_lattice[3][3],
+                                int const hall_number, double const symprec);
 static int get_layer_Wyckoff_notation(
-    char site_sym_symbol[7], const double position[3], const Symmetry *conv_sym,
-    const int ref_multiplicity, const double bravais_lattice[3][3],
-    const int hall_number, const double symprec);
+    char site_sym_symbol[7], double const position[3], Symmetry const *conv_sym,
+    int const ref_multiplicity, double const bravais_lattice[3][3],
+    int const hall_number, double const symprec);
 
 /* Return NULL if failed */
 VecDBL *ssm_get_exact_positions(int *wyckoffs, int *equiv_atoms,
                                 char (*site_symmetry_symbols)[7],
-                                const Cell *conv_prim, const Symmetry *conv_sym,
-                                const int num_pure_trans, const int hall_number,
-                                const double symprec) {
+                                Cell const *conv_prim, Symmetry const *conv_sym,
+                                int const num_pure_trans, int const hall_number,
+                                double const symprec) {
     int i;
     double tolerance;
     VecDBL *positions;
@@ -123,9 +123,9 @@ VecDBL *ssm_get_exact_positions(int *wyckoffs, int *equiv_atoms,
 }
 
 /* Return 0: succeeded, 1: tolerance too large, -1: tolerance too short */
-static VecDBL *get_exact_positions(int *equiv_atoms, const Cell *conv_prim,
-                                   const Symmetry *conv_sym,
-                                   const double symprec) {
+static VecDBL *get_exact_positions(int *equiv_atoms, Cell const *conv_prim,
+                                   Symmetry const *conv_sym,
+                                   double const symprec) {
     int i, num_indep_atoms;
     int *indep_atoms;
     VecDBL *positions;
@@ -186,10 +186,10 @@ static VecDBL *get_exact_positions(int *equiv_atoms, const Cell *conv_prim,
     return positions;
 }
 
-static int set_equivalent_atom(VecDBL *positions, int *equiv_atoms, const int i,
-                               const int num_indep_atoms,
-                               const int *indep_atoms, const Cell *conv_prim,
-                               const Symmetry *conv_sym, const double symprec) {
+static int set_equivalent_atom(VecDBL *positions, int *equiv_atoms, int const i,
+                               int const num_indep_atoms,
+                               int const *indep_atoms, Cell const *conv_prim,
+                               Symmetry const *conv_sym, double const symprec) {
     int j, k, l;
     double pos[3];
 
@@ -219,9 +219,9 @@ static int set_equivalent_atom(VecDBL *positions, int *equiv_atoms, const int i,
 /* Site-symmetry is used to determine exact location of an atom */
 /* R. W. Grosse-Kunstleve and P. D. Adams */
 /* Acta Cryst. (2002). A58, 60-65 */
-static void set_exact_location(double position[3], const Symmetry *conv_sym,
-                               const double bravais_lattice[3][3],
-                               const double symprec) {
+static void set_exact_location(double position[3], Symmetry const *conv_sym,
+                               double const bravais_lattice[3][3],
+                               double const symprec) {
     int i, j, k, num_site_sym;
     double sum_rot[3][3];
     double pos[3], sum_trans[3];
@@ -271,11 +271,11 @@ static void set_exact_location(double position[3], const Symmetry *conv_sym,
 }
 
 static int set_layer_equivalent_atom(VecDBL *positions, int *equiv_atoms,
-                                     const int i, const int num_indep_atoms,
-                                     const int *indep_atoms,
-                                     const Cell *conv_prim,
-                                     const Symmetry *conv_sym,
-                                     const double symprec) {
+                                     int const i, int const num_indep_atoms,
+                                     int const *indep_atoms,
+                                     Cell const *conv_prim,
+                                     Symmetry const *conv_sym,
+                                     double const symprec) {
     int j, k, l;
     double pos[3];
     int periodic_axes[2] = {0, 1};
@@ -307,9 +307,9 @@ static int set_layer_equivalent_atom(VecDBL *positions, int *equiv_atoms,
 /* R. W. Grosse-Kunstleve and P. D. Adams */
 /* Acta Cryst. (2002). A58, 60-65 */
 static void set_layer_exact_location(double position[3],
-                                     const Symmetry *conv_sym,
-                                     const double bravais_lattice[3][3],
-                                     const double symprec) {
+                                     Symmetry const *conv_sym,
+                                     double const bravais_lattice[3][3],
+                                     double const symprec) {
     int i, j, k, num_site_sym;
     double sum_rot[3][3];
     double pos[3], sum_trans[3];
@@ -361,10 +361,10 @@ static void set_layer_exact_location(double position[3],
 }
 
 static int set_Wyckoffs_labels(int *wyckoffs, char (*site_symmetry_symbols)[7],
-                               const VecDBL *positions, const int *equiv_atoms,
-                               const Cell *conv_prim, const Symmetry *conv_sym,
-                               const int num_pure_trans, const int hall_number,
-                               const double symprec) {
+                               VecDBL const *positions, int const *equiv_atoms,
+                               Cell const *conv_prim, Symmetry const *conv_sym,
+                               int const num_pure_trans, int const hall_number,
+                               double const symprec) {
     int i, j, w;
     int *nums_equiv_atoms;
 
@@ -435,11 +435,11 @@ err:
 
 /* Return -1 if failed */
 static int get_Wyckoff_notation(char site_sym_symbol[7],
-                                const double position[3],
-                                const Symmetry *conv_sym,
-                                const int ref_multiplicity,
-                                const double bravais_lattice[3][3],
-                                const int hall_number, const double symprec) {
+                                double const position[3],
+                                Symmetry const *conv_sym,
+                                int const ref_multiplicity,
+                                double const bravais_lattice[3][3],
+                                int const hall_number, double const symprec) {
     int i, j, k, l, num_sitesym, multiplicity, wyckoff_letter;
     int indices_wyc[2];
     int rot[3][3];
@@ -516,9 +516,9 @@ end:
 
 /* Return -1 if failed */
 static int get_layer_Wyckoff_notation(
-    char site_sym_symbol[7], const double position[3], const Symmetry *conv_sym,
-    const int ref_multiplicity, const double bravais_lattice[3][3],
-    const int hall_number, const double symprec) {
+    char site_sym_symbol[7], double const position[3], Symmetry const *conv_sym,
+    int const ref_multiplicity, double const bravais_lattice[3][3],
+    int const hall_number, double const symprec) {
     int i, j, k, l, num_sitesym, multiplicity, wyckoff_letter;
     int indices_wyc[2];
     int rot[3][3];

--- a/src/site_symmetry.h
+++ b/src/site_symmetry.h
@@ -41,8 +41,8 @@
 
 VecDBL* ssm_get_exact_positions(int* wyckoffs, int* equiv_atoms,
                                 char (*site_symmetry_symbols)[7],
-                                const Cell* bravais, const Symmetry* conv_sym,
-                                const int num_pure_trans, const int hall_number,
-                                const double symprec);
+                                Cell const* bravais, Symmetry const* conv_sym,
+                                int const num_pure_trans, int const hall_number,
+                                double const symprec);
 
 #endif

--- a/src/sitesym_database.c
+++ b/src/sitesym_database.c
@@ -40,7 +40,7 @@
 /* Space group No. 1: 1 = 2-1 */
 /* Space group No. 2: 9 = 11-2 */
 /* Space group No. 3: 5 = 16-11 */
-static const int position_wyckoff[] = {
+static int const position_wyckoff[] = {
     0,    1,    2,    11,   16,   21,   26,   27,   28,   29,   32,   35,
     38,   41,   44,   47,   50,   53,   56,   59,   62,   65,   66,   67,
     68,   69,   70,   71,   72,   73,   74,   76,   78,   80,   82,   84,
@@ -88,7 +88,7 @@ static const int position_wyckoff[] = {
     3440, 3448, 3460, 3468,
 };
 
-static const int position_layer_wyckoff[] = {
+static int const position_layer_wyckoff[] = {
     0,    3468, 3469, 3474, 3479, 3481, 3482, 3483, 3484, 3494, 3499, 3504,
     3509, 3512, 3515, 3516, 3517, 3519, 3521, 3524, 3527, 3528, 3529, 3531,
     3533, 3542, 3551, 3555, 3559, 3563, 3567, 3570, 3573, 3579, 3585, 3598,
@@ -109,7 +109,7 @@ static const int position_layer_wyckoff[] = {
 /* If x is at the 'Coordinates', x'=x (mod Z). */
 /* 63923 is decoded to identity and (0, 0, 0) matrices, respectively. */
 /* See ssmdb_get_coordinate. */
-static const int coordinates_first[] = {
+static int const coordinates_first[] = {
     0,          63923,     63923,     657239062,  27383062,   630995062,
     656145562,  629901562, 26289562,  1139062,    45562,      63923,
     630995197,  629901697, 1139197,   45697,      63923,      656145563,
@@ -795,7 +795,7 @@ static const int coordinates_first[] = {
     629901562,  45563,     454941562, 45562,
 };
 
-static const int multiplicities[] = {
+static int const multiplicities[] = {
     0,  1,  2,   1,   1,  1,  1,  1,  1,   1,  1,  2,  1,   1,  1,  1,  2,  1,
     1,  1,  1,   2,   1,  1,  1,  1,  2,   2,  2,  4,  2,   2,  4,  2,  2,  4,
     2,  2,  4,   2,   2,  4,  2,  2,  4,   2,  2,  4,  2,   2,  4,  2,  2,  4,
@@ -1026,7 +1026,7 @@ static const int multiplicities[] = {
     12, 12, 6,   6,   6,  4,  3,  2,  2,   1,
 };
 
-static const char site_symmetry_symbols[][7] = {
+static char const site_symmetry_symbols[][7] = {
     "      ", "1     ", "1     ", "-1    ", "-1    ", "-1    ", "-1    ",
     "-1    ", "-1    ", "-1    ", "-1    ", "1     ", "2     ", "2     ",
     "2     ", "2     ", "1     ", "2     ", "2     ", "2     ", "2     ",
@@ -1615,7 +1615,7 @@ static const char site_symmetry_symbols[][7] = {
     "6/mmm ",
 };
 
-int ssmdb_get_coordinate(int rot[3][3], double trans[3], const int index) {
+int ssmdb_get_coordinate(int rot[3][3], double trans[3], int const index) {
     int i, rot_enc, trans_enc;
     int rows[3], trans_int[3];
 
@@ -1653,7 +1653,7 @@ int ssmdb_get_coordinate(int rot[3][3], double trans[3], const int index) {
 
 /* databases for layer group is directly added behind its spacegroup
  * counterparts */
-void ssmdb_get_wyckoff_indices(int indices[2], const int index) {
+void ssmdb_get_wyckoff_indices(int indices[2], int const index) {
     if (index > 0) {
         indices[0] = position_wyckoff[index];
         indices[1] = position_wyckoff[index + 1] - position_wyckoff[index];
@@ -1664,7 +1664,7 @@ void ssmdb_get_wyckoff_indices(int indices[2], const int index) {
     }
 }
 
-void ssmdb_get_site_symmetry_symbol(char symbol[7], const int index) {
+void ssmdb_get_site_symmetry_symbol(char symbol[7], int const index) {
     int i;
 
     for (i = 0; i < 6; i++) {

--- a/src/sitesym_database.h
+++ b/src/sitesym_database.h
@@ -35,8 +35,8 @@
 #ifndef __sitesym_database_H__
 #define __sitesym_database_H__
 
-int ssmdb_get_coordinate(int rot[3][3], double trans[3], const int index);
-void ssmdb_get_wyckoff_indices(int indices[2], const int index);
-void ssmdb_get_site_symmetry_symbol(char symbol[7], const int index);
+int ssmdb_get_coordinate(int rot[3][3], double trans[3], int const index);
+void ssmdb_get_wyckoff_indices(int indices[2], int const index);
+void ssmdb_get_site_symmetry_symbol(char symbol[7], int const index);
 
 #endif

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -384,103 +384,103 @@ static double F_mat[3][3] = {
     {0, 1. / 2, 1. / 2}, {1. / 2, 0, 1. / 2}, {1. / 2, 1. / 2, 0}};
 
 static Spacegroup *search_spacegroup_with_symmetry(
-    const Primitive *primitive, const int candidates[],
-    const int num_candidates, const Symmetry *symmetry, const double symprec,
-    const double angle_tolerance);
-static Spacegroup *get_spacegroup(const int hall_number,
-                                  const double origin_shift[3],
-                                  const double conv_lattice[3][3]);
+    Primitive const *primitive, int const candidates[],
+    int const num_candidates, Symmetry const *symmetry, double const symprec,
+    double const angle_tolerance);
+static Spacegroup *get_spacegroup(int const hall_number,
+                                  double const origin_shift[3],
+                                  double const conv_lattice[3][3]);
 static int iterative_search_hall_number(
-    double origin_shift[3], double conv_lattice[3][3], const int candidates[],
-    const int num_candidates, const Primitive *primitive,
-    const Symmetry *symmetry, const double symprec,
-    const double angle_tolerance);
+    double origin_shift[3], double conv_lattice[3][3], int const candidates[],
+    int const num_candidates, Primitive const *primitive,
+    Symmetry const *symmetry, double const symprec,
+    double const angle_tolerance);
 static int change_basis_tricli(int tmat_int[3][3],
-                               const double conv_lattice[3][3],
-                               const double primitive_lattice[3][3],
-                               const double symprec, const int aperiodic_axis);
+                               double const conv_lattice[3][3],
+                               double const primitive_lattice[3][3],
+                               double const symprec, int const aperiodic_axis);
 static int change_basis_monocli(int tmat_int[3][3],
-                                const double conv_lattice[3][3],
-                                const double primitive_lattice[3][3],
-                                const double symprec,
-                                const int aperiodic_axis_prim);
-static Symmetry *get_initial_conventional_symmetry(const Centering centering,
-                                                   const double tmat[3][3],
-                                                   const Symmetry *symmetry);
+                                double const conv_lattice[3][3],
+                                double const primitive_lattice[3][3],
+                                double const symprec,
+                                int const aperiodic_axis_prim);
+static Symmetry *get_initial_conventional_symmetry(Centering const centering,
+                                                   double const tmat[3][3],
+                                                   Symmetry const *symmetry);
 static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
-                              const int candidates[], const int num_candidates,
-                              const Primitive *primitive,
-                              const Symmetry *symmetry, const double symprec);
+                              int const candidates[], int const num_candidates,
+                              Primitive const *primitive,
+                              Symmetry const *symmetry, double const symprec);
 static int match_hall_symbol_db(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const int pointgroup_number, const Holohedry holohedry,
-    const Centering centering, const Symmetry *symmetry, const double symprec);
+    double const (*orig_lattice)[3], int const hall_number,
+    int const pointgroup_number, Holohedry const holohedry,
+    Centering const centering, Symmetry const *symmetry, double const symprec);
 static int match_hall_symbol_db_monocli(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const int group_number, const Centering centering,
-    const Symmetry *conv_symmetry, const double symprec);
+    double const (*orig_lattice)[3], int const hall_number,
+    int const group_number, Centering const centering,
+    Symmetry const *conv_symmetry, double const symprec);
 static int match_hall_symbol_db_monocli_in_loop(
     double origin_shift[3], double conv_lattice[3][3], double norms_squared[2],
-    const int change_of_basis_index, const double (*orig_lattice)[3],
-    const int check_norms, const int hall_number, const Centering centering,
-    const Symmetry *conv_symmetry, const double symprec);
+    int const change_of_basis_index, double const (*orig_lattice)[3],
+    int const check_norms, int const hall_number, Centering const centering,
+    Symmetry const *conv_symmetry, double const symprec);
 static int match_hall_symbol_db_ortho(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const Centering centering, const Symmetry *symmetry,
-    const int num_free_axes, const double symprec);
+    double const (*orig_lattice)[3], int const hall_number,
+    Centering const centering, Symmetry const *symmetry,
+    int const num_free_axes, double const symprec);
 static int match_hall_symbol_db_ortho_in_loop(
     double origin_shift[3], double lattice[3][3],
-    const double (*orig_lattice)[3], const int axis_choice_index,
-    const int hall_number, const Centering centering, const Symmetry *symmetry,
-    const int num_free_axes, const double symprec);
+    double const (*orig_lattice)[3], int const axis_choice_index,
+    int const hall_number, Centering const centering, Symmetry const *symmetry,
+    int const num_free_axes, double const symprec);
 static int match_hall_symbol_db_cubic(double origin_shift[3],
                                       double conv_lattice[3][3],
-                                      const double (*orig_lattice)[3],
-                                      const int hall_number,
-                                      const Centering centering,
-                                      const Symmetry *conv_symmetry,
-                                      const double symprec);
+                                      double const (*orig_lattice)[3],
+                                      int const hall_number,
+                                      Centering const centering,
+                                      Symmetry const *conv_symmetry,
+                                      double const symprec);
 static int match_hall_symbol_db_cubic_in_loop(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int i, const int hall_number,
-    const Centering centering, const Symmetry *conv_symmetry,
-    const double symprec);
+    double const (*orig_lattice)[3], int const i, int const hall_number,
+    Centering const centering, Symmetry const *conv_symmetry,
+    double const symprec);
 static int match_hall_symbol_db_rhombo(double origin_shift[3],
                                        double conv_lattice[3][3],
-                                       const double (*orig_lattice)[3],
-                                       const int hall_number,
-                                       const Symmetry *conv_symmetry,
-                                       const double symprec);
+                                       double const (*orig_lattice)[3],
+                                       int const hall_number,
+                                       Symmetry const *conv_symmetry,
+                                       double const symprec);
 static int match_hall_symbol_db_others(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const Centering centering, const Holohedry holohedry,
-    const Symmetry *conv_symmetry, const double symprec);
+    double const (*orig_lattice)[3], int const hall_number,
+    Centering const centering, Holohedry const holohedry,
+    Symmetry const *conv_symmetry, double const symprec);
 static int match_hall_symbol_db_change_of_basis_loop(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const double (*change_of_basis)[3][3],
-    const int num_change_of_basis, const int hall_number,
-    const Centering centering, const Symmetry *conv_symmetry,
-    const double symprec);
-static Symmetry *get_conventional_symmetry(const double tmat[3][3],
-                                           const Centering centering,
-                                           const Symmetry *primitive_sym);
+    double const (*orig_lattice)[3], double const (*change_of_basis)[3][3],
+    int const num_change_of_basis, int const hall_number,
+    Centering const centering, Symmetry const *conv_symmetry,
+    double const symprec);
+static Symmetry *get_conventional_symmetry(double const tmat[3][3],
+                                           Centering const centering,
+                                           Symmetry const *primitive_sym);
 static Centering get_centering(double correction_mat[3][3],
-                               const int tmat[3][3], const Laue laue);
-static Centering get_base_center(const int tmat[3][3]);
-static int get_centering_shifts(double shift[3][3], const Centering centering);
-static int is_equivalent_lattice(double tmat[3][3], const int allow_flip,
-                                 const double lattice[3][3],
-                                 const double orig_lattice[3][3],
-                                 const double symprec);
+                               int const tmat[3][3], Laue const laue);
+static Centering get_base_center(int const tmat[3][3]);
+static int get_centering_shifts(double shift[3][3], Centering const centering);
+static int is_equivalent_lattice(double tmat[3][3], int const allow_flip,
+                                 double const lattice[3][3],
+                                 double const orig_lattice[3][3],
+                                 double const symprec);
 
 /* Return NULL if failed */
-Spacegroup *spa_search_spacegroup(const Primitive *primitive,
-                                  const int hall_number, const double symprec,
-                                  const double angle_tolerance) {
+Spacegroup *spa_search_spacegroup(Primitive const *primitive,
+                                  int const hall_number, double const symprec,
+                                  double const angle_tolerance) {
     Spacegroup *spacegroup;
     Symmetry *symmetry;
     int candidate[1];
@@ -520,9 +520,9 @@ Spacegroup *spa_search_spacegroup(const Primitive *primitive,
 
 /* Return NULL if failed */
 /* Assume symmetry is transformed in primitive cell. */
-Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
-                                                const double prim_lat[3][3],
-                                                const double symprec) {
+Spacegroup *spa_search_spacegroup_with_symmetry(Symmetry const *symmetry,
+                                                double const prim_lat[3][3],
+                                                double const symprec) {
     int i;
     Spacegroup *spacegroup;
     Primitive *primitive;
@@ -548,10 +548,10 @@ Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
 }
 
 /* Return NULL if failed */
-Cell *spa_transform_to_primitive(int *mapping_table, const Cell *cell,
-                                 const double trans_mat[3][3],
-                                 const Centering centering,
-                                 const double symprec) {
+Cell *spa_transform_to_primitive(int *mapping_table, Cell const *cell,
+                                 double const trans_mat[3][3],
+                                 Centering const centering,
+                                 double const symprec) {
     double tmat[3][3], tmat_inv[3][3], prim_lat[3][3];
     Cell *primitive;
 
@@ -598,9 +598,9 @@ err:
 }
 
 /* Return NULL if failed */
-Cell *spa_transform_from_primitive(const Cell *primitive,
-                                   const Centering centering,
-                                   const double symprec) {
+Cell *spa_transform_from_primitive(Cell const *primitive,
+                                   Centering const centering,
+                                   double const symprec) {
     int multi, i, j, k, num_atom;
     int *mapping_table;
     double tmat[3][3], inv_tmat[3][3], shift[3][3];
@@ -685,7 +685,7 @@ ret:
     return trimmed_cell;
 }
 
-void spa_copy_spacegroup(Spacegroup *dst, const Spacegroup *src) {
+void spa_copy_spacegroup(Spacegroup *dst, Spacegroup const *src) {
     dst->number = src->number;
     dst->hall_number = src->hall_number;
     dst->pointgroup_number = src->pointgroup_number;
@@ -701,9 +701,9 @@ void spa_copy_spacegroup(Spacegroup *dst, const Spacegroup *src) {
 
 /* Return NULL if failed */
 static Spacegroup *search_spacegroup_with_symmetry(
-    const Primitive *primitive, const int candidates[],
-    const int num_candidates, const Symmetry *symmetry, const double symprec,
-    const double angle_tolerance) {
+    Primitive const *primitive, int const candidates[],
+    int const num_candidates, Symmetry const *symmetry, double const symprec,
+    double const angle_tolerance) {
     int hall_number;
     double conv_lattice[3][3];
     double origin_shift[3];
@@ -737,9 +737,9 @@ static Spacegroup *search_spacegroup_with_symmetry(
 }
 
 /* Return spacegroup.number = 0 if failed */
-static Spacegroup *get_spacegroup(const int hall_number,
-                                  const double origin_shift[3],
-                                  const double conv_lattice[3][3]) {
+static Spacegroup *get_spacegroup(int const hall_number,
+                                  double const origin_shift[3],
+                                  double const conv_lattice[3][3]) {
     Spacegroup *spacegroup;
     SpacegroupType spacegroup_type;
 
@@ -772,10 +772,10 @@ static Spacegroup *get_spacegroup(const int hall_number,
 
 /* Return 0 if failed */
 static int iterative_search_hall_number(
-    double origin_shift[3], double conv_lattice[3][3], const int candidates[],
-    const int num_candidates, const Primitive *primitive,
-    const Symmetry *symmetry, const double symprec,
-    const double angle_tolerance) {
+    double origin_shift[3], double conv_lattice[3][3], int const candidates[],
+    int const num_candidates, Primitive const *primitive,
+    Symmetry const *symmetry, double const symprec,
+    double const angle_tolerance) {
     int attempt, hall_number;
     double tolerance;
     Symmetry *sym_reduced;
@@ -818,9 +818,9 @@ ret:
 
 /* Return 0 if failed */
 static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
-                              const int candidates[], const int num_candidates,
-                              const Primitive *primitive,
-                              const Symmetry *symmetry, const double symprec) {
+                              int const candidates[], int const num_candidates,
+                              Primitive const *primitive,
+                              Symmetry const *symmetry, double const symprec) {
     int i, hall_number, aperiodic_axis;
     Centering centering;
     Pointgroup pointgroup;
@@ -923,9 +923,9 @@ err:
 
 // Perform Niggli cell reduction for Triclinic. Return 0 if failed.
 static int change_basis_tricli(int tmat_int[3][3],
-                               const double conv_lattice[3][3],
-                               const double primitive_lattice[3][3],
-                               const double symprec, const int aperiodic_axis) {
+                               double const conv_lattice[3][3],
+                               double const primitive_lattice[3][3],
+                               double const symprec, int const aperiodic_axis) {
     int i, j;
     double niggli_cell[9];
     double smallest_lattice[3][3], inv_lattice[3][3], tmat[3][3];
@@ -962,10 +962,10 @@ static int change_basis_tricli(int tmat_int[3][3],
 /* Monoclinic: choose shortest a, c lattice vectors (|a| < |c|) */
 /* Return 0 if failed */
 static int change_basis_monocli(int tmat_int[3][3],
-                                const double conv_lattice[3][3],
-                                const double primitive_lattice[3][3],
-                                const double symprec,
-                                const int aperiodic_axis_prim) {
+                                double const conv_lattice[3][3],
+                                double const primitive_lattice[3][3],
+                                double const symprec,
+                                int const aperiodic_axis_prim) {
     double smallest_lattice[3][3], inv_lattice[3][3], tmat[3][3];
     int i, aperiodic_axis_conv, unique_axis;
 
@@ -1002,9 +1002,9 @@ static int change_basis_monocli(int tmat_int[3][3],
 }
 
 /* Return NULL if failed */
-static Symmetry *get_initial_conventional_symmetry(const Centering centering,
-                                                   const double tmat[3][3],
-                                                   const Symmetry *symmetry) {
+static Symmetry *get_initial_conventional_symmetry(Centering const centering,
+                                                   double const tmat[3][3],
+                                                   Symmetry const *symmetry) {
     Symmetry *conv_symmetry;
 
     debug_print("get_initial_conventional_symmetry\n");
@@ -1024,9 +1024,9 @@ static Symmetry *get_initial_conventional_symmetry(const Centering centering,
 /* Return 0 if failed */
 static int match_hall_symbol_db(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const int pointgroup_number, const Holohedry holohedry,
-    const Centering centering, const Symmetry *symmetry, const double symprec) {
+    double const (*orig_lattice)[3], int const hall_number,
+    int const pointgroup_number, Holohedry const holohedry,
+    Centering const centering, Symmetry const *symmetry, double const symprec) {
     int is_found, num_free_axes;
     SpacegroupType spacegroup_type;
     Symmetry *changed_symmetry;
@@ -1144,9 +1144,9 @@ err:
 /* Return 0 if failed */
 static int match_hall_symbol_db_monocli(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const int group_number, const Centering centering,
-    const Symmetry *conv_symmetry, const double symprec) {
+    double const (*orig_lattice)[3], int const hall_number,
+    int const group_number, Centering const centering,
+    Symmetry const *conv_symmetry, double const symprec) {
     int i, check_norms, i_shortest, is_found_any, j, num_change_of_basis;
     int is_found[36];
     double shortest_norm_sum, norm_sum;
@@ -1260,9 +1260,9 @@ err:
 
 static int match_hall_symbol_db_monocli_in_loop(
     double origin_shift[3], double conv_lattice[3][3], double norms_squared[2],
-    const int change_of_basis_index, const double (*orig_lattice)[3],
-    const int check_norms, const int hall_number, const Centering centering,
-    const Symmetry *conv_symmetry, const double symprec) {
+    int const change_of_basis_index, double const (*orig_lattice)[3],
+    int const check_norms, int const hall_number, Centering const centering,
+    Symmetry const *conv_symmetry, double const symprec) {
     int j, k, l, is_found, retval, unique_axis;
     double vec[2][3];
     double tmat[3][3], change_of_basis[3][3];
@@ -1356,9 +1356,9 @@ cont:
 /* Return 0 if failed */
 static int match_hall_symbol_db_ortho(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const Centering centering, const Symmetry *conv_symmetry,
-    const int num_free_axes, const double symprec) {
+    double const (*orig_lattice)[3], int const hall_number,
+    Centering const centering, Symmetry const *conv_symmetry,
+    int const num_free_axes, double const symprec) {
     int i, j;
 
     // For layer, try axis choices abc and ba-c, which preserve the aperiodic
@@ -1403,9 +1403,9 @@ static int match_hall_symbol_db_ortho(
 // @param[in] symprec
 static int match_hall_symbol_db_ortho_in_loop(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int axis_choice_index,
-    const int hall_number, const Centering centering, const Symmetry *symmetry,
-    const int num_free_axes, const double symprec) {
+    double const (*orig_lattice)[3], int const axis_choice_index,
+    int const hall_number, Centering const centering, Symmetry const *symmetry,
+    int const num_free_axes, double const symprec) {
     int j, k, l, is_found;
     double vec[3], norms[3];
     Centering changed_centering;
@@ -1508,11 +1508,11 @@ cont:
 
 static int match_hall_symbol_db_cubic(double origin_shift[3],
                                       double conv_lattice[3][3],
-                                      const double (*orig_lattice)[3],
-                                      const int hall_number,
-                                      const Centering centering,
-                                      const Symmetry *conv_symmetry,
-                                      const double symprec) {
+                                      double const (*orig_lattice)[3],
+                                      int const hall_number,
+                                      Centering const centering,
+                                      Symmetry const *conv_symmetry,
+                                      double const symprec) {
     int i;
 
     /* Special treatment for No. 205 (501) is included in this change of */
@@ -1541,9 +1541,9 @@ static int match_hall_symbol_db_cubic(double origin_shift[3],
 
 static int match_hall_symbol_db_cubic_in_loop(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int i, const int hall_number,
-    const Centering centering, const Symmetry *conv_symmetry,
-    const double symprec) {
+    double const (*orig_lattice)[3], int const i, int const hall_number,
+    Centering const centering, Symmetry const *conv_symmetry,
+    double const symprec) {
     int is_found;
     double changed_lattice[3][3], tmat[3][3], change_of_basis[3][3];
     Symmetry *changed_symmetry;
@@ -1587,10 +1587,10 @@ cont:
 
 static int match_hall_symbol_db_rhombo(double origin_shift[3],
                                        double conv_lattice[3][3],
-                                       const double (*orig_lattice)[3],
-                                       const int hall_number,
-                                       const Symmetry *conv_symmetry,
-                                       const double symprec) {
+                                       double const (*orig_lattice)[3],
+                                       int const hall_number,
+                                       Symmetry const *conv_symmetry,
+                                       double const symprec) {
     int is_found;
 
     if (hall_number == 433 || hall_number == 436 || hall_number == 444 ||
@@ -1618,9 +1618,9 @@ static int match_hall_symbol_db_rhombo(double origin_shift[3],
 /* HEXA, TETRA, TRICLI and TRIGO but not Rhombohedral a=b=c */
 static int match_hall_symbol_db_others(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const int hall_number,
-    const Centering centering, const Holohedry holohedry,
-    const Symmetry *conv_symmetry, const double symprec) {
+    double const (*orig_lattice)[3], int const hall_number,
+    Centering const centering, Holohedry const holohedry,
+    Symmetry const *conv_symmetry, double const symprec) {
     /* TRICLI: No check. */
     if (holohedry == TRICLI) {
         return hal_match_hall_symbol_db(origin_shift, conv_lattice, hall_number,
@@ -1643,10 +1643,10 @@ static int match_hall_symbol_db_others(
 
 static int match_hall_symbol_db_change_of_basis_loop(
     double origin_shift[3], double conv_lattice[3][3],
-    const double (*orig_lattice)[3], const double (*change_of_basis)[3][3],
-    const int num_change_of_basis, const int hall_number,
-    const Centering centering, const Symmetry *conv_symmetry,
-    const double symprec) {
+    double const (*orig_lattice)[3], double const (*change_of_basis)[3][3],
+    int const num_change_of_basis, int const hall_number,
+    Centering const centering, Symmetry const *conv_symmetry,
+    double const symprec) {
     int i, is_found;
     double changed_lattice[3][3], tmat[3][3];
     Symmetry *changed_symmetry;
@@ -1714,9 +1714,9 @@ static int match_hall_symbol_db_change_of_basis_loop(
 }
 
 /* Return NULL if failed */
-static Symmetry *get_conventional_symmetry(const double tmat[3][3],
-                                           const Centering centering,
-                                           const Symmetry *primitive_sym) {
+static Symmetry *get_conventional_symmetry(double const tmat[3][3],
+                                           Centering const centering,
+                                           Symmetry const *primitive_sym) {
     int i, j, k, multi, size;
     double inv_tmat[3][3], shift[3][3];
     double symmetry_rot_d3[3][3], primitive_sym_rot_d3[3][3];
@@ -1798,7 +1798,7 @@ static Symmetry *get_conventional_symmetry(const double tmat[3][3],
 
 /* Return CENTERING_ERROR if failed */
 static Centering get_centering(double correction_mat[3][3],
-                               const int tmat[3][3], const Laue laue) {
+                               int const tmat[3][3], Laue const laue) {
     int det;
     double trans_corr_mat[3][3];
     Centering centering;
@@ -1864,7 +1864,7 @@ static Centering get_centering(double correction_mat[3][3],
     return centering;
 }
 
-static Centering get_base_center(const int tmat[3][3]) {
+static Centering get_base_center(int const tmat[3][3]) {
     int i;
     Centering centering = PRIMITIVE;
 
@@ -1911,7 +1911,7 @@ end:
     return centering;
 }
 
-static int get_centering_shifts(double shift[3][3], const Centering centering) {
+static int get_centering_shifts(double shift[3][3], Centering const centering) {
     int i, j, multi;
 
     multi = 1;
@@ -1976,10 +1976,10 @@ static int get_centering_shifts(double shift[3][3], const Centering centering) {
 // @param[in] lattice
 // @param[in] orig_lattice
 // @param[in] symprec
-static int is_equivalent_lattice(double tmat[3][3], const int mode,
-                                 const double lattice[3][3],
-                                 const double orig_lattice[3][3],
-                                 const double symprec) {
+static int is_equivalent_lattice(double tmat[3][3], int const mode,
+                                 double const lattice[3][3],
+                                 double const orig_lattice[3][3],
+                                 double const symprec) {
     int i, j;
     double inv_lat[3][3], tmat_abs[3][3], metric[3][3], orig_metric[3][3];
     int tmat_int[3][3];

--- a/src/spacegroup.h
+++ b/src/spacegroup.h
@@ -66,19 +66,19 @@ typedef enum {
     R_CENTER,
 } Centering;
 
-Spacegroup *spa_search_spacegroup(const Primitive *primitive,
-                                  const int hall_number, const double symprec,
-                                  const double angle_tolerance);
-Spacegroup *spa_search_spacegroup_with_symmetry(const Symmetry *symmetry,
-                                                const double prim_lat[3][3],
-                                                const double symprec);
-Cell *spa_transform_to_primitive(int *mapping_table, const Cell *cell,
-                                 const double trans_mat[3][3],
-                                 const Centering centering,
-                                 const double symprec);
-Cell *spa_transform_from_primitive(const Cell *primitive,
-                                   const Centering centering,
-                                   const double symprec);
-void spa_copy_spacegroup(Spacegroup *dst, const Spacegroup *src);
+Spacegroup *spa_search_spacegroup(Primitive const *primitive,
+                                  int const hall_number, double const symprec,
+                                  double const angle_tolerance);
+Spacegroup *spa_search_spacegroup_with_symmetry(Symmetry const *symmetry,
+                                                double const prim_lat[3][3],
+                                                double const symprec);
+Cell *spa_transform_to_primitive(int *mapping_table, Cell const *cell,
+                                 double const trans_mat[3][3],
+                                 Centering const centering,
+                                 double const symprec);
+Cell *spa_transform_from_primitive(Cell const *primitive,
+                                   Centering const centering,
+                                   double const symprec);
+void spa_copy_spacegroup(Spacegroup *dst, Spacegroup const *src);
 
 #endif

--- a/src/spg_database.c
+++ b/src/spg_database.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 
 /* In Hall symbols (3rd column), '=' is used instead of '"'. */
-static const SpacegroupType spacegroup_types[] = {
+static SpacegroupType const spacegroup_types[] = {
     {0, "      ", "                ", "                               ",
      "                   ", "          ", "     ", CENTERING_ERROR,
      0}, /*   0 */
@@ -1103,7 +1103,7 @@ static const SpacegroupType spacegroup_types[] = {
      "I 4_1/a -3 2/d     ", "Ia-3d     ", "     ", BODY, 32}, /* 530 */
 };
 
-static const int symmetry_operations[] = {
+static int const symmetry_operations[] = {
     0,        /* dummy */
     16484,    /*    1 (  1) [ 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] */
     16484,    /*    2 (  2) [ 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] */
@@ -9254,7 +9254,7 @@ static const int symmetry_operations[] = {
     5549,     /* 8146 (116) [-1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0] */
 };
 
-static const int symmetry_operation_index[][2] = {
+static int const symmetry_operation_index[][2] = {
     {0, 0},      /*   0 */
     {1, 1},      /*   1 */
     {2, 2},      /*   2 */
@@ -9788,7 +9788,7 @@ static const int symmetry_operation_index[][2] = {
     {96, 7293},  /* 530 */
 };
 
-static const SpacegroupType layer_group_types[] = {
+static SpacegroupType const layer_group_types[] = {
     {0, "      ", "                ", "                               ",
      "                   ", "          ", "     ", CENTERING_ERROR,
      0}, /*   0 */
@@ -10026,7 +10026,7 @@ static const SpacegroupType layer_group_types[] = {
      "p 6/m m m          ", "p6/mmm    ", "     ", PRIMITIVE, 27}, /* 116 */
 };
 
-static const int layer_symmetry_operation_index[][2] = {
+static int const layer_symmetry_operation_index[][2] = {
     {0, 0},     /*   0 */
     {1, 7389},  /*   1 */
     {2, 7390},  /*   2 */
@@ -10146,9 +10146,9 @@ static const int layer_symmetry_operation_index[][2] = {
     {24, 8123}, /* 116 */
 };
 
-static void replace_equal_char(char symbol[], const int position);
+static void replace_equal_char(char symbol[], int const position);
 
-void spgdb_decode_symmetry(int rot[3][3], double trans[3], const int encoded) {
+void spgdb_decode_symmetry(int rot[3][3], double trans[3], int const encoded) {
     int i, j, r, t, degit;
 
     /* A space group operation is compressed using ternary numerical system for
@@ -10178,7 +10178,7 @@ void spgdb_decode_symmetry(int rot[3][3], double trans[3], const int encoded) {
     }
 }
 
-int spgdb_get_operation(int rot[3][3], double trans[3], const int hall_number) {
+int spgdb_get_operation(int rot[3][3], double trans[3], int const hall_number) {
     spgdb_decode_symmetry(rot, trans, symmetry_operations[hall_number]);
     return 1;
 }
@@ -10186,7 +10186,7 @@ int spgdb_get_operation(int rot[3][3], double trans[3], const int hall_number) {
 /* Use negative hall number to represent layer group. */
 /* databases for layer group is directly added behind its spacegroup
  * counterparts */
-void spgdb_get_operation_index(int indices[2], const int hall_number) {
+void spgdb_get_operation_index(int indices[2], int const hall_number) {
     if (hall_number > 0) {
         indices[0] = symmetry_operation_index[hall_number][0];
         indices[1] = symmetry_operation_index[hall_number][1];
@@ -10197,7 +10197,7 @@ void spgdb_get_operation_index(int indices[2], const int hall_number) {
 }
 
 /* Return NULL if failed */
-Symmetry *spgdb_get_spacegroup_operations(const int hall_number) {
+Symmetry *spgdb_get_spacegroup_operations(int const hall_number) {
     int i;
     int operation_index[2];
     int rot[3][3];
@@ -10227,7 +10227,7 @@ Symmetry *spgdb_get_spacegroup_operations(const int hall_number) {
 }
 
 /* Return spgtype.number = 0 if hall_number is out of range. */
-SpacegroupType spgdb_get_spacegroup_type(const int hall_number) {
+SpacegroupType spgdb_get_spacegroup_type(int const hall_number) {
     int position;
     SpacegroupType spgtype;
 
@@ -10252,7 +10252,7 @@ SpacegroupType spgdb_get_spacegroup_type(const int hall_number) {
     return spgtype;
 }
 
-int spgdb_remove_space(char symbol[], const int num_char) {
+int spgdb_remove_space(char symbol[], int const num_char) {
     int i;
 
     for (i = num_char - 2; i > -1; i--) {
@@ -10265,7 +10265,7 @@ int spgdb_remove_space(char symbol[], const int num_char) {
     return i;
 }
 
-static void replace_equal_char(char symbol[], const int position) {
+static void replace_equal_char(char symbol[], int const position) {
     int i;
 
     for (i = position; i > -1; i--) {

--- a/src/spg_database.h
+++ b/src/spg_database.h
@@ -50,11 +50,11 @@ typedef struct {
     int pointgroup_number;
 } SpacegroupType;
 
-void spgdb_decode_symmetry(int rot[3][3], double trans[3], const int encoded);
-int spgdb_get_operation(int rot[3][3], double trans[3], const int hall_number);
-void spgdb_get_operation_index(int indices[2], const int hall_number);
-Symmetry* spgdb_get_spacegroup_operations(const int hall_number);
-SpacegroupType spgdb_get_spacegroup_type(const int hall_number);
-int spgdb_remove_space(char symbol[], const int num_char);
+void spgdb_decode_symmetry(int rot[3][3], double trans[3], int const encoded);
+int spgdb_get_operation(int rot[3][3], double trans[3], int const hall_number);
+void spgdb_get_operation_index(int indices[2], int const hall_number);
+Symmetry* spgdb_get_spacegroup_operations(int const hall_number);
+SpacegroupType spgdb_get_spacegroup_type(int const hall_number);
+int spgdb_remove_space(char symbol[], int const num_char);
 
 #endif

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -101,100 +101,100 @@ static SpglibErrorMessage spglib_error_message[] = {
 /*---------*/
 /* general */
 /*---------*/
-static SpglibDataset *get_dataset(const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const int hall_number,
-                                  const double symprec,
-                                  const double angle_tolerance);
+static SpglibDataset *get_dataset(double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, int const hall_number,
+                                  double const symprec,
+                                  double const angle_tolerance);
 static SpglibDataset *get_layer_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int aperiodic_axis, const int hall_number,
-    const double symprec, const double angle_tolerance);
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const aperiodic_axis, int const hall_number,
+    double const symprec, double const angle_tolerance);
 static SpglibMagneticDataset *get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec);
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec);
 static SpglibDataset *init_dataset(void);
 static SpglibMagneticDataset *init_magnetic_dataset(void);
-static int set_dataset(SpglibDataset *dataset, const Cell *cell,
-                       const Primitive *primitive, const Spacegroup *spacegroup,
+static int set_dataset(SpglibDataset *dataset, Cell const *cell,
+                       Primitive const *primitive, Spacegroup const *spacegroup,
                        ExactStructure *exstr);
 static int set_magnetic_dataset(SpglibMagneticDataset *dataset,
-                                const int num_atoms, const Cell *cell_std,
-                                const MagneticSymmetry *magnetic_symmetry,
-                                const MagneticDataset *msgdata,
-                                const int *equivalent_atoms,
-                                const double primitive_lattice[3][3]);
+                                int const num_atoms, Cell const *cell_std,
+                                MagneticSymmetry const *magnetic_symmetry,
+                                MagneticDataset const *msgdata,
+                                int const *equivalent_atoms,
+                                double const primitive_lattice[3][3]);
 static int get_symmetry_from_dataset(
-    int rotation[][3][3], double translation[][3], const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const double symprec, const double angle_tolerance);
+    int rotation[][3][3], double translation[][3], int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, double const symprec, double const angle_tolerance);
 static MagneticSymmetry *get_symmetry_with_site_tensors(
     int equivalent_atoms[], int **permutations, double primitive_lattice[3][3],
-    const Cell *cell, const int with_time_reversal, const int is_axial,
-    const double symprec, const double angle_tolerance,
-    const double mag_symprec);
-static int get_multiplicity(const double lattice[3][3],
-                            const double position[][3], const int types[],
-                            const int num_atom, const double symprec,
-                            const double angle_tolerance);
+    Cell const *cell, int const with_time_reversal, int const is_axial,
+    double const symprec, double const angle_tolerance,
+    double const mag_symprec);
+static int get_multiplicity(double const lattice[3][3],
+                            double const position[][3], int const types[],
+                            int const num_atom, double const symprec,
+                            double const angle_tolerance);
 static int standardize_primitive(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const double symprec,
-                                 const double angle_tolerance);
+                                 int types[], int const num_atom,
+                                 double const symprec,
+                                 double const angle_tolerance);
 static int standardize_cell(double lattice[3][3], double position[][3],
-                            int types[], const int num_atom,
-                            const int num_array_size, const double symprec,
-                            const double angle_tolerance);
+                            int types[], int const num_atom,
+                            int const num_array_size, double const symprec,
+                            double const angle_tolerance);
 static int get_standardized_cell(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const int num_array_size,
-                                 const int to_primitive, const double symprec,
-                                 const double angle_tolerance);
+                                 int types[], int const num_atom,
+                                 int const num_array_size,
+                                 int const to_primitive, double const symprec,
+                                 double const angle_tolerance);
 static Centering get_centering(int hall_number);
 static void set_cell(double lattice[3][3], double position[][3], int types[],
                      Cell *cell);
-static int get_international(char symbol[11], const double lattice[3][3],
-                             const double position[][3], const int types[],
-                             const int num_atom, const double symprec,
-                             const double angle_tolerance);
-static int get_schoenflies(char symbol[7], const double lattice[3][3],
-                           const double position[][3], const int types[],
-                           const int num_atom, const double symprec,
-                           const double angle_tolerance);
-static SpglibSpacegroupType get_spacegroup_type(const int hall_number);
-static int get_hall_number_from_symmetry(const int rotation[][3][3],
-                                         const double translation[][3],
-                                         const int num_operations,
-                                         const double lattice[3][3],
-                                         const int transform_lattice_by_tmat,
-                                         const double symprec);
+static int get_international(char symbol[11], double const lattice[3][3],
+                             double const position[][3], int const types[],
+                             int const num_atom, double const symprec,
+                             double const angle_tolerance);
+static int get_schoenflies(char symbol[7], double const lattice[3][3],
+                           double const position[][3], int const types[],
+                           int const num_atom, double const symprec,
+                           double const angle_tolerance);
+static SpglibSpacegroupType get_spacegroup_type(int const hall_number);
+static int get_hall_number_from_symmetry(int const rotation[][3][3],
+                                         double const translation[][3],
+                                         int const num_operations,
+                                         double const lattice[3][3],
+                                         int const transform_lattice_by_tmat,
+                                         double const symprec);
 
 /*---------*/
 /* kpoints */
 /*---------*/
 static int get_ir_reciprocal_mesh(int grid_address[][3], int ir_mapping_table[],
-                                  const int mesh[3], const int is_shift[3],
-                                  const int is_time_reversal,
-                                  const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const double symprec,
-                                  const double angle_tolerance);
+                                  int const mesh[3], int const is_shift[3],
+                                  int const is_time_reversal,
+                                  double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, double const symprec,
+                                  double const angle_tolerance);
 static size_t get_dense_ir_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const size_t num_atom, const double symprec, const double angle_tolerance);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal,
+    double const lattice[3][3], double const position[][3], int const types[],
+    size_t const num_atom, double const symprec, double const angle_tolerance);
 
 static int get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const int num_rot,
-    const int rotations[][3][3], const size_t num_q, const double qpoints[][3]);
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, int const num_rot,
+    int const rotations[][3][3], size_t const num_q, double const qpoints[][3]);
 static size_t get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const size_t num_rot,
-    const int rotations[][3][3], const size_t num_q, const double qpoints[][3]);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, size_t const num_rot,
+    int const rotations[][3][3], size_t const num_q, double const qpoints[][3]);
 
 /*========*/
 /* global */
@@ -203,17 +203,17 @@ static size_t get_dense_stabilized_reciprocal_mesh(
 /*-----------------------------------------*/
 /* Version: spglib-[major].[minor].[micro] */
 /*-----------------------------------------*/
-const char *spg_get_version() {
+char const *spg_get_version() {
     spglib_error_code = SPGLIB_SUCCESS;
     return SPGLIB_VERSION;
 }
 
-const char *spg_get_version_full() {
+char const *spg_get_version_full() {
     spglib_error_code = SPGLIB_SUCCESS;
     return SPGLIB_VERSION_FULL;
 }
 
-const char *spg_get_commit() {
+char const *spg_get_commit() {
     spglib_error_code = SPGLIB_SUCCESS;
     return SPGLIB_COMMIT;
 }
@@ -261,61 +261,61 @@ char *spg_get_error_message(SpglibError error) {
 /* general */
 /*---------*/
 /* Return NULL if failed */
-SpglibDataset *spg_get_dataset(const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const int num_atom, const double symprec) {
+SpglibDataset *spg_get_dataset(double const lattice[3][3],
+                               double const position[][3], int const types[],
+                               int const num_atom, double const symprec) {
     return get_dataset(lattice, position, types, num_atom, 0, symprec, -1.0);
 }
 
-SpglibDataset *spg_get_layer_dataset(const double lattice[3][3],
-                                     const double position[][3],
-                                     const int types[], const int num_atom,
-                                     const int aperiodic_axis,
-                                     const double symprec) {
+SpglibDataset *spg_get_layer_dataset(double const lattice[3][3],
+                                     double const position[][3],
+                                     int const types[], int const num_atom,
+                                     int const aperiodic_axis,
+                                     double const symprec) {
     return get_layer_dataset(lattice, position, types, num_atom, aperiodic_axis,
                              0, symprec, -1.0);
 }
 
 SpglibMagneticDataset *spg_get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec) {
     return get_magnetic_dataset(lattice, position, types, tensors, tensor_rank,
                                 num_atom, is_axial, symprec, -1.0, -1.0);
 }
 
 SpglibMagneticDataset *spgms_get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec) {
     return get_magnetic_dataset(lattice, position, types, tensors, tensor_rank,
                                 num_atom, is_axial, symprec, angle_tolerance,
                                 mag_symprec);
 }
 
 /* Return NULL if failed */
-SpglibDataset *spgat_get_dataset(const double lattice[3][3],
-                                 const double position[][3], const int types[],
-                                 const int num_atom, const double symprec,
-                                 const double angle_tolerance) {
+SpglibDataset *spgat_get_dataset(double const lattice[3][3],
+                                 double const position[][3], int const types[],
+                                 int const num_atom, double const symprec,
+                                 double const angle_tolerance) {
     return get_dataset(lattice, position, types, num_atom, 0, symprec,
                        angle_tolerance);
 }
 
 /* Return NULL if failed */
 SpglibDataset *spg_get_dataset_with_hall_number(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int hall_number, const double symprec) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const hall_number, double const symprec) {
     return get_dataset(lattice, position, types, num_atom, hall_number, symprec,
                        -1.0);
 }
 
 /* Return NULL if failed */
 SpglibDataset *spgat_get_dataset_with_hall_number(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int hall_number, const double symprec,
-    const double angle_tolerance) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const hall_number, double const symprec,
+    double const angle_tolerance) {
     return get_dataset(lattice, position, types, num_atom, hall_number, symprec,
                        angle_tolerance);
 }
@@ -396,19 +396,19 @@ void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset) {
 
 /* Return 0 if failed */
 int spg_get_symmetry(int rotation[][3][3], double translation[][3],
-                     const int max_size, const double lattice[3][3],
-                     const double position[][3], const int types[],
-                     const int num_atom, const double symprec) {
+                     int const max_size, double const lattice[3][3],
+                     double const position[][3], int const types[],
+                     int const num_atom, double const symprec) {
     return get_symmetry_from_dataset(rotation, translation, max_size, lattice,
                                      position, types, num_atom, symprec, -1.0);
 }
 
 /* Return 0 if failed */
 int spgat_get_symmetry(int rotation[][3][3], double translation[][3],
-                       const int max_size, const double lattice[3][3],
-                       const double position[][3], const int types[],
-                       const int num_atom, const double symprec,
-                       const double angle_tolerance) {
+                       int const max_size, double const lattice[3][3],
+                       double const position[][3], int const types[],
+                       int const num_atom, double const symprec,
+                       double const angle_tolerance) {
     return get_symmetry_from_dataset(rotation, translation, max_size, lattice,
                                      position, types, num_atom, symprec,
                                      angle_tolerance);
@@ -417,9 +417,9 @@ int spgat_get_symmetry(int rotation[][3][3], double translation[][3],
 /* Return 0 if failed */
 int spg_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec) {
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec) {
     return spgms_get_symmetry_with_collinear_spin(
         rotation, translation, equivalent_atoms, max_size, lattice, position,
         types, spins, num_atom, symprec, -1.0, -1.0);
@@ -428,9 +428,9 @@ int spg_get_symmetry_with_collinear_spin(
 /* Return 0 if failed */
 int spgat_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec, const double angle_tolerance) {
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec, double const angle_tolerance) {
     return spgms_get_symmetry_with_collinear_spin(
         rotation, translation, equivalent_atoms, max_size, lattice, position,
         types, spins, num_atom, symprec, angle_tolerance, -1.0);
@@ -438,10 +438,10 @@ int spgat_get_symmetry_with_collinear_spin(
 
 int spgms_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec, const double angle_tolerance,
-    const double mag_symprec) {
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec, double const angle_tolerance,
+    double const mag_symprec) {
     int succeeded;
     double primitive_lattice[3][3];
     int *spin_flips;
@@ -467,10 +467,10 @@ int spgms_get_symmetry_with_collinear_spin(
 /* Need to get rotation and translation before calling this function. */
 int spg_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec) {
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec) {
     return spgms_get_symmetry_with_site_tensors(
         rotation, translation, equivalent_atoms, primitive_lattice, spin_flips,
         max_size, lattice, position, types, tensors, tensor_rank, num_atom,
@@ -480,11 +480,11 @@ int spg_get_symmetry_with_site_tensors(
 /* Return 0 if failed */
 int spgat_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec,
-    const double angle_tolerance) {
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec,
+    double const angle_tolerance) {
     return spgms_get_symmetry_with_site_tensors(
         rotation, translation, equivalent_atoms, primitive_lattice, spin_flips,
         max_size, lattice, position, types, tensors, tensor_rank, num_atom,
@@ -494,11 +494,11 @@ int spgat_get_symmetry_with_site_tensors(
 /* Return 0 if failed */
 int spgms_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec,
-    const double angle_tolerance, const double mag_symprec) {
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec,
+    double const angle_tolerance, double const mag_symprec) {
     int i, size;
     MagneticSymmetry *magnetic_symmetry;
     int *permutations;
@@ -551,10 +551,10 @@ int spgms_get_symmetry_with_site_tensors(
 }
 
 /* Deprecated at v2.0 */
-int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
-                                      const double translation[][3],
-                                      const int num_operations,
-                                      const double symprec) {
+int spg_get_hall_number_from_symmetry(int const rotation[][3][3],
+                                      double const translation[][3],
+                                      int const num_operations,
+                                      double const symprec) {
     int hall_number;
     double lattice[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 
@@ -571,9 +571,9 @@ int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
 }
 
 SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
-    const int rotation[][3][3], const double translation[][3],
-    const int num_operations, const double lattice[3][3],
-    const double symprec) {
+    int const rotation[][3][3], double const translation[][3],
+    int const num_operations, double const lattice[3][3],
+    double const symprec) {
     int hall_number;
     SpglibSpacegroupType spglibtype;
 
@@ -595,9 +595,9 @@ err:
 }
 
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
-    const int rotations[][3][3], const double translations[][3],
-    const int *time_reversals, const int num_operations,
-    const double lattice[3][3], const double symprec) {
+    int const rotations[][3][3], double const translations[][3],
+    int const *time_reversals, int const num_operations,
+    double const lattice[3][3], double const symprec) {
     int i;
     MagneticSymmetry *magnetic_symmetry;
     MagneticDataset *msgdata;
@@ -648,58 +648,58 @@ SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type_from_symmetry(
 }
 
 /* Return 0 if failed */
-int spg_get_multiplicity(const double lattice[3][3], const double position[][3],
-                         const int types[], const int num_atom,
-                         const double symprec) {
+int spg_get_multiplicity(double const lattice[3][3], double const position[][3],
+                         int const types[], int const num_atom,
+                         double const symprec) {
     return get_multiplicity(lattice, position, types, num_atom, symprec, -1.0);
 }
 
 /* Return 0 if failed */
-int spgat_get_multiplicity(const double lattice[3][3],
-                           const double position[][3], const int types[],
-                           const int num_atom, const double symprec,
-                           const double angle_tolerance) {
+int spgat_get_multiplicity(double const lattice[3][3],
+                           double const position[][3], int const types[],
+                           int const num_atom, double const symprec,
+                           double const angle_tolerance) {
     return get_multiplicity(lattice, position, types, num_atom, symprec,
                             angle_tolerance);
 }
 
 /* Return 0 if failed */
-int spg_get_international(char symbol[11], const double lattice[3][3],
-                          const double position[][3], const int types[],
-                          const int num_atom, const double symprec) {
+int spg_get_international(char symbol[11], double const lattice[3][3],
+                          double const position[][3], int const types[],
+                          int const num_atom, double const symprec) {
     return get_international(symbol, lattice, position, types, num_atom,
                              symprec, -1.0);
 }
 
 /* Return 0 if failed */
-int spgat_get_international(char symbol[11], const double lattice[3][3],
-                            const double position[][3], const int types[],
-                            const int num_atom, const double symprec,
-                            const double angle_tolerance) {
+int spgat_get_international(char symbol[11], double const lattice[3][3],
+                            double const position[][3], int const types[],
+                            int const num_atom, double const symprec,
+                            double const angle_tolerance) {
     return get_international(symbol, lattice, position, types, num_atom,
                              symprec, angle_tolerance);
 }
 
 /* Return 0 if failed */
-int spg_get_schoenflies(char symbol[7], const double lattice[3][3],
-                        const double position[][3], const int types[],
-                        const int num_atom, const double symprec) {
+int spg_get_schoenflies(char symbol[7], double const lattice[3][3],
+                        double const position[][3], int const types[],
+                        int const num_atom, double const symprec) {
     return get_schoenflies(symbol, lattice, position, types, num_atom, symprec,
                            -1.0);
 }
 
 /* Return 0 if failed */
-int spgat_get_schoenflies(char symbol[7], const double lattice[3][3],
-                          const double position[][3], const int types[],
-                          const int num_atom, const double symprec,
-                          const double angle_tolerance) {
+int spgat_get_schoenflies(char symbol[7], double const lattice[3][3],
+                          double const position[][3], int const types[],
+                          int const num_atom, double const symprec,
+                          double const angle_tolerance) {
     return get_schoenflies(symbol, lattice, position, types, num_atom, symprec,
                            angle_tolerance);
 }
 
 /* Return 0 if failed */
 int spg_get_pointgroup(char symbol[6], int transform_mat[3][3],
-                       const int rotations[][3][3], const int num_rotations) {
+                       int const rotations[][3][3], int const num_rotations) {
     Pointgroup pointgroup;
 
     pointgroup = ptg_get_transformation_matrix(
@@ -719,7 +719,7 @@ int spg_get_pointgroup(char symbol[6], int transform_mat[3][3],
 /* Return 0 if failed */
 int spg_get_symmetry_from_database(int rotations[192][3][3],
                                    double translations[192][3],
-                                   const int hall_number) {
+                                   int const hall_number) {
     int i, size;
     Symmetry *symmetry;
 
@@ -750,8 +750,8 @@ err:
 int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
                                             double translations[384][3],
                                             int time_reversals[384],
-                                            const int uni_number,
-                                            const int hall_number) {
+                                            int const uni_number,
+                                            int const hall_number) {
     int i, size;
     MagneticSymmetry *symmetry;
 
@@ -778,7 +778,7 @@ int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
 }
 
 /* Return spglibtype.number = 0 if failed */
-SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number) {
+SpglibSpacegroupType spg_get_spacegroup_type(int const hall_number) {
     SpglibSpacegroupType spglibtype;
     spglibtype = get_spacegroup_type(hall_number);
     if (0 < hall_number && hall_number < 531) {
@@ -791,7 +791,7 @@ SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number) {
 }
 
 SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type(
-    const int uni_number) {
+    int const uni_number) {
     SpglibMagneticSpacegroupType spglibtype;
     MagneticSpacegroupType msgtype;
 
@@ -823,18 +823,18 @@ SpglibMagneticSpacegroupType spg_get_magnetic_spacegroup_type(
 
 /* Return 0 if failed */
 int spg_standardize_cell(double lattice[3][3], double position[][3],
-                         int types[], const int num_atom,
-                         const int to_primitive, const int no_idealize,
-                         const double symprec) {
+                         int types[], int const num_atom,
+                         int const to_primitive, int const no_idealize,
+                         double const symprec) {
     return spgat_standardize_cell(lattice, position, types, num_atom,
                                   to_primitive, no_idealize, symprec, -1.0);
 }
 
 /* Return 0 if failed */
 int spgat_standardize_cell(double lattice[3][3], double position[][3],
-                           int types[], const int num_atom,
-                           const int to_primitive, const int no_idealize,
-                           const double symprec, const double angle_tolerance) {
+                           int types[], int const num_atom,
+                           int const to_primitive, int const no_idealize,
+                           double const symprec, double const angle_tolerance) {
     if (to_primitive) {
         if (no_idealize) {
             return get_standardized_cell(lattice, position, types, num_atom, 0,
@@ -856,35 +856,35 @@ int spgat_standardize_cell(double lattice[3][3], double position[][3],
 
 /* Return 0 if failed */
 int spg_find_primitive(double lattice[3][3], double position[][3], int types[],
-                       const int num_atom, const double symprec) {
+                       int const num_atom, double const symprec) {
     return standardize_primitive(lattice, position, types, num_atom, symprec,
                                  -1.0);
 }
 
 /* Return 0 if failed */
 int spgat_find_primitive(double lattice[3][3], double position[][3],
-                         int types[], const int num_atom, const double symprec,
-                         const double angle_tolerance) {
+                         int types[], int const num_atom, double const symprec,
+                         double const angle_tolerance) {
     return standardize_primitive(lattice, position, types, num_atom, symprec,
                                  angle_tolerance);
 }
 
 /* Return 0 if failed */
 int spg_refine_cell(double lattice[3][3], double position[][3], int types[],
-                    const int num_atom, const double symprec) {
+                    int const num_atom, double const symprec) {
     return standardize_cell(lattice, position, types, num_atom, 0, symprec,
                             -1.0);
 }
 
 /* Return 0 if failed */
 int spgat_refine_cell(double lattice[3][3], double position[][3], int types[],
-                      const int num_atom, const double symprec,
-                      const double angle_tolerance) {
+                      int const num_atom, double const symprec,
+                      double const angle_tolerance) {
     return standardize_cell(lattice, position, types, num_atom, 0, symprec,
                             angle_tolerance);
 }
 
-int spg_delaunay_reduce(double lattice[3][3], const double symprec) {
+int spg_delaunay_reduce(double lattice[3][3], double const symprec) {
     int i, j, succeeded;
     double red_lattice[3][3];
 
@@ -907,8 +907,8 @@ int spg_delaunay_reduce(double lattice[3][3], const double symprec) {
 /*---------*/
 /* kpoints */
 /*---------*/
-int spg_get_grid_point_from_address(const int grid_address[3],
-                                    const int mesh[3]) {
+int spg_get_grid_point_from_address(int const grid_address[3],
+                                    int const mesh[3]) {
     int address_double[3];
     int is_shift[3];
 
@@ -920,8 +920,8 @@ int spg_get_grid_point_from_address(const int grid_address[3],
     return kgd_get_grid_point_double_mesh(address_double, mesh);
 }
 
-size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
-                                             const int mesh[3]) {
+size_t spg_get_dense_grid_point_from_address(int const grid_address[3],
+                                             int const mesh[3]) {
     int address_double[3];
     int is_shift[3];
 
@@ -934,74 +934,74 @@ size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
 }
 
 int spg_get_ir_reciprocal_mesh(int grid_address[][3], int ir_mapping_table[],
-                               const int mesh[3], const int is_shift[3],
-                               const int is_time_reversal,
-                               const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const int num_atom, const double symprec) {
+                               int const mesh[3], int const is_shift[3],
+                               int const is_time_reversal,
+                               double const lattice[3][3],
+                               double const position[][3], int const types[],
+                               int const num_atom, double const symprec) {
     return get_ir_reciprocal_mesh(grid_address, ir_mapping_table, mesh,
                                   is_shift, is_time_reversal, lattice, position,
                                   types, num_atom, symprec, -1.0);
 }
 
 size_t spg_get_dense_ir_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const double symprec) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal,
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, double const symprec) {
     return get_dense_ir_reciprocal_mesh(
         grid_address, ir_mapping_table, mesh, is_shift, is_time_reversal,
         lattice, position, types, num_atom, symprec, -1.0);
 }
 
 int spg_get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const int num_rot,
-    const int rotations[][3][3], const int num_q, const double qpoints[][3]) {
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, int const num_rot,
+    int const rotations[][3][3], int const num_q, double const qpoints[][3]) {
     return get_stabilized_reciprocal_mesh(grid_address, ir_mapping_table, mesh,
                                           is_shift, is_time_reversal, num_rot,
                                           rotations, num_q, qpoints);
 }
 
 size_t spg_get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const int num_rot,
-    const int rotations[][3][3], const int num_q, const double qpoints[][3]) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, int const num_rot,
+    int const rotations[][3][3], int const num_q, double const qpoints[][3]) {
     return get_dense_stabilized_reciprocal_mesh(
         grid_address, ir_mapping_table, mesh, is_shift, is_time_reversal,
         num_rot, rotations, num_q, qpoints);
 }
 
 void spg_get_dense_grid_points_by_rotations(size_t rot_grid_points[],
-                                            const int address_orig[3],
-                                            const int num_rot,
-                                            const int rot_reciprocal[][3][3],
-                                            const int mesh[3],
-                                            const int is_shift[3]) {
+                                            int const address_orig[3],
+                                            int const num_rot,
+                                            int const rot_reciprocal[][3][3],
+                                            int const mesh[3],
+                                            int const is_shift[3]) {
     kpt_get_dense_grid_points_by_rotations(
         rot_grid_points, address_orig, rot_reciprocal, num_rot, mesh, is_shift);
 }
 
 void spg_get_dense_BZ_grid_points_by_rotations(
-    size_t rot_grid_points[], const int address_orig[3], const int num_rot,
-    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3],
-    const size_t bz_map[]) {
+    size_t rot_grid_points[], int const address_orig[3], int const num_rot,
+    int const rot_reciprocal[][3][3], int const mesh[3], int const is_shift[3],
+    size_t const bz_map[]) {
     kpt_get_dense_BZ_grid_points_by_rotations(rot_grid_points, address_orig,
                                               rot_reciprocal, num_rot, mesh,
                                               is_shift, bz_map);
 }
 
 int spg_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
-                                 const int grid_address[][3], const int mesh[3],
-                                 const double rec_lattice[3][3],
-                                 const int is_shift[3]) {
+                                 int const grid_address[][3], int const mesh[3],
+                                 double const rec_lattice[3][3],
+                                 int const is_shift[3]) {
     return kpt_relocate_BZ_grid_address(bz_grid_address, bz_map, grid_address,
                                         mesh, rec_lattice, is_shift);
 }
 
 size_t spg_relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]) {
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]) {
     return kpt_relocate_dense_BZ_grid_address(
         bz_grid_address, bz_map, grid_address, mesh, rec_lattice, is_shift);
 }
@@ -1010,7 +1010,7 @@ size_t spg_relocate_dense_BZ_grid_address(
 /* Niggli */
 /*--------*/
 /* Return 0 if failed */
-int spg_niggli_reduce(double lattice[3][3], const double symprec) {
+int spg_niggli_reduce(double lattice[3][3], double const symprec) {
     int i, j, succeeded;
     double vals[9];
 
@@ -1044,11 +1044,11 @@ int spg_niggli_reduce(double lattice[3][3], const double symprec) {
 /* general */
 /*---------*/
 /* Return NULL if failed */
-static SpglibDataset *get_dataset(const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const int hall_number,
-                                  const double symprec,
-                                  const double angle_tolerance) {
+static SpglibDataset *get_dataset(double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, int const hall_number,
+                                  double const symprec,
+                                  double const angle_tolerance) {
     SpglibDataset *dataset;
     Cell *cell;
     DataContainer *container;
@@ -1111,9 +1111,9 @@ found:
 
 /* Return NULL if failed */
 static SpglibDataset *get_layer_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int aperiodic_axis, const int hall_number,
-    const double symprec, const double angle_tolerance) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const aperiodic_axis, int const hall_number,
+    double const symprec, double const angle_tolerance) {
     SpglibDataset *dataset;
     Cell *cell;
     DataContainer *container;
@@ -1196,10 +1196,10 @@ found:
 
 /* Return NULL if failed */
 static SpglibMagneticDataset *get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec) {
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec) {
     Cell *cell, *exact_cell, *exact_cell_std;
     Spacegroup *fsg, *xsg;
     MagneticSymmetry *magnetic_symmetry, *representatives;
@@ -1418,8 +1418,8 @@ static SpglibMagneticDataset *init_magnetic_dataset(void) {
 }
 
 /* Return 0 if failed */
-static int set_dataset(SpglibDataset *dataset, const Cell *cell,
-                       const Primitive *primitive, const Spacegroup *spacegroup,
+static int set_dataset(SpglibDataset *dataset, Cell const *cell,
+                       Primitive const *primitive, Spacegroup const *spacegroup,
                        ExactStructure *exstr) {
     int i, j;
     double inv_lat[3][3];
@@ -1591,11 +1591,11 @@ err:
 }
 
 static int set_magnetic_dataset(SpglibMagneticDataset *dataset,
-                                const int num_atoms, const Cell *cell_std,
-                                const MagneticSymmetry *magnetic_symmetry,
-                                const MagneticDataset *msgdata,
-                                const int *equivalent_atoms,
-                                const double primitive_lattice[3][3]) {
+                                int const num_atoms, Cell const *cell_std,
+                                MagneticSymmetry const *magnetic_symmetry,
+                                MagneticDataset const *msgdata,
+                                int const *equivalent_atoms,
+                                double const primitive_lattice[3][3]) {
     int i, s;
 
     /* Magnetic space-group type */
@@ -1714,9 +1714,9 @@ err:
 
 /* Return 0 if failed */
 static int get_symmetry_from_dataset(
-    int rotation[][3][3], double translation[][3], const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const double symprec, const double angle_tolerance) {
+    int rotation[][3][3], double translation[][3], int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, double const symprec, double const angle_tolerance) {
     int i, num_sym;
     SpglibDataset *dataset;
 
@@ -1756,9 +1756,9 @@ err:
 /* Return NULL if failed */
 static MagneticSymmetry *get_symmetry_with_site_tensors(
     int equivalent_atoms[], int **permutations, double primitive_lattice[3][3],
-    const Cell *cell, const int with_time_reversal, const int is_axial,
-    const double symprec, const double angle_tolerance,
-    const double mag_symprec) {
+    Cell const *cell, int const with_time_reversal, int const is_axial,
+    double const symprec, double const angle_tolerance,
+    double const mag_symprec) {
     int i;
     MagneticSymmetry *magnetic_symmetry;
     Symmetry *sym_nonspin;
@@ -1822,10 +1822,10 @@ err:
 }
 
 /* Return 0 if failed */
-static int get_multiplicity(const double lattice[3][3],
-                            const double position[][3], const int types[],
-                            const int num_atom, const double symprec,
-                            const double angle_tolerance) {
+static int get_multiplicity(double const lattice[3][3],
+                            double const position[][3], int const types[],
+                            int const num_atom, double const symprec,
+                            double const angle_tolerance) {
     int size;
     SpglibDataset *dataset;
 
@@ -1845,9 +1845,9 @@ static int get_multiplicity(const double lattice[3][3],
 }
 
 static int standardize_primitive(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const double symprec,
-                                 const double angle_tolerance) {
+                                 int types[], int const num_atom,
+                                 double const symprec,
+                                 double const angle_tolerance) {
     int i, num_prim_atom;
     int *mapping_table;
     Centering centering;
@@ -1934,9 +1934,9 @@ err:
 }
 
 static int standardize_cell(double lattice[3][3], double position[][3],
-                            int types[], const int num_atom,
-                            const int num_array_size, const double symprec,
-                            const double angle_tolerance) {
+                            int types[], int const num_atom,
+                            int const num_array_size, double const symprec,
+                            double const angle_tolerance) {
     int i, n_std_atoms;
     SpglibDataset *dataset;
 
@@ -1976,10 +1976,10 @@ array_size_shortage_err:
 }
 
 static int get_standardized_cell(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const int num_array_size,
-                                 const int to_primitive, const double symprec,
-                                 const double angle_tolerance) {
+                                 int types[], int const num_atom,
+                                 int const num_array_size,
+                                 int const to_primitive, double const symprec,
+                                 double const angle_tolerance) {
     int i, num_std_atom, num_prim_atom;
     int *mapping_table;
     SpglibDataset *dataset;
@@ -2117,10 +2117,10 @@ static Centering get_centering(int hall_number) {
     return spgtype.centering;
 }
 
-static int get_international(char symbol[11], const double lattice[3][3],
-                             const double position[][3], const int types[],
-                             const int num_atom, const double symprec,
-                             const double angle_tolerance) {
+static int get_international(char symbol[11], double const lattice[3][3],
+                             double const position[][3], int const types[],
+                             int const num_atom, double const symprec,
+                             double const angle_tolerance) {
     SpglibDataset *dataset;
     int number;
 
@@ -2151,10 +2151,10 @@ err:
     return 0;
 }
 
-static int get_schoenflies(char symbol[7], const double lattice[3][3],
-                           const double position[][3], const int types[],
-                           const int num_atom, const double symprec,
-                           const double angle_tolerance) {
+static int get_schoenflies(char symbol[7], double const lattice[3][3],
+                           double const position[][3], int const types[],
+                           int const num_atom, double const symprec,
+                           double const angle_tolerance) {
     SpglibDataset *dataset;
     SpglibSpacegroupType spgtype;
     int number;
@@ -2190,12 +2190,12 @@ err:
 /* kpoints */
 /*---------*/
 static int get_ir_reciprocal_mesh(int grid_address[][3], int ir_mapping_table[],
-                                  const int mesh[3], const int is_shift[3],
-                                  const int is_time_reversal,
-                                  const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const double symprec,
-                                  const double angle_tolerance) {
+                                  int const mesh[3], int const is_shift[3],
+                                  int const is_time_reversal,
+                                  double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, double const symprec,
+                                  double const angle_tolerance) {
     SpglibDataset *dataset;
     int num_ir, i;
     MatINT *rotations, *rot_reciprocal;
@@ -2228,10 +2228,10 @@ static int get_ir_reciprocal_mesh(int grid_address[][3], int ir_mapping_table[],
 }
 
 static size_t get_dense_ir_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const size_t num_atom, const double symprec, const double angle_tolerance) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal,
+    double const lattice[3][3], double const position[][3], int const types[],
+    size_t const num_atom, double const symprec, double const angle_tolerance) {
     SpglibDataset *dataset;
     int i;
     size_t num_ir;
@@ -2265,9 +2265,9 @@ static size_t get_dense_ir_reciprocal_mesh(
 }
 
 static int get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int map[], const int mesh[3], const int is_shift[3],
-    const int is_time_reversal, const int num_rot, const int rotations[][3][3],
-    const size_t num_q, const double qpoints[][3]) {
+    int grid_address[][3], int map[], int const mesh[3], int const is_shift[3],
+    int const is_time_reversal, int const num_rot, int const rotations[][3][3],
+    size_t const num_q, double const qpoints[][3]) {
     MatINT *rot_real;
     int i, num_ir;
 
@@ -2292,10 +2292,10 @@ static int get_stabilized_reciprocal_mesh(
 }
 
 static size_t get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const size_t num_rot,
-    const int rotations[][3][3], const size_t num_q,
-    const double qpoints[][3]) {
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, size_t const num_rot,
+    int const rotations[][3][3], size_t const num_q,
+    double const qpoints[][3]) {
     MatINT *rot_real;
     size_t i, num_ir;
 
@@ -2319,7 +2319,7 @@ static size_t get_dense_stabilized_reciprocal_mesh(
     return num_ir;
 }
 
-SpglibSpacegroupType get_spacegroup_type(const int hall_number) {
+SpglibSpacegroupType get_spacegroup_type(int const hall_number) {
     SpglibSpacegroupType spglibtype;
     SpacegroupType spgtype;
     Pointgroup pointgroup;
@@ -2360,12 +2360,12 @@ SpglibSpacegroupType get_spacegroup_type(const int hall_number) {
     return spglibtype;
 }
 
-static int get_hall_number_from_symmetry(const int rotation[][3][3],
-                                         const double translation[][3],
-                                         const int num_operations,
-                                         const double lattice[3][3],
-                                         const int transform_lattice_by_tmat,
-                                         const double symprec) {
+static int get_hall_number_from_symmetry(int const rotation[][3][3],
+                                         double const translation[][3],
+                                         int const num_operations,
+                                         double const lattice[3][3],
+                                         int const transform_lattice_by_tmat,
+                                         double const symprec) {
     int i, hall_number;
     Symmetry *symmetry;
     Symmetry *prim_symmetry;

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -63,15 +63,15 @@
 // Windows does not support _Thread_local. Use appropriate aliases
 // Reference: https://stackoverflow.com/a/18298965
 #ifndef thread_local
-#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
-#define thread_local _Thread_local
-#elif defined _MSC_VER
-#define thread_local __declspec(thread)
-#elif defined __GNUC__
-#define thread_local __thread
-#else
-#error "Cannot define thread_local"
-#endif
+    #if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+        #define thread_local _Thread_local
+    #elif defined _MSC_VER
+        #define thread_local __declspec(thread)
+    #elif defined __GNUC__
+        #define thread_local __thread
+    #else
+        #error "Cannot define thread_local"
+    #endif
 #endif
 
 /*-------*/

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -211,43 +211,43 @@ SPG_API int spg_get_micro_version();
 SPG_API SpglibError spg_get_error_code(void);
 SPG_API char *spg_get_error_message(SpglibError spglib_error);
 
-SPG_API SpglibDataset *spg_get_dataset(const double lattice[3][3],
-                                       const double position[][3],
-                                       const int types[], const int num_atom,
-                                       const double symprec);
+SPG_API SpglibDataset *spg_get_dataset(double const lattice[3][3],
+                                       double const position[][3],
+                                       int const types[], int const num_atom,
+                                       double const symprec);
 
 /* This is for test using */
 SPG_API SpglibDataset *spg_get_layer_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int aperiodic_axis, const double symprec);
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const aperiodic_axis, double const symprec);
 
 SPG_API SpglibMagneticDataset *spg_get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec);
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec);
 
 SPG_API SpglibMagneticDataset *spgms_get_magnetic_dataset(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec);
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec);
 
-SPG_API SpglibDataset *spgat_get_dataset(const double lattice[3][3],
-                                         const double position[][3],
-                                         const int types[], const int num_atom,
-                                         const double symprec,
-                                         const double angle_tolerance);
+SPG_API SpglibDataset *spgat_get_dataset(double const lattice[3][3],
+                                         double const position[][3],
+                                         int const types[], int const num_atom,
+                                         double const symprec,
+                                         double const angle_tolerance);
 
 /* hall_number = 0 gives the same as spg_get_dataset. */
 SPG_API SpglibDataset *spg_get_dataset_with_hall_number(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int hall_number, const double symprec);
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const hall_number, double const symprec);
 
 /* hall_number = 0 gives the same as spgat_get_dataset. */
 SPG_API SpglibDataset *spgat_get_dataset_with_hall_number(
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const int hall_number, const double symprec,
-    const double angle_tolerance);
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, int const hall_number, double const symprec,
+    double const angle_tolerance);
 
 SPG_API void spg_free_dataset(SpglibDataset *dataset);
 SPG_API void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset);
@@ -259,35 +259,35 @@ SPG_API void spg_free_magnetic_dataset(SpglibMagneticDataset *dataset);
 /* ``translation[i]`` with same index give a symmetry operations, */
 /* i.e., these have to be used together. */
 SPG_API int spg_get_symmetry(int rotation[][3][3], double translation[][3],
-                             const int max_size, const double lattice[3][3],
-                             const double position[][3], const int types[],
-                             const int num_atom, const double symprec);
+                             int const max_size, double const lattice[3][3],
+                             double const position[][3], int const types[],
+                             int const num_atom, double const symprec);
 
 SPG_API int spgat_get_symmetry(int rotation[][3][3], double translation[][3],
-                               const int max_size, const double lattice[3][3],
-                               const double position[][3], const int types[],
-                               const int num_atom, const double symprec,
-                               const double angle_tolerance);
+                               int const max_size, double const lattice[3][3],
+                               double const position[][3], int const types[],
+                               int const num_atom, double const symprec,
+                               double const angle_tolerance);
 
 /* Find symmetry operations with collinear spins on atoms. */
 SPG_API int spg_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec);
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec);
 
 SPG_API int spgat_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec, const double angle_tolerance);
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec, double const angle_tolerance);
 
 SPG_API int spgms_get_symmetry_with_collinear_spin(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    const int max_size, const double lattice[3][3], const double position[][3],
-    const int types[], const double spins[], const int num_atom,
-    const double symprec, const double angle_tolerance,
-    const double mag_symprec);
+    int const max_size, double const lattice[3][3], double const position[][3],
+    int const types[], double const spins[], int const num_atom,
+    double const symprec, double const angle_tolerance,
+    double const mag_symprec);
 
 /**
  * @brief
@@ -312,33 +312,33 @@ SPG_API int spgms_get_symmetry_with_collinear_spin(
  */
 SPG_API int spg_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec);
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec);
 
 SPG_API int spgat_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec,
-    const double angle_tolerance);
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec,
+    double const angle_tolerance);
 
 SPG_API int spgms_get_symmetry_with_site_tensors(
     int rotation[][3][3], double translation[][3], int equivalent_atoms[],
-    double primitive_lattice[3][3], int *spin_flips, const int max_size,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const double *tensors, const int tensor_rank, const int num_atom,
-    const int with_time_reversal, const int is_axial, const double symprec,
-    const double angle_tolerance, const double mag_symprec);
+    double primitive_lattice[3][3], int *spin_flips, int const max_size,
+    double const lattice[3][3], double const position[][3], int const types[],
+    double const *tensors, int const tensor_rank, int const num_atom,
+    int const with_time_reversal, int const is_axial, double const symprec,
+    double const angle_tolerance, double const mag_symprec);
 
 /* Deprecated at v2.0 */
 /* Space group type (hall_number) is searched from symmetry operations. */
-SPG_API int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
-                                              const double translation[][3],
-                                              const int num_operations,
-                                              const double symprec);
+SPG_API int spg_get_hall_number_from_symmetry(int const rotation[][3][3],
+                                              double const translation[][3],
+                                              int const num_operations,
+                                              double const symprec);
 /**
  * @brief Search space group type from symmetry operations
  *
@@ -350,65 +350,65 @@ SPG_API int spg_get_hall_number_from_symmetry(const int rotation[][3][3],
  * @return SpglibSpacegroupType
  */
 SPG_API SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
-    const int rotation[][3][3], const double translation[][3],
-    const int num_operations, const double lattice[3][3], const double symprec);
+    int const rotation[][3][3], double const translation[][3],
+    int const num_operations, double const lattice[3][3], double const symprec);
 
 SPG_API SpglibMagneticSpacegroupType
-spg_get_magnetic_spacegroup_type_from_symmetry(const int rotations[][3][3],
-                                               const double translations[][3],
-                                               const int *time_reversals,
-                                               const int num_operations,
-                                               const double lattice[3][3],
-                                               const double symprec);
+spg_get_magnetic_spacegroup_type_from_symmetry(int const rotations[][3][3],
+                                               double const translations[][3],
+                                               int const *time_reversals,
+                                               int const num_operations,
+                                               double const lattice[3][3],
+                                               double const symprec);
 
 /* Return exact number of symmetry operations. This function may */
 /* be used in advance to allocate memory space for symmetry */
 /* operations. */
-SPG_API int spg_get_multiplicity(const double lattice[3][3],
-                                 const double position[][3], const int types[],
-                                 const int num_atom, const double symprec);
+SPG_API int spg_get_multiplicity(double const lattice[3][3],
+                                 double const position[][3], int const types[],
+                                 int const num_atom, double const symprec);
 
-SPG_API int spgat_get_multiplicity(const double lattice[3][3],
-                                   const double position[][3],
-                                   const int types[], const int num_atom,
-                                   const double symprec,
-                                   const double angle_tolerance);
+SPG_API int spgat_get_multiplicity(double const lattice[3][3],
+                                   double const position[][3],
+                                   int const types[], int const num_atom,
+                                   double const symprec,
+                                   double const angle_tolerance);
 
 /* Space group is found in international table symbol (``symbol``) and */
 /* number (return value). 0 is returned when it fails. */
-SPG_API int spg_get_international(char symbol[11], const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const double symprec);
+SPG_API int spg_get_international(char symbol[11], double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, double const symprec);
 
-SPG_API int spgat_get_international(char symbol[11], const double lattice[3][3],
-                                    const double position[][3],
-                                    const int types[], const int num_atom,
-                                    const double symprec,
-                                    const double angle_tolerance);
+SPG_API int spgat_get_international(char symbol[11], double const lattice[3][3],
+                                    double const position[][3],
+                                    int const types[], int const num_atom,
+                                    double const symprec,
+                                    double const angle_tolerance);
 
 /* Space group is found in schoenflies (``symbol``) and as number (return */
 /* value).  0 is returned when it fails. */
-SPG_API int spg_get_schoenflies(char symbol[7], const double lattice[3][3],
-                                const double position[][3], const int types[],
-                                const int num_atom, const double symprec);
+SPG_API int spg_get_schoenflies(char symbol[7], double const lattice[3][3],
+                                double const position[][3], int const types[],
+                                int const num_atom, double const symprec);
 
-SPG_API int spgat_get_schoenflies(char symbol[7], const double lattice[3][3],
-                                  const double position[][3], const int types[],
-                                  const int num_atom, const double symprec,
-                                  const double angle_tolerance);
+SPG_API int spgat_get_schoenflies(char symbol[7], double const lattice[3][3],
+                                  double const position[][3], int const types[],
+                                  int const num_atom, double const symprec,
+                                  double const angle_tolerance);
 
 /* Point group symbol is obtained from the rotation part of */
 /* symmetry operations */
 SPG_API int spg_get_pointgroup(char symbol[6], int trans_mat[3][3],
-                               const int rotations[][3][3],
-                               const int num_rotations);
+                               int const rotations[][3][3],
+                               int const num_rotations);
 
 /* Space-group operations in built-in database are accessed by index */
 /* of hall symbol. The index is defined as number from 1 to 530. */
 /* The maximum number of symmetry operations is 192. */
 SPG_API int spg_get_symmetry_from_database(int rotations[192][3][3],
                                            double translations[192][3],
-                                           const int hall_number);
+                                           int const hall_number);
 
 /* This is unstable feature under active development! */
 /* Magnetic space-group operations in built-in database are accessed by UNI
@@ -424,30 +424,30 @@ SPG_API int spg_get_symmetry_from_database(int rotations[192][3][3],
 SPG_API int spg_get_magnetic_symmetry_from_database(int rotations[384][3][3],
                                                     double translations[384][3],
                                                     int time_reversals[384],
-                                                    const int uni_number,
-                                                    const int hall_number);
+                                                    int const uni_number,
+                                                    int const hall_number);
 
 /* Space-group type information is accessed by index of hall symbol. */
 /* The index is defined as number from 1 to 530. */
-SPG_API SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number);
+SPG_API SpglibSpacegroupType spg_get_spacegroup_type(int const hall_number);
 
 /* This is unstable feature under active development! */
 /* Magnetic space-group type information is accessed by index of UNI symbol.
  */
 /* The index is defined as number from 1 to 1651. */
 SPG_API SpglibMagneticSpacegroupType
-spg_get_magnetic_spacegroup_type(const int uni_number);
+spg_get_magnetic_spacegroup_type(int const uni_number);
 
 SPG_API int spg_standardize_cell(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const int to_primitive, const int no_idealize,
-                                 const double symprec);
+                                 int types[], int const num_atom,
+                                 int const to_primitive, int const no_idealize,
+                                 double const symprec);
 
 SPG_API int spgat_standardize_cell(double lattice[3][3], double position[][3],
-                                   int types[], const int num_atom,
-                                   const int to_primitive,
-                                   const int no_idealize, const double symprec,
-                                   const double angle_tolerance);
+                                   int types[], int const num_atom,
+                                   int const to_primitive,
+                                   int const no_idealize, double const symprec,
+                                   double const angle_tolerance);
 
 /* This is a wrapper of spg_standardize_cell. */
 /* A primitive cell is found from an input cell. */
@@ -456,13 +456,13 @@ SPG_API int spgat_standardize_cell(double lattice[3][3], double position[][3],
 /* ``num_atom`` is returned as return value. */
 /* When any primitive cell is not found, 0 is returned. */
 SPG_API int spg_find_primitive(double lattice[3][3], double position[][3],
-                               int types[], const int num_atom,
-                               const double symprec);
+                               int types[], int const num_atom,
+                               double const symprec);
 
 SPG_API int spgat_find_primitive(double lattice[3][3], double position[][3],
-                                 int types[], const int num_atom,
-                                 const double symprec,
-                                 const double angle_tolerance);
+                                 int types[], int const num_atom,
+                                 double const symprec,
+                                 double const angle_tolerance);
 
 /* This is a wrapper of spg_standardize_cell. */
 /* Bravais lattice with internal atomic points are returned. */
@@ -471,17 +471,17 @@ SPG_API int spgat_find_primitive(double lattice[3][3], double position[][3],
 /* When bravais lattice could not be found, or could not be */
 /* symmetrized, 0 is returned. */
 SPG_API int spg_refine_cell(double lattice[3][3], double position[][3],
-                            int types[], const int num_atom,
-                            const double symprec);
+                            int types[], int const num_atom,
+                            double const symprec);
 
 SPG_API int spgat_refine_cell(double lattice[3][3], double position[][3],
-                              int types[], const int num_atom,
-                              const double symprec,
-                              const double angle_tolerance);
+                              int types[], int const num_atom,
+                              double const symprec,
+                              double const angle_tolerance);
 
 /* Delaunay reduction for lattice parameters */
 /* ``lattice`` is overwritten when the reduction ends succeeded. */
-SPG_API int spg_delaunay_reduce(double lattice[3][3], const double symprec);
+SPG_API int spg_delaunay_reduce(double lattice[3][3], double const symprec);
 
 /*---------*/
 /* kpoints */
@@ -492,10 +492,10 @@ SPG_API int spg_delaunay_reduce(double lattice[3][3], const double symprec);
 /* A q-point in fractional coordinates is given as */
 /* ((grid_address * 2 + (shift != 0)) / (mesh * 2)). */
 /* Each element of shift[] is 0 or non-zero. */
-SPG_API int spg_get_grid_point_from_address(const int grid_address[3],
-                                            const int mesh[3]);
-SPG_API size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
-                                                     const int mesh[3]);
+SPG_API int spg_get_grid_point_from_address(int const grid_address[3],
+                                            int const mesh[3]);
+SPG_API size_t spg_get_dense_grid_point_from_address(int const grid_address[3],
+                                                     int const mesh[3]);
 
 /* Irreducible reciprocal grid points are searched from uniform */
 /* mesh grid points specified by ``mesh`` and ``is_shift``. */
@@ -514,15 +514,15 @@ SPG_API size_t spg_get_dense_grid_point_from_address(const int grid_address[3],
 /* returned as the return value.  The time reversal symmetry is */
 /* imposed by setting ``is_time_reversal`` 1. */
 SPG_API int spg_get_ir_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const double symprec);
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal,
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, double const symprec);
 SPG_API size_t spg_get_dense_ir_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal,
-    const double lattice[3][3], const double position[][3], const int types[],
-    const int num_atom, const double symprec);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal,
+    double const lattice[3][3], double const position[][3], int const types[],
+    int const num_atom, double const symprec);
 
 /* The irreducible k-points are searched from unique k-point mesh */
 /* grids from real space lattice vectors and rotation matrices of */
@@ -533,33 +533,33 @@ SPG_API size_t spg_get_dense_ir_reciprocal_mesh(
 /* reduced k-points with stabilizers are returned as the return */
 /* value. */
 SPG_API int spg_get_stabilized_reciprocal_mesh(
-    int grid_address[][3], int ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const int num_rot,
-    const int rotations[][3][3], const int num_q, const double qpoints[][3]);
+    int grid_address[][3], int ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, int const num_rot,
+    int const rotations[][3][3], int const num_q, double const qpoints[][3]);
 SPG_API size_t spg_get_dense_stabilized_reciprocal_mesh(
-    int grid_address[][3], size_t ir_mapping_table[], const int mesh[3],
-    const int is_shift[3], const int is_time_reversal, const int num_rot,
-    const int rotations[][3][3], const int num_q, const double qpoints[][3]);
+    int grid_address[][3], size_t ir_mapping_table[], int const mesh[3],
+    int const is_shift[3], int const is_time_reversal, int const num_rot,
+    int const rotations[][3][3], int const num_q, double const qpoints[][3]);
 
 /* Rotation operations in reciprocal space ``rot_reciprocal`` are applied */
 /* to a grid address ``address_orig`` and resulting grid points are stored
  * in */
 /* ``rot_grid_points``. Return 0 if failed. */
 SPG_API void spg_get_grid_points_by_rotations(
-    int rot_grid_points[], const int address_orig[3], const int num_rot,
-    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3]);
+    int rot_grid_points[], int const address_orig[3], int const num_rot,
+    int const rot_reciprocal[][3][3], int const mesh[3], int const is_shift[3]);
 SPG_API void spg_get_dense_grid_points_by_rotations(
-    size_t rot_grid_points[], const int address_orig[3], const int num_rot,
-    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3]);
+    size_t rot_grid_points[], int const address_orig[3], int const num_rot,
+    int const rot_reciprocal[][3][3], int const mesh[3], int const is_shift[3]);
 
 SPG_API void spg_get_BZ_grid_points_by_rotations(
-    int rot_grid_points[], const int address_orig[3], const int num_rot,
-    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3],
-    const int bz_map[]);
+    int rot_grid_points[], int const address_orig[3], int const num_rot,
+    int const rot_reciprocal[][3][3], int const mesh[3], int const is_shift[3],
+    int const bz_map[]);
 SPG_API void spg_get_dense_BZ_grid_points_by_rotations(
-    size_t rot_grid_points[], const int address_orig[3], const int num_rot,
-    const int rot_reciprocal[][3][3], const int mesh[3], const int is_shift[3],
-    const size_t bz_map[]);
+    size_t rot_grid_points[], int const address_orig[3], int const num_rot,
+    int const rot_reciprocal[][3][3], int const mesh[3], int const is_shift[3],
+    size_t const bz_map[]);
 
 /* Grid addresses are relocated inside Brillouin zone. */
 /* Number of ir-grid-points inside Brillouin zone is returned. */
@@ -584,19 +584,19 @@ SPG_API void spg_get_dense_BZ_grid_points_by_rotations(
 /* surface from grid address. The grid point indices are mapped to */
 /* (mesh[0] * 2) x (mesh[1] * 2) x (mesh[2] * 2) space (bz_map). */
 SPG_API int spg_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
-                                         const int grid_address[][3],
-                                         const int mesh[3],
-                                         const double rec_lattice[3][3],
-                                         const int is_shift[3]);
+                                         int const grid_address[][3],
+                                         int const mesh[3],
+                                         double const rec_lattice[3][3],
+                                         int const is_shift[3]);
 SPG_API size_t spg_relocate_dense_BZ_grid_address(
-    int bz_grid_address[][3], size_t bz_map[], const int grid_address[][3],
-    const int mesh[3], const double rec_lattice[3][3], const int is_shift[3]);
+    int bz_grid_address[][3], size_t bz_map[], int const grid_address[][3],
+    int const mesh[3], double const rec_lattice[3][3], int const is_shift[3]);
 
 /*--------*/
 /* Niggli */
 /*--------*/
 /* Return 0 if failed */
-SPG_API int spg_niggli_reduce(double lattice[3][3], const double symprec);
+SPG_API int spg_niggli_reduce(double lattice[3][3], double const symprec);
 
 #ifdef __cplusplus
 }

--- a/src/spglib.h
+++ b/src/spglib.h
@@ -40,20 +40,20 @@ extern "C" {
 #endif
 
 #ifdef SPG_BUILD
-// When compiling define API for export
-#if defined(_MSC_VER)
-// On windows the API must be explicitly marked for export/import
-#define SPG_API __declspec(dllexport)
-#else
-// On Unix this is not necessary
-#define SPG_API __attribute__((visibility("default")))
-#endif
+    // When compiling define API for export
+    #if defined(_MSC_VER)
+        // On windows the API must be explicitly marked for export/import
+        #define SPG_API __declspec(dllexport)
+    #else
+        // On Unix this is not necessary
+        #define SPG_API __attribute__((visibility("default")))
+    #endif
 #elif defined(_MSC_VER)
-// Otherwise mark it for import (Only needed for windows)
-#define SPG_API __declspec(dllimport)
+    // Otherwise mark it for import (Only needed for windows)
+    #define SPG_API __declspec(dllimport)
 #else
-// Not building and not on windows, no need to do anything
-#define SPG_API
+    // Not building and not on windows, no need to do anything
+    #define SPG_API
 #endif
 
 #include <stddef.h>

--- a/src/spin.c
+++ b/src/spin.c
@@ -44,53 +44,53 @@
 #include "symmetry.h"
 
 static MagneticSymmetry *get_operations(
-    const Symmetry *sym_nonspin, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double mag_symprec);
-static int *get_symmetry_permutations(const MagneticSymmetry *magnetic_symmetry,
-                                      const Cell *cell,
-                                      const int with_time_reversal,
-                                      const int is_axial, const double symprec,
-                                      const double mag_symprec);
-static int *get_orbits(const int *permutations, const int num_sym,
-                       const int num_atoms);
+    Symmetry const *sym_nonspin, Cell const *cell, int const with_time_reversal,
+    int const is_axial, double const symprec, double const mag_symprec);
+static int *get_symmetry_permutations(MagneticSymmetry const *magnetic_symmetry,
+                                      Cell const *cell,
+                                      int const with_time_reversal,
+                                      int const is_axial, double const symprec,
+                                      double const mag_symprec);
+static int *get_orbits(int const *permutations, int const num_sym,
+                       int const num_atoms);
 static int get_operation_sign_on_scalar(
-    const double spin_j, const double spin_k, const double rot_cart[3][3],
-    const int with_time_reversal, const int is_axial, const double mag_symprec);
-static int get_operation_sign_on_vector(const int j, const int k,
-                                        const double *vectors,
-                                        const double rot_cart[3][3],
-                                        const int with_time_reversal,
-                                        const int is_axial,
-                                        const double mag_symprec);
+    double const spin_j, double const spin_k, double const rot_cart[3][3],
+    int const with_time_reversal, int const is_axial, double const mag_symprec);
+static int get_operation_sign_on_vector(int const j, int const k,
+                                        double const *vectors,
+                                        double const rot_cart[3][3],
+                                        int const with_time_reversal,
+                                        int const is_axial,
+                                        double const mag_symprec);
 static void apply_symmetry_to_position(double pos_dst[3],
-                                       const double pos_src[3],
-                                       const int rot[3][3],
-                                       const double trans[3]);
-static double apply_symmetry_to_site_scalar(const double src,
-                                            const double rot_cart[3][3],
-                                            const int timerev,
-                                            const int with_time_reversal,
-                                            const int is_axial);
-static void apply_symmetry_to_site_vector(double dst[3], const int idx,
-                                          const double *tensors,
-                                          const double rot_cart[3][3],
-                                          const int timerev,
-                                          const int with_time_reversal,
-                                          const int is_axial);
+                                       double const pos_src[3],
+                                       int const rot[3][3],
+                                       double const trans[3]);
+static double apply_symmetry_to_site_scalar(double const src,
+                                            double const rot_cart[3][3],
+                                            int const timerev,
+                                            int const with_time_reversal,
+                                            int const is_axial);
+static void apply_symmetry_to_site_vector(double dst[3], int const idx,
+                                          double const *tensors,
+                                          double const rot_cart[3][3],
+                                          int const timerev,
+                                          int const with_time_reversal,
+                                          int const is_axial);
 void set_rotations_in_cartesian(double (*rotations_cart)[3][3],
-                                const double lattice[3][3],
-                                const MagneticSymmetry *magnetic_symmetry);
-static int is_zero(const double a, const double mag_symprec);
-static int is_zero_d3(const double a[3], const double mag_symprec);
+                                double const lattice[3][3],
+                                MagneticSymmetry const *magnetic_symmetry);
+static int is_zero(double const a, double const mag_symprec);
+static int is_zero_d3(double const a[3], double const mag_symprec);
 
 /******************************************************************************/
 
 /* doc was moved to spin.h. */
 MagneticSymmetry *spn_get_operations_with_site_tensors(
     int **equivalent_atoms, int **permutations, double prim_lattice[3][3],
-    const Symmetry *sym_nonspin, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec_) {
+    Symmetry const *sym_nonspin, Cell const *cell, int const with_time_reversal,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec_) {
     int multi;
     double mag_symprec;
     MagneticSymmetry *magnetic_symmetry;
@@ -148,7 +148,7 @@ err:
 }
 
 VecDBL *spn_collect_pure_translations_from_magnetic_symmetry(
-    const MagneticSymmetry *sym_msg) {
+    MagneticSymmetry const *sym_msg) {
     int i, num_pure_trans;
     VecDBL *pure_trans;
     VecDBL *ret_pure_trans;
@@ -189,9 +189,9 @@ VecDBL *spn_collect_pure_translations_from_magnetic_symmetry(
 }
 
 /* Apply special position operator to `cell`. */
-Cell *spn_get_idealized_cell(const int *permutations, const Cell *cell,
-                             const MagneticSymmetry *magnetic_symmetry,
-                             const int with_time_reversal, const int is_axial) {
+Cell *spn_get_idealized_cell(int const *permutations, Cell const *cell,
+                             MagneticSymmetry const *magnetic_symmetry,
+                             int const with_time_reversal, int const is_axial) {
     int i, j, s, p;
     Cell *exact_cell;
     double scalar_tmp, scalar_res;
@@ -306,7 +306,7 @@ Cell *spn_get_idealized_cell(const int *permutations, const Cell *cell,
 }
 
 /* If failed, return NULL. */
-double *spn_alloc_site_tensors(const int num_atoms, const int tensor_rank) {
+double *spn_alloc_site_tensors(int const num_atoms, int const tensor_rank) {
     double *ret;
     if (tensor_rank == 0) {
         if ((ret = (double *)malloc(sizeof(double) * num_atoms)) == NULL) {
@@ -332,8 +332,8 @@ double *spn_alloc_site_tensors(const int num_atoms, const int tensor_rank) {
 /* is_axial: If true, tensors with tensor_rank==1 do not change by */
 /*           spatial inversion */
 static MagneticSymmetry *get_operations(
-    const Symmetry *sym_nonspin, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double mag_symprec) {
+    Symmetry const *sym_nonspin, Cell const *cell, int const with_time_reversal,
+    int const is_axial, double const symprec, double const mag_symprec) {
     MagneticSymmetry *magnetic_symmetry;
     int i, j, k, sign, num_sym, found, determined, max_size;
     double pos[3];
@@ -553,11 +553,11 @@ err:
 // Return permutation tables `permutations` such that the p-th operation
 // in `magnetic_symmetry` maps site-`i` to site-`permutations[p * cell->size +
 // * i]`. If failed, return NULL.
-static int *get_symmetry_permutations(const MagneticSymmetry *magnetic_symmetry,
-                                      const Cell *cell,
-                                      const int with_time_reversal,
-                                      const int is_axial, const double symprec,
-                                      const double mag_symprec) {
+static int *get_symmetry_permutations(MagneticSymmetry const *magnetic_symmetry,
+                                      Cell const *cell,
+                                      int const with_time_reversal,
+                                      int const is_axial, double const symprec,
+                                      double const mag_symprec) {
     int p, i, j;
     int *permutations;
     double scalar;
@@ -648,8 +648,8 @@ static int *get_symmetry_permutations(const MagneticSymmetry *magnetic_symmetry,
 }
 
 // Return equivalent_atoms. If failed, return NULL.
-static int *get_orbits(const int *permutations, const int num_sym,
-                       const int num_atoms) {
+static int *get_orbits(int const *permutations, int const num_sym,
+                       int const num_atoms) {
     int s, i;
     int *equivalent_atoms;
 
@@ -677,12 +677,12 @@ static int *get_orbits(const int *permutations, const int num_sym,
 
 /* Return sign in {-1, 1} such that `sign * spin'_j == spin_k` */
 /* If spin_j and spin_k are not the same dimension, return 0 */
-static int get_operation_sign_on_scalar(const double spin_j,
-                                        const double spin_k,
-                                        const double rot_cart[3][3],
-                                        const int with_time_reversal,
-                                        const int is_axial,
-                                        const double mag_symprec) {
+static int get_operation_sign_on_scalar(double const spin_j,
+                                        double const spin_k,
+                                        double const rot_cart[3][3],
+                                        int const with_time_reversal,
+                                        int const is_axial,
+                                        double const mag_symprec) {
     int timerev;
     double spin_j_ops;
 
@@ -702,12 +702,12 @@ static int get_operation_sign_on_scalar(const double spin_j,
 /* If v_j and v_k are not transformed each other, return 0 */
 /* is_axial: Non-collinear magnetic moment v'_j = |detR|R v_j */
 /* !is_axial: Usual vector: v'_j = R v_j */
-static int get_operation_sign_on_vector(const int j, const int k,
-                                        const double *vectors,
-                                        const double rot_cart[3][3],
-                                        const int with_time_reversal,
-                                        const int is_axial,
-                                        const double mag_symprec) {
+static int get_operation_sign_on_vector(int const j, int const k,
+                                        double const *vectors,
+                                        double const rot_cart[3][3],
+                                        int const with_time_reversal,
+                                        int const is_axial,
+                                        double const mag_symprec) {
     int s, timerev;
     double vec_j_ops[3], diff[3];
 
@@ -727,9 +727,9 @@ static int get_operation_sign_on_vector(const int j, const int k,
 
 /* Apply `idx`th operation in `magnetic_symmetry` to position. */
 static void apply_symmetry_to_position(double pos_dst[3],
-                                       const double pos_src[3],
-                                       const int rot[3][3],
-                                       const double trans[3]) {
+                                       double const pos_src[3],
+                                       int const rot[3][3],
+                                       double const trans[3]) {
     int k;
     mat_multiply_matrix_vector_id3(pos_dst, rot, pos_src);
     for (k = 0; k < 3; k++) {
@@ -738,11 +738,11 @@ static void apply_symmetry_to_position(double pos_dst[3],
 }
 
 /* tensor_rank=0 case */
-static double apply_symmetry_to_site_scalar(const double src,
-                                            const double rot_cart[3][3],
-                                            const int timerev,
-                                            const int with_time_reversal,
-                                            const int is_axial) {
+static double apply_symmetry_to_site_scalar(double const src,
+                                            double const rot_cart[3][3],
+                                            int const timerev,
+                                            int const with_time_reversal,
+                                            int const is_axial) {
     double det, dst;
 
     dst = (with_time_reversal && timerev) ? -src : src;
@@ -755,12 +755,12 @@ static double apply_symmetry_to_site_scalar(const double src,
 }
 
 /* tensor_rank=1 case */
-static void apply_symmetry_to_site_vector(double dst[3], const int idx,
-                                          const double *tensors,
-                                          const double rot_cart[3][3],
-                                          const int timerev,
-                                          const int with_time_reversal,
-                                          const int is_axial) {
+static void apply_symmetry_to_site_vector(double dst[3], int const idx,
+                                          double const *tensors,
+                                          double const rot_cart[3][3],
+                                          int const timerev,
+                                          int const with_time_reversal,
+                                          int const is_axial) {
     int s;
     double det;
     double vec[3];
@@ -782,8 +782,8 @@ static void apply_symmetry_to_site_vector(double dst[3], const int idx,
 }
 
 void set_rotations_in_cartesian(double (*rotations_cart)[3][3],
-                                const double lattice[3][3],
-                                const MagneticSymmetry *magnetic_symmetry) {
+                                double const lattice[3][3],
+                                MagneticSymmetry const *magnetic_symmetry) {
     int i;
     double inv_lat[3][3];
 
@@ -796,11 +796,11 @@ void set_rotations_in_cartesian(double (*rotations_cart)[3][3],
     }
 }
 
-static int is_zero(const double a, const double mag_symprec) {
+static int is_zero(double const a, double const mag_symprec) {
     return mat_Dabs(a) < mag_symprec;
 }
 
-static int is_zero_d3(const double a[3], const double mag_symprec) {
+static int is_zero_d3(double const a[3], double const mag_symprec) {
     int i;
     for (i = 0; i < 3; i++) {
         if (!is_zero(a[i], mag_symprec)) {

--- a/src/spin.h
+++ b/src/spin.h
@@ -58,14 +58,14 @@
  */
 MagneticSymmetry *spn_get_operations_with_site_tensors(
     int **equivalent_atoms, int **permutations, double prim_lattice[3][3],
-    const Symmetry *sym_nonspin, const Cell *cell, const int with_time_reversal,
-    const int is_axial, const double symprec, const double angle_tolerance,
-    const double mag_symprec);
+    Symmetry const *sym_nonspin, Cell const *cell, int const with_time_reversal,
+    int const is_axial, double const symprec, double const angle_tolerance,
+    double const mag_symprec);
 VecDBL *spn_collect_pure_translations_from_magnetic_symmetry(
-    const MagneticSymmetry *sym_msg);
-Cell *spn_get_idealized_cell(const int *permutations, const Cell *cell,
-                             const MagneticSymmetry *magnetic_symmetry,
-                             const int with_time_reversal, const int is_axial);
-double *spn_alloc_site_tensors(const int num_atoms, const int tensor_rank);
+    MagneticSymmetry const *sym_msg);
+Cell *spn_get_idealized_cell(int const *permutations, Cell const *cell,
+                             MagneticSymmetry const *magnetic_symmetry,
+                             int const with_time_reversal, int const is_axial);
+double *spn_alloc_site_tensors(int const num_atoms, int const tensor_rank);
 
 #endif

--- a/src/symmetry.c
+++ b/src/symmetry.c
@@ -62,61 +62,61 @@ static int relative_axes[][3] = {
 
 static int identity[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 
-static int get_index_with_least_atoms(const Cell *cell);
-static VecDBL *get_translation(const int rot[3][3], const Cell *cell,
-                               const double symprec, const int is_identity);
-static Symmetry *get_operations(const Cell *primitive, const double symprec,
-                                const double angle_symprec);
-static Symmetry *reduce_operation(const Cell *primitive,
-                                  const Symmetry *symmetry,
-                                  const double symprec,
-                                  const double angle_symprec,
-                                  const int is_pure_trans);
-static int search_translation_part(int atoms_found[], const Cell *cell,
-                                   const int rot[3][3],
-                                   const int min_atom_index,
-                                   const double origin[3], const double symprec,
-                                   const int is_identity);
-static int search_pure_translations(int atoms_found[], const Cell *cell,
-                                    const double trans[3],
-                                    const double symprec);
-static int is_overlap_all_atoms(const double test_trans[3], const int rot[3][3],
-                                const Cell *cell, const double symprec,
-                                const int is_identity);
+static int get_index_with_least_atoms(Cell const *cell);
+static VecDBL *get_translation(int const rot[3][3], Cell const *cell,
+                               double const symprec, int const is_identity);
+static Symmetry *get_operations(Cell const *primitive, double const symprec,
+                                double const angle_symprec);
+static Symmetry *reduce_operation(Cell const *primitive,
+                                  Symmetry const *symmetry,
+                                  double const symprec,
+                                  double const angle_symprec,
+                                  int const is_pure_trans);
+static int search_translation_part(int atoms_found[], Cell const *cell,
+                                   int const rot[3][3],
+                                   int const min_atom_index,
+                                   double const origin[3], double const symprec,
+                                   int const is_identity);
+static int search_pure_translations(int atoms_found[], Cell const *cell,
+                                    double const trans[3],
+                                    double const symprec);
+static int is_overlap_all_atoms(double const test_trans[3], int const rot[3][3],
+                                Cell const *cell, double const symprec,
+                                int const is_identity);
 static PointSymmetry transform_pointsymmetry(
-    const PointSymmetry *point_sym_prim, const double new_lattice[3][3],
-    const double original_lattice[3][3]);
-static Symmetry *get_space_group_operations(const PointSymmetry *lattice_sym,
-                                            const Cell *primitive,
-                                            const double symprec);
-static void set_axes(int axes[3][3], const int a1, const int a2, const int a3);
-static PointSymmetry get_lattice_symmetry(const Cell *cell,
-                                          const double symprec,
-                                          const double angle_symprec);
-static int is_identity_metric(const double metric_rotated[3][3],
-                              const double metric_orig[3][3],
-                              const double symprec, const double angle_symprec);
-static double get_angle(const double metric[3][3], const int i, const int j);
+    PointSymmetry const *point_sym_prim, double const new_lattice[3][3],
+    double const original_lattice[3][3]);
+static Symmetry *get_space_group_operations(PointSymmetry const *lattice_sym,
+                                            Cell const *primitive,
+                                            double const symprec);
+static void set_axes(int axes[3][3], int const a1, int const a2, int const a3);
+static PointSymmetry get_lattice_symmetry(Cell const *cell,
+                                          double const symprec,
+                                          double const angle_symprec);
+static int is_identity_metric(double const metric_rotated[3][3],
+                              double const metric_orig[3][3],
+                              double const symprec, double const angle_symprec);
+static double get_angle(double const metric[3][3], int const i, int const j);
 
 /* get_translation, search_translation_part and search_pure_translations */
 /* are duplicated to get the if statement outside the nested loops */
 /* I have not tested if it is better in efficiency. */
-static VecDBL *get_layer_translation(const int rot[3][3], const Cell *cell,
-                                     const double symprec,
-                                     const int is_identity);
-static int search_layer_translation_part(int atoms_found[], const Cell *cell,
-                                         const int rot[3][3],
-                                         const int min_atom_index,
-                                         const double origin[3],
-                                         const double symprec,
-                                         const int is_identity);
-static int search_layer_pure_translations(int atoms_found[], const Cell *cell,
-                                          const double trans[3],
-                                          const int periodic_axes[2],
-                                          const double symprec);
+static VecDBL *get_layer_translation(int const rot[3][3], Cell const *cell,
+                                     double const symprec,
+                                     int const is_identity);
+static int search_layer_translation_part(int atoms_found[], Cell const *cell,
+                                         int const rot[3][3],
+                                         int const min_atom_index,
+                                         double const origin[3],
+                                         double const symprec,
+                                         int const is_identity);
+static int search_layer_pure_translations(int atoms_found[], Cell const *cell,
+                                          double const trans[3],
+                                          int const periodic_axes[2],
+                                          double const symprec);
 
 /* Return NULL if failed */
-Symmetry *sym_alloc_symmetry(const int size) {
+Symmetry *sym_alloc_symmetry(int const size) {
     Symmetry *symmetry;
 
     symmetry = NULL;
@@ -167,7 +167,7 @@ void sym_free_symmetry(Symmetry *symmetry) {
 }
 
 /* Return NULL if failed */
-MagneticSymmetry *sym_alloc_magnetic_symmetry(const int size) {
+MagneticSymmetry *sym_alloc_magnetic_symmetry(int const size) {
     MagneticSymmetry *symmetry;
 
     symmetry = NULL;
@@ -232,22 +232,22 @@ void sym_free_magnetic_symmetry(MagneticSymmetry *symmetry) {
 }
 
 /* Return NULL if failed */
-Symmetry *sym_get_operation(const Cell *primitive, const double symprec,
-                            const double angle_tolerance) {
+Symmetry *sym_get_operation(Cell const *primitive, double const symprec,
+                            double const angle_tolerance) {
     debug_print("sym_get_operations:\n");
 
     return get_operations(primitive, symprec, angle_tolerance);
 }
 
 /* Return NULL if failed */
-Symmetry *sym_reduce_operation(const Cell *primitive, const Symmetry *symmetry,
-                               const double symprec,
-                               const double angle_tolerance) {
+Symmetry *sym_reduce_operation(Cell const *primitive, Symmetry const *symmetry,
+                               double const symprec,
+                               double const angle_tolerance) {
     return reduce_operation(primitive, symmetry, symprec, angle_tolerance, 0);
 }
 
 /* Return NULL if failed */
-VecDBL *sym_get_pure_translation(const Cell *cell, const double symprec) {
+VecDBL *sym_get_pure_translation(Cell const *cell, double const symprec) {
     int multi;
     VecDBL *pure_trans;
 
@@ -282,9 +282,9 @@ VecDBL *sym_get_pure_translation(const Cell *cell, const double symprec) {
 }
 
 /* Return NULL if failed */
-VecDBL *sym_reduce_pure_translation(const Cell *cell, const VecDBL *pure_trans,
-                                    const double symprec,
-                                    const double angle_tolerance) {
+VecDBL *sym_reduce_pure_translation(Cell const *cell, VecDBL const *pure_trans,
+                                    double const symprec,
+                                    double const angle_tolerance) {
     int i, multi;
     Symmetry *symmetry, *symmetry_reduced;
     VecDBL *pure_trans_reduced;
@@ -342,8 +342,8 @@ VecDBL *sym_reduce_pure_translation(const Cell *cell, const VecDBL *pure_trans,
 /* 3) The spacegroup operations for the primitive cell are */
 /*    transformed to those of original input cells, if the input cell */
 /*    was not a primitive cell. */
-static Symmetry *get_operations(const Cell *primitive, const double symprec,
-                                const double angle_symprec) {
+static Symmetry *get_operations(Cell const *primitive, double const symprec,
+                                double const angle_symprec) {
     PointSymmetry lattice_sym;
     Symmetry *symmetry;
 
@@ -365,11 +365,11 @@ static Symmetry *get_operations(const Cell *primitive, const double symprec,
 }
 
 /* Return NULL if failed */
-static Symmetry *reduce_operation(const Cell *primitive,
-                                  const Symmetry *symmetry,
-                                  const double symprec,
-                                  const double angle_symprec,
-                                  const int is_pure_trans) {
+static Symmetry *reduce_operation(Cell const *primitive,
+                                  Symmetry const *symmetry,
+                                  double const symprec,
+                                  double const angle_symprec,
+                                  int const is_pure_trans) {
     int i, j, num_sym;
     Symmetry *sym_reduced;
     PointSymmetry point_symmetry;
@@ -436,8 +436,8 @@ static Symmetry *reduce_operation(const Cell *primitive,
 /* Look for the translations which satisfy the input symmetry operation. */
 /* This function is heaviest in this code. */
 /* Return NULL if failed */
-static VecDBL *get_translation(const int rot[3][3], const Cell *cell,
-                               const double symprec, const int is_identity) {
+static VecDBL *get_translation(int const rot[3][3], Cell const *cell,
+                               double const symprec, int const is_identity) {
     int i, j, k, min_atom_index, num_trans;
     int *is_found;
     double origin[3];
@@ -498,11 +498,11 @@ ret:
 }
 
 /* Returns -1 on failure. */
-static int search_translation_part(int atoms_found[], const Cell *cell,
-                                   const int rot[3][3],
-                                   const int min_atom_index,
-                                   const double origin[3], const double symprec,
-                                   const int is_identity) {
+static int search_translation_part(int atoms_found[], Cell const *cell,
+                                   int const rot[3][3],
+                                   int const min_atom_index,
+                                   double const origin[3], double const symprec,
+                                   int const is_identity) {
     int i, j, num_trans, is_overlap;
     double trans[3];
     OverlapChecker *checker;
@@ -552,9 +552,9 @@ err:
     return -1;
 }
 
-static int search_pure_translations(int atoms_found[], const Cell *cell,
-                                    const double trans[3],
-                                    const double symprec) {
+static int search_pure_translations(int atoms_found[], Cell const *cell,
+                                    double const trans[3],
+                                    double const symprec) {
     int i, j, num_trans, i_atom, initial_atom;
     int *copy_atoms_found;
     double vec[3];
@@ -606,9 +606,9 @@ static int search_pure_translations(int atoms_found[], const Cell *cell,
 /* Thoroughly confirms that a given symmetry operation is a symmetry. */
 /* This is a convenient wrapper around ovl_check_total_overlap. */
 /* -1: Error.  0: Not a symmetry.  1: Is a symmetry. */
-static int is_overlap_all_atoms(const double trans[3], const int rot[3][3],
-                                const Cell *cell, const double symprec,
-                                const int is_identity) {
+static int is_overlap_all_atoms(double const trans[3], int const rot[3][3],
+                                Cell const *cell, double const symprec,
+                                int const is_identity) {
     OverlapChecker *checker;
     int result;
 
@@ -632,7 +632,7 @@ static int is_overlap_all_atoms(const double trans[3], const int rot[3][3],
     return result;
 }
 
-static int get_index_with_least_atoms(const Cell *cell) {
+static int get_index_with_least_atoms(Cell const *cell) {
     int i, j, min, min_index;
     int *mapping;
 
@@ -674,9 +674,9 @@ static int get_index_with_least_atoms(const Cell *cell) {
 /* Look for the translations which satisfy the input symmetry operation. */
 /* This function is heaviest in this code. */
 /* Return NULL if failed */
-static VecDBL *get_layer_translation(const int rot[3][3], const Cell *cell,
-                                     const double symprec,
-                                     const int is_identity) {
+static VecDBL *get_layer_translation(int const rot[3][3], Cell const *cell,
+                                     double const symprec,
+                                     int const is_identity) {
     int i, j, k, min_atom_index, num_trans;
     int *is_found;
     double origin[3];
@@ -739,12 +739,12 @@ ret:
 }
 
 /* Returns -1 on failure. */
-static int search_layer_translation_part(int atoms_found[], const Cell *cell,
-                                         const int rot[3][3],
-                                         const int min_atom_index,
-                                         const double origin[3],
-                                         const double symprec,
-                                         const int is_identity) {
+static int search_layer_translation_part(int atoms_found[], Cell const *cell,
+                                         int const rot[3][3],
+                                         int const min_atom_index,
+                                         double const origin[3],
+                                         double const symprec,
+                                         int const is_identity) {
     int i, j, num_trans, is_overlap;
     double trans[3];
     OverlapChecker *checker;
@@ -794,10 +794,10 @@ err:
     return -1;
 }
 
-static int search_layer_pure_translations(int atoms_found[], const Cell *cell,
-                                          const double trans[3],
-                                          const int periodic_axes[2],
-                                          const double symprec) {
+static int search_layer_pure_translations(int atoms_found[], Cell const *cell,
+                                          double const trans[3],
+                                          int const periodic_axes[2],
+                                          double const symprec) {
     int i, j, num_trans, i_atom, initial_atom;
     int *copy_atoms_found;
     double vec[3];
@@ -848,9 +848,9 @@ static int search_layer_pure_translations(int atoms_found[], const Cell *cell,
 }
 
 /* Return NULL if failed */
-static Symmetry *get_space_group_operations(const PointSymmetry *lattice_sym,
-                                            const Cell *primitive,
-                                            const double symprec) {
+static Symmetry *get_space_group_operations(PointSymmetry const *lattice_sym,
+                                            Cell const *primitive,
+                                            double const symprec) {
     int i, j, num_sym, total_num_sym;
     VecDBL **trans;
     Symmetry *symmetry;
@@ -924,9 +924,9 @@ ret:
 }
 
 /* lattice_sym.size = 0 is returned if failed. */
-static PointSymmetry get_lattice_symmetry(const Cell *cell,
-                                          const double symprec,
-                                          const double angle_symprec) {
+static PointSymmetry get_lattice_symmetry(Cell const *cell,
+                                          double const symprec,
+                                          double const angle_symprec) {
     int i, j, k, attempt, num_sym, aperiodic_axis;
     double angle_tol;
     int axes[3][3];
@@ -1039,10 +1039,10 @@ err:
     return lattice_sym;
 }
 
-static int is_identity_metric(const double metric_rotated[3][3],
-                              const double metric_orig[3][3],
-                              const double symprec,
-                              const double angle_symprec) {
+static int is_identity_metric(double const metric_rotated[3][3],
+                              double const metric_orig[3][3],
+                              double const symprec,
+                              double const angle_symprec) {
     int i, j, k;
     int elem_sets[3][2] = {{0, 1}, {0, 2}, {1, 2}};
     double cos1, cos2, x, length_ave2, sin_dtheta2;
@@ -1090,7 +1090,7 @@ fail:
     return 0;
 }
 
-static double get_angle(const double metric[3][3], const int i, const int j) {
+static double get_angle(double const metric[3][3], int const i, int const j) {
     double length_i, length_j;
 
     length_i = sqrt(metric[i][i]);
@@ -1100,8 +1100,8 @@ static double get_angle(const double metric[3][3], const int i, const int j) {
 }
 
 static PointSymmetry transform_pointsymmetry(
-    const PointSymmetry *lat_sym_orig, const double new_lattice[3][3],
-    const double original_lattice[3][3]) {
+    PointSymmetry const *lat_sym_orig, double const new_lattice[3][3],
+    double const original_lattice[3][3]) {
     int i, size;
     double trans_mat[3][3], inv_mat[3][3], drot[3][3];
     PointSymmetry lat_sym_new;
@@ -1146,7 +1146,7 @@ err:
 
 // @brief Set an integer matrix to `axes`. Three integer vectors are specified
 //        by indices of array `symmetry.c:relative_axes`.
-static void set_axes(int axes[3][3], const int a1, const int a2, const int a3) {
+static void set_axes(int axes[3][3], int const a1, int const a2, int const a3) {
     int i;
     for (i = 0; i < 3; i++) {
         axes[i][0] = relative_axes[a1][i];

--- a/src/symmetry.h
+++ b/src/symmetry.h
@@ -56,19 +56,19 @@ typedef struct {
     int size;
 } PointSymmetry;
 
-Symmetry *sym_alloc_symmetry(const int size);
+Symmetry *sym_alloc_symmetry(int const size);
 SPG_API_TEST void sym_free_symmetry(Symmetry *symmetry);
-MagneticSymmetry *sym_alloc_magnetic_symmetry(const int size);
+MagneticSymmetry *sym_alloc_magnetic_symmetry(int const size);
 void sym_free_magnetic_symmetry(MagneticSymmetry *symmetry);
-SPG_API_TEST Symmetry *sym_get_operation(const Cell *primitive,
-                                         const double symprec,
-                                         const double angle_tolerance);
-Symmetry *sym_reduce_operation(const Cell *primitive, const Symmetry *symmetry,
-                               const double symprec,
-                               const double angle_tolerance);
-VecDBL *sym_get_pure_translation(const Cell *cell, const double symprec);
-VecDBL *sym_reduce_pure_translation(const Cell *cell, const VecDBL *pure_trans,
-                                    const double symprec,
-                                    const double angle_tolerance);
+SPG_API_TEST Symmetry *sym_get_operation(Cell const *primitive,
+                                         double const symprec,
+                                         double const angle_tolerance);
+Symmetry *sym_reduce_operation(Cell const *primitive, Symmetry const *symmetry,
+                               double const symprec,
+                               double const angle_tolerance);
+VecDBL *sym_get_pure_translation(Cell const *cell, double const symprec);
+VecDBL *sym_reduce_pure_translation(Cell const *cell, VecDBL const *pure_trans,
+                                    double const symprec,
+                                    double const angle_tolerance);
 
 #endif

--- a/test/example/c_api/example.c
+++ b/test/example/c_api/example.c
@@ -5,7 +5,7 @@
 int main(int argc, char* argv[]) {
     SpglibDataset* dataset;
     int i, j;
-    const char wl[26] = "abcdefghijklmnopqrstuvwxyz";
+    char const wl[26] = "abcdefghijklmnopqrstuvwxyz";
 
     // Wurtzite structure (P6_3mc)
     double lattice[3][3] = {

--- a/test/example/c_api/example_full.c
+++ b/test/example/c_api/example_full.c
@@ -20,21 +20,21 @@ static void example_spg_get_dataset(void);
 static void example_layer_spg_get_dataset(void);
 static void example_spg_get_ir_reciprocal_mesh(void);
 static void example_spg_get_error_message(void);
-static void show_spg_dataset(double lattice[3][3], const double origin_shift[3],
-                             double position[][3], const int num_atom,
-                             const int types[]);
+static void show_spg_dataset(double lattice[3][3], double const origin_shift[3],
+                             double position[][3], int const num_atom,
+                             int const types[]);
 static void show_layer_spg_dataset(double lattice[3][3],
-                                   const double origin_shift[3],
-                                   double position[][3], const int num_atom,
-                                   const int types[], const int aperiodic_axis,
-                                   const double symprec);
+                                   double const origin_shift[3],
+                                   double position[][3], int const num_atom,
+                                   int const types[], int const aperiodic_axis,
+                                   double const symprec);
 static void show_cell(double lattice[3][3], double position[][3],
-                      const int types[], const int num_atom);
+                      int const types[], int const num_atom);
 static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
-                                     int types[], const int num_atom,
-                                     const double symprec,
-                                     const int to_primitive,
-                                     const int no_idealize);
+                                     int types[], int const num_atom,
+                                     double const symprec,
+                                     int const to_primitive,
+                                     int const no_idealize);
 
 int main(int argc, char *argv[]) {
     example_spg_find_primitive_BCC();
@@ -562,14 +562,14 @@ static void example_spg_get_error_message(void) {
     }
 }
 
-static void show_spg_dataset(double lattice[3][3], const double origin_shift[3],
-                             double position[][3], const int num_atom,
-                             const int types[]) {
+static void show_spg_dataset(double lattice[3][3], double const origin_shift[3],
+                             double position[][3], int const num_atom,
+                             int const types[]) {
     SpglibDataset *dataset;
     char ptsymbol[6];
     int pt_trans_mat[3][3];
 
-    const char *wl = "abcdefghijklmnopqrstuvwxyz";
+    char const *wl = "abcdefghijklmnopqrstuvwxyz";
 
     for (int i = 0; i < num_atom; i++) {
         for (int j = 0; j < 3; j++) {
@@ -616,15 +616,15 @@ static void show_spg_dataset(double lattice[3][3], const double origin_shift[3],
 }
 
 static void show_layer_spg_dataset(double lattice[3][3],
-                                   const double origin_shift[3],
-                                   double position[][3], const int num_atom,
-                                   const int types[], const int aperiodic_axis,
-                                   const double symprec) {
+                                   double const origin_shift[3],
+                                   double position[][3], int const num_atom,
+                                   int const types[], int const aperiodic_axis,
+                                   double const symprec) {
     SpglibDataset *dataset;
     char ptsymbol[6];
     int pt_trans_mat[3][3];
 
-    const char *wl = "abcdefghijklmnopqrstuvwxyz";
+    char const *wl = "abcdefghijklmnopqrstuvwxyz";
 
     for (int i = 0; i < num_atom; i++) {
         for (int j = 0; j < 3; j++) {
@@ -672,10 +672,10 @@ static void show_layer_spg_dataset(double lattice[3][3],
 }
 
 static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
-                                     int types[], const int num_atom,
-                                     const double symprec,
-                                     const int to_primitive,
-                                     const int no_idealize) {
+                                     int types[], int const num_atom,
+                                     double const symprec,
+                                     int const to_primitive,
+                                     int const no_idealize) {
     double lat[3][3], pos[4 * num_atom][3];
     int typ[4 * num_atom];
 
@@ -719,7 +719,7 @@ static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
 }
 
 static void show_cell(double lattice[3][3], double position[][3],
-                      const int types[], const int num_atom) {
+                      int const types[], int const num_atom) {
     printf("Lattice parameter:\n");
     for (int i = 0; i < 3; i++) {
         printf("%f %f %f\n", lattice[0][i], lattice[1][i], lattice[2][i]);

--- a/test/unit/test_delaunay.cpp
+++ b/test/unit/test_delaunay.cpp
@@ -18,8 +18,8 @@ TEST(Delaunay, Delaunay_reduce_layer) {
         {0, 37, 10},
         {0, 11, 3},
     };
-    const int aperiodic_axis = 0;
-    const double symprec = 1e-5;
+    int const aperiodic_axis = 0;
+    double const symprec = 1e-5;
 
     del_layer_delaunay_reduce(min_lattice, lattice, aperiodic_axis, symprec);
 
@@ -44,7 +44,7 @@ TEST(Delaunay, Delaunay_reduce) {
     auto setenv_result = setenv("SPGLIB_NUM_ATTEMPTS", "100", 1);
     ASSERT_EQ(setenv_result, 0);
 
-    const double symprec = 1e-5;
+    double const symprec = 1e-5;
     int succeeded = del_delaunay_reduce(min_lattice, lattice, symprec);
     // Default get_num_attempts() == 1000 --> succeeded == 1.
     // With get_num_attempts() == 100 --> succeeded == 0.

--- a/test/unit/test_niggli.cpp
+++ b/test/unit/test_niggli.cpp
@@ -19,7 +19,7 @@ TEST(Niggli, Niggli_reduce) {
     double inv_lat[3][3], tmat[3][3], metric[3][3];
     int int_tmat[3][3];
 
-    const double symprec = 1e-5;
+    double const symprec = 1e-5;
     mat_copy_matrix_d3(min_lattice, lattice);
 
     auto setenv_result = setenv("SPGLIB_NUM_ATTEMPTS", "100", 1);

--- a/test/unit/test_symmetry.cpp
+++ b/test/unit/test_symmetry.cpp
@@ -13,16 +13,16 @@ TEST(Symmetry, test_get_lattice_symmetry_layer) {
     cell = nullptr;
     symmetry = nullptr;
 
-    const int size = 1;
+    int const size = 1;
     double lattice[3][3] = {
         {1, 0, 0},
         {0, 1, 0},
         {0, 0, 1},
     };
     double positions[1][3] = {{0, 0, 0}};
-    const int types[1] = {0};
-    const double symprec = 1e-5;
-    const double angle_tolerance = -1;
+    int const types[1] = {0};
+    double const symprec = 1e-5;
+    double const angle_tolerance = -1;
 
     cell = cel_alloc_cell(size, NOSPIN);
     EXPECT_EQ(spg_get_error_code(), SPGLIB_SUCCESS);

--- a/test/utils.c
+++ b/test/utils.c
@@ -3,8 +3,8 @@
 
 #include "spglib.h"
 
-void show_symmetry_operations(const int (*rotations)[3][3],
-                              const double (*translations)[3], const int size) {
+void show_symmetry_operations(int const (*rotations)[3][3],
+                              double const (*translations)[3], int const size) {
     int i, j;
     for (i = 0; i < size; i++) {
         printf("--- %d ---\n", i + 1);
@@ -17,14 +17,14 @@ void show_symmetry_operations(const int (*rotations)[3][3],
     }
 }
 
-void show_matrix_3d(const double lattice[3][3]) {
+void show_matrix_3d(double const lattice[3][3]) {
     for (int i = 0; i < 3; i++) {
         printf("%f %f %f\n", lattice[0][i], lattice[1][i], lattice[2][i]);
     }
 }
 
-void show_cell(const double lattice[3][3], const double positions[][3],
-               const int types[], const int num_atoms) {
+void show_cell(double const lattice[3][3], double const positions[][3],
+               int const types[], int const num_atoms) {
     printf("Lattice parameter:\n");
     show_matrix_3d(lattice);
     printf("Atomic positions:\n");
@@ -34,7 +34,7 @@ void show_cell(const double lattice[3][3], const double positions[][3],
     }
 }
 
-void show_spacegroup_type(const SpglibSpacegroupType spgtype) {
+void show_spacegroup_type(SpglibSpacegroupType const spgtype) {
     printf("Number:            %d\n", spgtype.number);
     printf("International:     %s\n", spgtype.international_short);
     printf("International:     %s\n", spgtype.international_full);
@@ -47,10 +47,10 @@ void show_spacegroup_type(const SpglibSpacegroupType spgtype) {
     printf("Arithmetic cc sym. %s\n", spgtype.arithmetic_crystal_class_symbol);
 }
 
-void show_magnetic_symmetry_operations(const int (*rotations)[3][3],
-                                       const double (*translations)[3],
-                                       const int *time_reversals,
-                                       const int size) {
+void show_magnetic_symmetry_operations(int const (*rotations)[3][3],
+                                       double const (*translations)[3],
+                                       int const *time_reversals,
+                                       int const size) {
     int i, j;
     for (i = 0; i < size; i++) {
         printf("--- %d ---\n", i + 1);
@@ -64,7 +64,7 @@ void show_magnetic_symmetry_operations(const int (*rotations)[3][3],
     }
 }
 
-void show_magnetic_spacegroup_type(const SpglibMagneticSpacegroupType msgtype) {
+void show_magnetic_spacegroup_type(SpglibMagneticSpacegroupType const msgtype) {
     printf("UNI Number:    %d\n", msgtype.uni_number);
     printf("Litvin Number: %d\n", msgtype.litvin_number);
     printf("BNS Number:    %s\n", msgtype.bns_number);
@@ -73,7 +73,7 @@ void show_magnetic_spacegroup_type(const SpglibMagneticSpacegroupType msgtype) {
     printf("Type:          %d\n", msgtype.type);
 }
 
-void show_spg_magnetic_dataset(const SpglibMagneticDataset *dataset) {
+void show_spg_magnetic_dataset(SpglibMagneticDataset const *dataset) {
     int i, p, s;
     printf("UNI number: %d\n", dataset->uni_number);
     printf("Type: %d\n", dataset->msg_type);
@@ -135,9 +135,9 @@ void show_spg_magnetic_dataset(const SpglibMagneticDataset *dataset) {
 }
 
 int sub_spg_standardize_cell(double lattice[3][3], double position[][3],
-                             int types[], const int num_atom,
-                             const double symprec, const int to_primitive,
-                             const int no_idealize) {
+                             int types[], int const num_atom,
+                             double const symprec, int const to_primitive,
+                             int const no_idealize) {
     int i, num_primitive_atom, retval;
     double lat[3][3];
     double(*pos)[3];
@@ -199,15 +199,15 @@ int sub_spg_standardize_cell(double lattice[3][3], double position[][3],
     return retval;
 }
 
-int show_spg_dataset(double lattice[3][3], const double origin_shift[3],
-                     double position[][3], const int num_atom,
-                     const int types[]) {
+int show_spg_dataset(double lattice[3][3], double const origin_shift[3],
+                     double position[][3], int const num_atom,
+                     int const types[]) {
     SpglibDataset *dataset;
     char ptsymbol[6];
     int pt_trans_mat[3][3];
     int i, j;
     int retval = 0;
-    const char *wl = "abcdefghijklmnopqrstuvwxyz";
+    char const *wl = "abcdefghijklmnopqrstuvwxyz";
 
     for (i = 0; i < num_atom; i++) {
         for (j = 0; j < 3; j++) {
@@ -269,7 +269,7 @@ end:
 
 #ifdef _MSC_VER
 // https://stackoverflow.com/a/23616164
-int setenv(const char *name, const char *value, int overwrite) {
+int setenv(char const *name, char const *value, int overwrite) {
     int errcode = 0;
     if (!overwrite) {
         size_t envsize = 0;

--- a/test/utils.h
+++ b/test/utils.h
@@ -3,29 +3,29 @@
 
 #include "spglib.h"
 
-void show_symmetry_operations(const int (*rotations)[3][3],
-                              const double (*translations)[3], const int size);
-void show_matrix_3d(const double lattice[3][3]);
-void show_cell(const double lattice[3][3], const double positions[][3],
-               const int types[], const int num_atoms);
-void show_spacegroup_type(const SpglibSpacegroupType spgtype);
-void show_magnetic_symmetry_operations(const int (*rotations)[3][3],
-                                       const double (*translations)[3],
-                                       const int *time_reversals,
-                                       const int size);
-void show_magnetic_spacegroup_type(const SpglibMagneticSpacegroupType msgtype);
-void show_spg_magnetic_dataset(const SpglibMagneticDataset *dataset);
+void show_symmetry_operations(int const (*rotations)[3][3],
+                              double const (*translations)[3], int const size);
+void show_matrix_3d(double const lattice[3][3]);
+void show_cell(double const lattice[3][3], double const positions[][3],
+               int const types[], int const num_atoms);
+void show_spacegroup_type(SpglibSpacegroupType const spgtype);
+void show_magnetic_symmetry_operations(int const (*rotations)[3][3],
+                                       double const (*translations)[3],
+                                       int const *time_reversals,
+                                       int const size);
+void show_magnetic_spacegroup_type(SpglibMagneticSpacegroupType const msgtype);
+void show_spg_magnetic_dataset(SpglibMagneticDataset const *dataset);
 int sub_spg_standardize_cell(double lattice[3][3], double position[][3],
-                             int types[], const int num_atom,
-                             const double symprec, const int to_primitive,
-                             const int no_idealize);
-int show_spg_dataset(double lattice[3][3], const double origin_shift[3],
-                     double position[][3], const int num_atom,
-                     const int types[]);
+                             int types[], int const num_atom,
+                             double const symprec, int const to_primitive,
+                             int const no_idealize);
+int show_spg_dataset(double lattice[3][3], double const origin_shift[3],
+                     double position[][3], int const num_atom,
+                     int const types[]);
 
 #ifdef _MSC_VER
 // https://stackoverflow.com/a/23616164
-int setenv(const char *name, const char *value, int overwrite);
+int setenv(char const *name, char const *value, int overwrite);
 #endif
 
 #endif  // __test_utils_H__


### PR DESCRIPTION
There are a few styles that we should change:
- [`west const` -> `east const`](https://hackingcpp.com/cpp/design/east_vs_west_const.html). The latter is always consistent, e.g. take the case of const pointer in the link. `west const`: the thing on the left is always const. `east const` breaks the rule there.
- pre-processor indentation. Especially in #435 it makes things more readable

See the links in the commit message for alternatives.

Probably worth re-visiting some of the styles with this PR.