### PR TITLE
fix: windows export path

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,10 @@ include(GoogleTest)
 
 enable_testing()
 
+if (WIN32 AND CMAKE_VERSION VERSION_LESS 3.27)
+	message(FATAL_ERROR "Cannot reliably test for windows with CMake < 3.27")
+endif ()
+
 # Define the test framework
 add_executable(Spglib_tests)
 set_target_properties(Spglib_tests PROPERTIES
@@ -181,9 +185,13 @@ function(Spglib_add_gtest)
 	list(APPEND test_labels ${ARGS_LABELS})
 	set_tests_properties(${google_tests} PROPERTIES
 			LABELS "${test_labels}"
-			# https://stackoverflow.com/a/77990416
-			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:Spglib_tests>,\;>"
 	)
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+		# https://stackoverflow.com/a/77990416
+		set_property(TEST ${google_tests} APPEND PROPERTY
+				ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:Spglib_tests>,\;>"
+		)
+	endif ()
 endfunction()
 
 function(Spglib_add_test test)

--- a/test/package/FetchContent/CMakeLists.txt
+++ b/test/package/FetchContent/CMakeLists.txt
@@ -32,9 +32,13 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${Spglib_VERSION}\n*$"
-		# https://stackoverflow.com/a/77990416
-		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+	# https://stackoverflow.com/a/77990416
+	set_property(TEST smoke_test_c APPEND PROPERTY
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
+	)
+endif ()
 
 if (SPGLIB_WITH_Fortran)
 	enable_language(Fortran)
@@ -46,7 +50,11 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${Spglib_VERSION}[ \n]*Spglib_Fortran version: ${Spglib_VERSION}[ \n]*$"
-			# https://stackoverflow.com/a/77990416
-			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+		# https://stackoverflow.com/a/77990416
+		set_property(TEST smoke_test_Fortran APPEND PROPERTY
+				ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
+		)
+	endif ()
 endif ()

--- a/test/package/find_package/CMakeLists.txt
+++ b/test/package/find_package/CMakeLists.txt
@@ -20,9 +20,13 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${Spglib_VERSION}\n*$"
-		# https://stackoverflow.com/a/77990416
-		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+	# https://stackoverflow.com/a/77990416
+	set_property(TEST smoke_test_c APPEND PROPERTY
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
+	)
+endif ()
 
 if (SPGLIB_WITH_Fortran)
 	add_executable(main_Fortran src/main.F90)
@@ -33,7 +37,11 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${Spglib_VERSION}[ \n]*Spglib_Fortran version: ${Spglib_VERSION}[ \n]*$"
-			# https://stackoverflow.com/a/77990416
-			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+		# https://stackoverflow.com/a/77990416
+		set_property(TEST smoke_test_Fortran APPEND PROPERTY
+				ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
+		)
+	endif ()
 endif ()

--- a/test/package/pkg-config/CMakeLists.txt
+++ b/test/package/pkg-config/CMakeLists.txt
@@ -15,9 +15,13 @@ add_test(NAME smoke_test_c
 )
 set_tests_properties(smoke_test_c PROPERTIES
 		PASS_REGULAR_EXPRESSION "^Spglib version: ${spglib_VERSION}\n*$"
-		# https://stackoverflow.com/a/77990416
-		ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
 )
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+	# https://stackoverflow.com/a/77990416
+	set_property(TEST smoke_test_c APPEND PROPERTY
+			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_c>,\;>"
+	)
+endif ()
 
 if (SPGLIB_WITH_Fortran)
 	enable_language(Fortran)
@@ -30,7 +34,11 @@ if (SPGLIB_WITH_Fortran)
 	set_tests_properties(smoke_test_Fortran PROPERTIES
 			PASS_REGULAR_EXPRESSION
 			"^[ \n]*Spglib version: ${spglib_VERSION}[ \n]*Spglib_Fortran version: ${spglib_fortran_VERSION}[ \n]*$"
-			# https://stackoverflow.com/a/77990416
-			ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
 	)
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+		# https://stackoverflow.com/a/77990416
+		set_property(TEST smoke_test_Fortran APPEND PROPERTY
+				ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:main_Fortran>,\;>"
+		)
+	endif ()
 endif ()


### PR DESCRIPTION
The generator expression used was only for 3.27.
Reproduced the error in: https://github.com/spglib/spglib/actions/runs/8045683520
Confirming the fix in: https://github.com/spglib/spglib/actions/runs/8045769170

Hot-fix: #437 
Closes #444