### PR TITLE
fix: Debug and warning messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,11 +57,14 @@ option(SPGLIB_WITH_TESTS "Spglib: Build unit tests" ${PROJECT_IS_TOP_LEVEL})
 option(SPGLIB_SHARED_LIBS "Spglib: Build as a shared library" ${PROJECT_IS_TOP_LEVEL})
 option(SPGLIB_INSTALL "Spglib: Install project" ${PROJECT_IS_TOP_LEVEL})
 option(SPGLIB_WARNINGS "Spglib: Enable warning messages" ON)
-mark_as_advanced(SPGLIB_WITH_WARNINGS)
+option(SPGLIB_INFO "Spglib: Enable info messages" ON)
 option(SPGLIB_DEBUG "Spglib: Build in debug mode" ${_Spglib_default_debug})
-mark_as_advanced(SPGLIB_DEBUG)
 option(SPGLIB_COMPILATION_WARNING "Spglib: Enable compilation warnings" OFF)
-mark_as_advanced(SPGLIB_COMPILATION_WARNING)
+mark_as_advanced(
+        SPGLIB_DEBUG
+        SPGLIB_WARNINGS
+        SPGLIB_COMPILATION_WARNING
+)
 
 #[=============================================================================[
 #                            Project configuration                            #

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,11 @@ GitHub release pages and in the git history.
   (Note: previously the project was not tested for the minimum CMake version)
 - Migrated the example and package test to the ctest test-suite
 - Properly mark all deprecated functions where possible
+- Fix excessive debug/warning message prints
+- Debug and warning messages are controlled by:
+  - Environment variable `SPGLIB_DEBUG`: Define any value to enable printing of debug messages
+  - Environment variable `SPGLIB_WARNING`: Set to `OFF` to disable warning printing
+  - CMake option `SPGLIB_DEBUG`, `SPGLIB_WARNINGS`: Disable the compilation of these messages all-together
 
 ### C Interface
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ endif ()
 target_sources(Spglib_symspg PRIVATE
         arithmetic.c
         cell.c
+        debug.c
         delaunay.c
         determination.c
         hall_symbol.c
@@ -41,11 +42,6 @@ target_sources(Spglib_symspg PRIVATE
         spin.c
         symmetry.c
 )
-if (SPGLIB_DEBUG)
-    target_sources(Spglib_symspg PRIVATE
-            debug.c
-    )
-endif ()
 target_include_directories(Spglib_symspg PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,9 @@ endif ()
 if (SPGLIB_WARNINGS)
     target_compile_definitions(Spglib_symspg PRIVATE SPGWARNING)
 endif ()
+if (SPGLIB_INFO)
+    target_compile_definitions(Spglib_symspg PRIVATE SPGINFO)
+endif ()
 
 # Avoid One Definition Rule problems. Please fix these
 if (CMAKE_UNITY_BUILD)

--- a/src/cell.c
+++ b/src/cell.c
@@ -364,15 +364,13 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
     if (abs(mat_get_determinant_i3(tmp_mat_int)) != ratio) {
         warning_print(
             "spglib: Determinant of change of basis matrix "
-            "has to be same as volume ratio (line %d, %s).\n",
-            __LINE__, __FILE__);
+            "has to be same as volume ratio.\n");
         goto err;
     }
 
     /* Check if cell->size is dividable by ratio */
     if ((cell->size / ratio) * ratio != cell->size) {
         warning_print("spglib: atom number ratio is inconsistent.\n");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
         goto err;
     }
 
@@ -384,7 +382,6 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
     if ((position = translate_atoms_in_trimmed_lattice(cell, tmp_mat_int)) ==
         NULL) {
         warning_print("spglib: translate_atoms_in_trimmed_lattice failed.\n");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
         cel_free_cell(trimmed_cell);
         trimmed_cell = NULL;
         goto err;
@@ -397,7 +394,6 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
     if ((overlap_table = get_overlap_table(position, cell->size, cell->types,
                                            trimmed_cell, symprec)) == NULL) {
         warning_print("spglib: get_overlap_table failed.\n");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
         mat_free_VecDBL(position);
         position = NULL;
         cel_free_cell(trimmed_cell);
@@ -606,17 +602,14 @@ static int *get_overlap_table(VecDBL const *position, int const cell_size,
 
             if (num_overlap < ratio) {
                 trim_tolerance *= INCREASE_RATE;
-                warning_print("spglib: Increase tolerance to %f ",
-                              trim_tolerance);
-                warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+                debug_print("spglib: Increase tolerance to %f\n",
+                            trim_tolerance);
                 goto cont;
             }
             if (num_overlap > ratio) {
                 trim_tolerance *= REDUCE_RATE;
-                warning_print("spglib: Reduce tolerance to %f ",
-                              trim_tolerance);
-                warning_print("(%d) ", attempt);
-                warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+                debug_print("spglib: Reduce tolerance to %f (%d)\n",
+                            trim_tolerance, attempt);
                 goto cont;
             }
         }
@@ -626,8 +619,7 @@ static int *get_overlap_table(VecDBL const *position, int const cell_size,
     cont:;
     }
 
-    warning_print("spglib: Could not trim cell well ");
-    warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+    warning_print("spglib: Could not trim cell well\n");
     free(overlap_table);
     overlap_table = NULL;
 

--- a/src/cell.c
+++ b/src/cell.c
@@ -110,7 +110,7 @@ Cell *cel_alloc_cell(int const size, SiteTensorType const tensor_rank) {
     return cell;
 
 fail:
-    warning_print("spglib: Memory could not be allocated.");
+    warning_memory("cell");
     cel_free_cell(cell);
     cell = NULL;
     return NULL;

--- a/src/cell.c
+++ b/src/cell.c
@@ -362,7 +362,7 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
     mat_multiply_matrix_d3(tmp_mat, tmp_mat, cell->lattice);
     mat_cast_matrix_3d_to_3i(tmp_mat_int, tmp_mat);
     if (abs(mat_get_determinant_i3(tmp_mat_int)) != ratio) {
-        warning_print(
+        info_print(
             "spglib: Determinant of change of basis matrix "
             "has to be same as volume ratio.\n");
         goto err;
@@ -370,7 +370,7 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
 
     /* Check if cell->size is dividable by ratio */
     if ((cell->size / ratio) * ratio != cell->size) {
-        warning_print("spglib: atom number ratio is inconsistent.\n");
+        info_print("spglib: atom number ratio is inconsistent.\n");
         goto err;
     }
 
@@ -381,7 +381,7 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
 
     if ((position = translate_atoms_in_trimmed_lattice(cell, tmp_mat_int)) ==
         NULL) {
-        warning_print("spglib: translate_atoms_in_trimmed_lattice failed.\n");
+        info_print("spglib: translate_atoms_in_trimmed_lattice failed.\n");
         cel_free_cell(trimmed_cell);
         trimmed_cell = NULL;
         goto err;
@@ -393,7 +393,7 @@ static Cell *trim_cell(int *mapping_table, double const trimmed_lattice[3][3],
 
     if ((overlap_table = get_overlap_table(position, cell->size, cell->types,
                                            trimmed_cell, symprec)) == NULL) {
-        warning_print("spglib: get_overlap_table failed.\n");
+        info_print("spglib: get_overlap_table failed.\n");
         mat_free_VecDBL(position);
         position = NULL;
         cel_free_cell(trimmed_cell);
@@ -619,7 +619,7 @@ static int *get_overlap_table(VecDBL const *position, int const cell_size,
     cont:;
     }
 
-    warning_print("spglib: Could not trim cell well\n");
+    info_print("spglib: Could not trim cell well\n");
     free(overlap_table);
     overlap_table = NULL;
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -125,3 +125,7 @@ void warning_print(char const* format, ...) {
 #else
 void warning_print(char const* format, ...) {}
 #endif
+
+void warning_memory(char const* what) {
+    warning_print("Spglib: Memory could not be allocated: %s\n", what);
+}

--- a/src/debug.c
+++ b/src/debug.c
@@ -33,40 +33,68 @@
 /* POSSIBILITY OF SUCH DAMAGE. */
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "debug.h"
 
+bool debug_enabled() {
+    char const* debug_env = getenv("SPGLIB_DEBUG");
+    // If SPGLIB_DEBUG is not defined, do not output any debug info
+    if (debug_env == NULL) return false;
+    // Here we are not checking if SPGLIB_DEBUG is true/1/etc. we only check if
+    // it is defined, including SPGLIB_DEBUG=""
+    return true;
+}
+bool warning_enabled() {
+    char const* warning_env = getenv("SPGLIB_WARNING");
+    // If SPGLIB_WARNING is not defined assume warning is on
+    if (warning_env == NULL) return true;
+    // Check if SPGLIB_WARNING is disabled. Not performing case-insensitive
+    // checks.
+    if (strcmp(warning_env, "OFF") == 0) return false;
+    // Otherwise assume it's an ill-defined value and ignore it
+    return true;
+}
+
 #ifdef SPGDEBUG
 void debug_print_matrix_d3(double const a[3][3]) {
+    if (!debug_enabled()) return;
     for (int i = 0; i < 3; i++) {
         printf("%f %f %f\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_matrix_i3(int const a[3][3]) {
+    if (!debug_enabled()) return;
     for (int i = 0; i < 3; i++) {
         printf("%d %d %d\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_vectors_d3(double const a[][3], int size) {
+    if (!debug_enabled()) return;
     for (int i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_vector_d3(double const a[3]) {
+    if (!debug_enabled()) return;
     printf("%f %f %f\n", a[0], a[1], a[2]);
 }
 
 void debug_print_vectors_with_label(double const a[][3], int const b[],
                                     int size) {
+    if (!debug_enabled()) return;
     for (int i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);
     }
 }
 void debug_print(char const* format, ...) {
+    if (!debug_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
     vprintf(format, argptr);
@@ -88,6 +116,7 @@ void debug_print(char const* format, ...) {}
 
 #ifdef SPGWARNING
 void warning_print(char const* format, ...) {
+    if (!warning_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
     vprintf(format, argptr);

--- a/src/debug.c
+++ b/src/debug.c
@@ -58,6 +58,14 @@ bool warning_enabled() {
     // Otherwise assume it's an ill-defined value and ignore it
     return true;
 }
+bool info_enabled() {
+    char const* info_env = getenv("SPGLIB_INFO");
+    // If SPGLIB_INFO is not defined, do not output any info messages
+    if (info_env == NULL) return false;
+    // Here we are not checking if SPGLIB_INFO is true/1/etc. we only check if
+    // it is defined, including SPGLIB_INFO=""
+    return true;
+}
 
 #ifdef SPGDEBUG
 void debug_print_matrix_d3(double const a[3][3]) {
@@ -124,6 +132,18 @@ void warning_print(char const* format, ...) {
 }
 #else
 void warning_print(char const* format, ...) {}
+#endif
+
+#ifdef SPGINFO
+void info_print(char const* format, ...) {
+    if (!info_enabled()) return;
+    va_list argptr;
+    va_start(argptr, format);
+    vfprintf(stderr, format, argptr);
+    va_end(argptr);
+}
+#else
+void info_print(char const* format, ...) {}
 #endif
 
 void warning_memory(char const* what) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -32,39 +32,67 @@
 /* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE */
 /* POSSIBILITY OF SUCH DAMAGE. */
 
+#include <stdarg.h>
 #include <stdio.h>
 
 #include "debug.h"
 
-void dbg_print_matrix_d3(double const a[3][3]) {
-    int i;
-    for (i = 0; i < 3; i++) {
+#ifdef SPGDEBUG
+void debug_print_matrix_d3(double const a[3][3]) {
+    for (int i = 0; i < 3; i++) {
         printf("%f %f %f\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_matrix_i3(int const a[3][3]) {
-    int i;
-    for (i = 0; i < 3; i++) {
+void debug_print_matrix_i3(int const a[3][3]) {
+    for (int i = 0; i < 3; i++) {
         printf("%d %d %d\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vectors_d3(double const a[][3], int size) {
-    int i;
-    for (i = 0; i < size; i++) {
+void debug_print_vectors_d3(double const a[][3], int size) {
+    for (int i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
     }
 }
 
-void dbg_print_vector_d3(double const a[3]) {
+void debug_print_vector_d3(double const a[3]) {
     printf("%f %f %f\n", a[0], a[1], a[2]);
 }
 
-void dbg_print_vectors_with_label(double const a[][3], int const b[],
-                                  int size) {
-    int i;
-    for (i = 0; i < size; i++) {
+void debug_print_vectors_with_label(double const a[][3], int const b[],
+                                    int size) {
+    for (int i = 0; i < size; i++) {
         printf("%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);
     }
 }
+void debug_print(char const* format, ...) {
+    va_list argptr;
+    va_start(argptr, format);
+    vprintf(format, argptr);
+    va_end(argptr);
+}
+#else
+void debug_print_matrix_d3(double const a[3][3]) {}
+
+void debug_print_matrix_i3(int const a[3][3]) {}
+
+void debug_print_vectors_d3(double const a[][3], int size) {}
+
+void debug_print_vector_d3(double const a[3]) {}
+
+void debug_print_vectors_with_label(double const a[][3], int const b[],
+                                    int size) {}
+void debug_print(char const* format, ...) {}
+#endif
+
+#ifdef SPGWARNING
+void warning_print(char const* format, ...) {
+    va_list argptr;
+    va_start(argptr, format);
+    vprintf(format, argptr);
+    va_end(argptr);
+}
+#else
+void warning_print(char const* format, ...) {}
+#endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -63,41 +63,41 @@ bool warning_enabled() {
 void debug_print_matrix_d3(double const a[3][3]) {
     if (!debug_enabled()) return;
     for (int i = 0; i < 3; i++) {
-        printf("%f %f %f\n", a[i][0], a[i][1], a[i][2]);
+        fprintf(stdout, "%f %f %f\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_matrix_i3(int const a[3][3]) {
     if (!debug_enabled()) return;
     for (int i = 0; i < 3; i++) {
-        printf("%d %d %d\n", a[i][0], a[i][1], a[i][2]);
+        fprintf(stdout, "%d %d %d\n", a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_vectors_d3(double const a[][3], int size) {
     if (!debug_enabled()) return;
     for (int i = 0; i < size; i++) {
-        printf("%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
+        fprintf(stdout, "%d: %f %f %f\n", i + 1, a[i][0], a[i][1], a[i][2]);
     }
 }
 
 void debug_print_vector_d3(double const a[3]) {
     if (!debug_enabled()) return;
-    printf("%f %f %f\n", a[0], a[1], a[2]);
+    fprintf(stdout, "%f %f %f\n", a[0], a[1], a[2]);
 }
 
 void debug_print_vectors_with_label(double const a[][3], int const b[],
                                     int size) {
     if (!debug_enabled()) return;
     for (int i = 0; i < size; i++) {
-        printf("%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);
+        fprintf(stdout, "%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);
     }
 }
 void debug_print(char const* format, ...) {
     if (!debug_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
-    vprintf(format, argptr);
+    vfprintf(stdout, format, argptr);
     va_end(argptr);
 }
 #else
@@ -119,7 +119,7 @@ void warning_print(char const* format, ...) {
     if (!warning_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
-    vprintf(format, argptr);
+    vfprintf(stderr, format, argptr);
     va_end(argptr);
 }
 #else

--- a/src/debug.h
+++ b/src/debug.h
@@ -37,6 +37,7 @@
 // Main print interface
 extern inline void warning_print(char const* format, ...);
 extern inline void debug_print(char const* format, ...);
+extern inline void info_print(char const* format, ...);
 extern inline void debug_print_matrix_d3(double const a[3][3]);
 extern inline void debug_print_matrix_i3(int const a[3][3]);
 extern inline void debug_print_vector_d3(double const a[3]);

--- a/src/debug.h
+++ b/src/debug.h
@@ -34,36 +34,11 @@
 
 #pragma once
 
-#include <stdio.h>
-
-// Macros to either print or do nothing if in debug mode or not
-#ifdef SPGDEBUG
-    #define debug_print(...) printf(__VA_ARGS__)
-    #define debug_print_matrix_d3(a) dbg_print_matrix_d3(a)
-    #define debug_print_matrix_i3(a) dbg_print_matrix_i3(a)
-    #define debug_print_vector_d3(a) dbg_print_vector_d3(a)
-    #define debug_print_vectors_d3(...) dbg_print_vectors_d3(__VA_ARGS__)
-    #define debug_print_vectors_with_label(...) \
-        dbg_print_vectors_with_label(__VA_ARGS__)
-
-// Just to make sure these are never used, these definitions are #ifdef guarded
-void dbg_print_matrix_d3(double const a[3][3]);
-void dbg_print_matrix_i3(int const a[3][3]);
-void dbg_print_vector_d3(double const a[3]);
-void dbg_print_vectors_d3(double const a[][3], int size);
-void dbg_print_vectors_with_label(double const a[][3], int const b[], int size);
-
-#else
-    #define debug_print(...)
-    #define debug_print_matrix_d3(a)
-    #define debug_print_matrix_i3(a)
-    #define debug_print_vector_d3(a)
-    #define debug_print_vectors_d3(...)
-    #define debug_print_vectors_with_label(...)
-#endif
-
-#ifdef SPGWARNING
-    #define warning_print(...) fprintf(stderr, __VA_ARGS__)
-#else
-    #define warning_print(...)
-#endif
+extern inline void warning_print(char const* format, ...);
+extern inline void debug_print(char const* format, ...);
+extern inline void debug_print_matrix_d3(double const a[3][3]);
+extern inline void debug_print_matrix_i3(int const a[3][3]);
+extern inline void debug_print_vector_d3(double const a[3]);
+extern inline void debug_print_vectors_d3(double const a[][3], int size);
+extern inline void debug_print_vectors_with_label(double const a[][3],
+                                                  int const b[], int size);

--- a/src/debug.h
+++ b/src/debug.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+// Main print interface
 extern inline void warning_print(char const* format, ...);
 extern inline void debug_print(char const* format, ...);
 extern inline void debug_print_matrix_d3(double const a[3][3]);
@@ -42,3 +43,6 @@ extern inline void debug_print_vector_d3(double const a[3]);
 extern inline void debug_print_vectors_d3(double const a[][3], int size);
 extern inline void debug_print_vectors_with_label(double const a[][3],
                                                   int const b[], int size);
+
+// Common messages
+extern inline void warning_memory(char const* what);

--- a/src/debug.h
+++ b/src/debug.h
@@ -32,8 +32,7 @@
 /* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE */
 /* POSSIBILITY OF SUCH DAMAGE. */
 
-#ifndef __debug_H__
-#define __debug_H__
+#pragma once
 
 #include <stdio.h>
 
@@ -67,5 +66,4 @@ void dbg_print_vectors_with_label(double const a[][3], int const b[], int size);
     #define warning_print(...) fprintf(stderr, __VA_ARGS__)
 #else
     #define warning_print(...)
-#endif
 #endif

--- a/src/delaunay.c
+++ b/src/delaunay.c
@@ -74,7 +74,7 @@ int get_num_attempts() {
         if (end != num_attempts_str && num_attempts > 0 &&
             num_attempts < INT_MAX)
             return (int)num_attempts;
-        warning_print("Could not parse SPGLIB_NUM_ATTEMPTS=%s\n",
+        warning_print("spglib: Could not parse SPGLIB_NUM_ATTEMPTS=%s\n",
                       num_attempts_str);
     }
     // Otherwise return default number of attempts
@@ -147,8 +147,7 @@ static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
 
     volume = mat_get_determinant_d3(red_lattice);
     if (mat_Dabs(volume) < symprec) {
-        warning_print("spglib: Minimum lattice has no volume (line %d, %s).\n",
-                      __LINE__, __FILE__);
+        warning_print("spglib: Minimum lattice has no volume.\n");
         goto err;
     }
 
@@ -167,8 +166,7 @@ static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
     if (abs(mat_get_determinant_i3(tmp_mat_int)) != 1) {
         warning_print(
             "spglib: Determinant of Delaunay change of basis matrix "
-            "has to be 1 or -1 (line %d, %s).\n",
-            __LINE__, __FILE__);
+            "has to be 1 or -1.\n");
         goto err;
     }
 
@@ -313,8 +311,8 @@ static int delaunay_reduce_basis(double basis[4][3], int const lattice_rank,
                      * cell, so just a warning. */
                     warning_print(
                         "spglib: Dot product between basis %d, %d larger than "
-                        "0 (line %d, %s).\n",
-                        i + 1, j + 1, __LINE__, __FILE__);
+                        "0.\n",
+                        i + 1, j + 1);
                     debug_print_vectors_d3(basis, 4);
                 }
             }
@@ -431,8 +429,7 @@ int del_layer_delaunay_reduce_2D(double red_lattice[3][3],
 
     volume = mat_get_determinant_d3(red_lattice);
     if (mat_Dabs(volume) < symprec) {
-        warning_print("spglib: Minimum lattice has no volume (line %d, %s).\n",
-                      __LINE__, __FILE__);
+        warning_print("spglib: Minimum lattice has no volume.\n");
         goto err;
     }
 
@@ -476,8 +473,8 @@ static int delaunay_reduce_basis_2D(double basis[3][3], int const lattice_rank,
                 } else {
                     warning_print(
                         "spglib: Dot product between basis %d, %d larger than "
-                        "0 (line %d, %s).\n",
-                        i + 1, j + 1, __LINE__, __FILE__);
+                        "0.\n",
+                        i + 1, j + 1);
                     debug_print_vectors_d3(basis, 3);
                 }
             }

--- a/src/delaunay.c
+++ b/src/delaunay.c
@@ -147,7 +147,7 @@ static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
 
     volume = mat_get_determinant_d3(red_lattice);
     if (mat_Dabs(volume) < symprec) {
-        warning_print("spglib: Minimum lattice has no volume.\n");
+        info_print("spglib: Minimum lattice has no volume.\n");
         goto err;
     }
 
@@ -164,7 +164,7 @@ static int delaunay_reduce(double red_lattice[3][3], double const lattice[3][3],
     mat_multiply_matrix_d3(tmp_mat, tmp_mat, orig_lattice);
     mat_cast_matrix_3d_to_3i(tmp_mat_int, tmp_mat);
     if (abs(mat_get_determinant_i3(tmp_mat_int)) != 1) {
-        warning_print(
+        info_print(
             "spglib: Determinant of Delaunay change of basis matrix "
             "has to be 1 or -1.\n");
         goto err;
@@ -309,7 +309,7 @@ static int delaunay_reduce_basis(double basis[4][3], int const lattice_rank,
                      * affect the final results */
                     /* except the primitive cell is not a standard Delaunay
                      * cell, so just a warning. */
-                    warning_print(
+                    info_print(
                         "spglib: Dot product between basis %d, %d larger than "
                         "0.\n",
                         i + 1, j + 1);
@@ -429,7 +429,7 @@ int del_layer_delaunay_reduce_2D(double red_lattice[3][3],
 
     volume = mat_get_determinant_d3(red_lattice);
     if (mat_Dabs(volume) < symprec) {
-        warning_print("spglib: Minimum lattice has no volume.\n");
+        info_print("spglib: Minimum lattice has no volume.\n");
         goto err;
     }
 
@@ -471,7 +471,7 @@ static int delaunay_reduce_basis_2D(double basis[3][3], int const lattice_rank,
                     }
                     return 0;
                 } else {
-                    warning_print(
+                    info_print(
                         "spglib: Dot product between basis %d, %d larger than "
                         "0.\n",
                         i + 1, j + 1);

--- a/src/determination.c
+++ b/src/determination.c
@@ -135,7 +135,6 @@ static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
     for (attempt = 0; attempt < NUM_ATTEMPT; attempt++) {
         if ((container->primitive =
                  prm_get_primitive(cell, tolerance, angle_tolerance)) != NULL) {
-            debug_print("[line %d, %s]\n", __LINE__, __FILE__);
             debug_print("primitive lattice\n");
             debug_print_matrix_d3(container->primitive->cell->lattice);
 
@@ -150,7 +149,7 @@ static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
             container->primitive = NULL;
         }
 
-        debug_print("spglib: Attempt %d tolerance = %f failed.", attempt,
+        debug_print("spglib: Attempt %d tolerance = %f failed.\n", attempt,
                     tolerance);
 
         tolerance *= REDUCE_RATE;

--- a/src/determination.c
+++ b/src/determination.c
@@ -77,7 +77,7 @@ DataContainer *det_determine_all(Cell const *cell, int const hall_number,
                          container->primitive->tolerance)) != NULL) {
                 goto found;
             }
-            warning_print(
+            debug_print(
                 "spglib: ref_get_exact_structure_and_symmetry failed.\n");
             det_free_container(container);
             container = NULL;

--- a/src/determination.c
+++ b/src/determination.c
@@ -122,7 +122,7 @@ static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
     container = NULL;
 
     if ((container = (DataContainer *)malloc(sizeof(DataContainer))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("container");
         return NULL;
     }
 

--- a/src/determination.c
+++ b/src/determination.c
@@ -78,8 +78,7 @@ DataContainer *det_determine_all(Cell const *cell, int const hall_number,
                 goto found;
             }
             warning_print(
-                "spglib: ref_get_exact_structure_and_symmetry failed.");
-            warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+                "spglib: ref_get_exact_structure_and_symmetry failed.\n");
             det_free_container(container);
             container = NULL;
         }
@@ -151,9 +150,8 @@ static DataContainer *get_spacegroup_and_primitive(Cell const *cell,
             container->primitive = NULL;
         }
 
-        warning_print("spglib: Attempt %d tolerance = %f failed.", attempt,
-                      tolerance);
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        debug_print("spglib: Attempt %d tolerance = %f failed.", attempt,
+                    tolerance);
 
         tolerance *= REDUCE_RATE;
         if (angle_tolerance > 0) {

--- a/src/hall_symbol.c
+++ b/src/hall_symbol.c
@@ -9022,7 +9022,6 @@ static int is_hall_symbol(double shift[3], int const hall_number,
     int rot[3][3][3];
     double trans[3][3];
 
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("primitive lattice\n");
     debug_print_matrix_d3(primitive_lattice);
 
@@ -9051,7 +9050,6 @@ not_found:
     return 0;
 
 found:
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("origin shift\n");
     debug_print_vector_d3(shift);
 

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -35,18 +35,11 @@
 #include "kpoint.h"
 
 #include <stddef.h>
-#include <stdio.h>
 #include <stdlib.h>
 
+#include "debug.h"
 #include "kgrid.h"
 #include "mathfunc.h"
-
-#ifdef KPTWARNING
-    #include <stdio.h>
-    #define warning_print(...) fprintf(stderr, __VA_ARGS__)
-#else
-    #define warning_print(...)
-#endif
 
 #define KPT_NUM_BZ_SEARCH_SPACE 125
 

--- a/src/kpoint.c
+++ b/src/kpoint.c
@@ -121,7 +121,7 @@ int kpt_get_irreducible_reciprocal_mesh(int grid_address[][3],
 
     if ((dense_ir_mapping_table = (size_t *)malloc(
              sizeof(size_t) * mesh[0] * mesh[1] * mesh[2])) == NULL) {
-        warning_print("spglib: Memory of unique_rot could not be allocated.");
+        warning_memory("dense_ir_mapping_table");
         return 0;
     }
 
@@ -161,7 +161,7 @@ int kpt_get_stabilized_reciprocal_mesh(
 
     if ((dense_ir_mapping_table = (size_t *)malloc(
              sizeof(size_t) * mesh[0] * mesh[1] * mesh[2])) == NULL) {
-        warning_print("spglib: Memory of unique_rot could not be allocated.");
+        warning_memory("dense_ir_mapping_table");
         return 0;
     }
 
@@ -256,7 +256,7 @@ int kpt_relocate_BZ_grid_address(int bz_grid_address[][3], int bz_map[],
 
     if ((dense_bz_map = (size_t *)malloc(sizeof(size_t) * num_bz_map)) ==
         NULL) {
-        warning_print("spglib: Memory of unique_rot could not be allocated.");
+        warning_memory("dense_bz_map");
         return 0;
     }
 
@@ -322,7 +322,7 @@ static MatINT *get_point_group_reciprocal(MatINT const *rotations,
 
     if ((unique_rot = (int *)malloc(sizeof(int) * rot_reciprocal->size)) ==
         NULL) {
-        warning_print("spglib: Memory of unique_rot could not be allocated.");
+        warning_memory("unique_rot");
         mat_free_MatINT(rot_reciprocal);
         rot_reciprocal = NULL;
         return NULL;
@@ -386,7 +386,7 @@ static MatINT *get_point_group_reciprocal_with_q(MatINT const *rot_reciprocal,
     num_rot = 0;
 
     if ((ir_rot = (int *)malloc(sizeof(int) * rot_reciprocal->size)) == NULL) {
-        warning_print("spglib: Memory of ir_rot could not be allocated.");
+        warning_memory("ir_rot");
         return NULL;
     }
 

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -146,7 +146,7 @@ MagneticDataset *msg_identify_magnetic_space_group_type(
                      tmat_cor, shift_cor, changed_symmetry)) == NULL)
                 goto err;
 
-            debug_print("\e[33mCorrection\e[0m\n");
+            debug_print("\x1B[33mCorrection\x1B[0m\n");
             debug_print_matrix_d3(tmat_cor);
             debug_print_vector_d3(shift_cor);
             for (j = 0; j < symmetry_cor->size; j++) {

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -169,7 +169,7 @@ MagneticDataset *msg_identify_magnetic_space_group_type(
         if (same) break;
     }
     if (uni_number > uni_number_range[1]) {
-        warning_print("Failed to match with UNI number!\n");
+        warning_print("spglib: Failed to match with UNI number!\n");
         for (int i = 0; i < magnetic_symmetry->size; i++) {
             debug_print("--- %d ---\n", i + 1);
             debug_print_matrix_i3(magnetic_symmetry->rot[i]);
@@ -182,7 +182,7 @@ MagneticDataset *msg_identify_magnetic_space_group_type(
 
     msgtype = msgdb_get_magnetic_spacegroup_type(uni_number);
     if (msgtype.type != type) {
-        warning_print("Inconsistent MSG type:\n");
+        warning_print("spglib: Inconsistent MSG type:\n");
         warning_print("  From FSG and XSG: %d\n", type);
         warning_print("  From DB matching: %d\n", msgtype.type);
         goto err;

--- a/src/mathfunc.c
+++ b/src/mathfunc.c
@@ -266,7 +266,7 @@ int mat_inverse_matrix_d3(double m[3][3], double const a[3][3],
     double c[3][3];
     det = mat_get_determinant_d3(a);
     if (mat_Dabs(det) < precision) {
-        warning_print("spglib: No inverse matrix (det=%f)\n", det);
+        debug_print("spglib: No inverse matrix (det=%f)\n", det);
         return 0;
     }
 
@@ -288,7 +288,7 @@ int mat_get_similar_matrix_d3(double m[3][3], double const a[3][3],
                               double const b[3][3], double const precision) {
     double c[3][3];
     if (!mat_inverse_matrix_d3(c, b, precision)) {
-        warning_print("spglib: No similar matrix due to 0 determinant.\n");
+        debug_print("spglib: No similar matrix due to 0 determinant.\n");
         return 0;
     }
     mat_multiply_matrix_d3(m, a, b);

--- a/src/mathfunc.c
+++ b/src/mathfunc.c
@@ -380,7 +380,7 @@ MatINT *mat_alloc_MatINT(int const size) {
     matint = NULL;
 
     if ((matint = (MatINT *)malloc(sizeof(MatINT))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("matint");
         return NULL;
     }
 
@@ -388,8 +388,7 @@ MatINT *mat_alloc_MatINT(int const size) {
     if (size > 0) {
         if ((matint->mat = (int(*)[3][3])malloc(sizeof(int[3][3]) * size)) ==
             NULL) {
-            warning_print("spglib: Memory could not be allocated ");
-            warning_print("(MatINT, line %d, %s).\n", __LINE__, __FILE__);
+            warning_memory("matint->mat");
             free(matint);
             matint = NULL;
             return NULL;
@@ -412,7 +411,7 @@ VecDBL *mat_alloc_VecDBL(int const size) {
     vecdbl = NULL;
 
     if ((vecdbl = (VecDBL *)malloc(sizeof(VecDBL))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("vecdbl");
         return NULL;
     }
 
@@ -420,8 +419,7 @@ VecDBL *mat_alloc_VecDBL(int const size) {
     if (size > 0) {
         if ((vecdbl->vec = (double(*)[3])malloc(sizeof(double[3]) * size)) ==
             NULL) {
-            warning_print("spglib: Memory could not be allocated ");
-            warning_print("(VecDBL, line %d, %s).\n", __LINE__, __FILE__);
+            warning_memory("vecdbl->vec");
             free(vecdbl);
             vecdbl = NULL;
             return NULL;

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -343,7 +343,7 @@ static int step2(NiggliParams *p) {
 static int step2_for_layer(NiggliParams *p) {
     if (p->B > p->C + p->eps || (!(fabs(p->B - p->C) > p->eps) &&
                                  fabs(p->eta) > fabs(p->zeta) + p->eps)) {
-        warning_print(
+        debug_print(
             "niggli: B > C or B = C and |eta| > |zeta|. Please elongate the "
             "aperiodic axis.");
     }

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -77,27 +77,22 @@ static double *multiply_matrices(double const *A, double const *B);
 static int layer_swap_axis(NiggliParams *p, int const aperiodic_axis);
 static int step2_for_layer(NiggliParams *p);
 
-#ifdef SPGDEBUG
-static void debug_show(int const j, NiggliParams const *p) {
-    /* int i; */
-
+static inline void debug_show(int j, NiggliParams const *p) {
     if (j < 0) {
-        printf("Finish: ");
+        debug_print("Finish: ");
     } else {
-        printf("Step %d: ", j);
+        debug_print("Step %d: ", j);
     }
-    printf("%f %f %f %f %f %f\n", p->A, p->B, p->C, p->xi, p->eta, p->zeta);
+    debug_print("%f %f %f %f %f %f\n", p->A, p->B, p->C, p->xi, p->eta,
+                p->zeta);
 
-    /* printf("%d %d %d\n", p->l, p->m, p->n); */
-    /* for (i = 0; i < 3; i++) { */
-    /*   printf("%f %f %f\n", */
-    /*       p->lattice[i * 3], p->lattice[i * 3 + 1], p->lattice[i * 3 + 2]);
-     */
-    /* } */
+    // TODO: Remove or uncomment this debug script
+    // debug_print("%d %d %d\n", p->l, p->m, p->n);
+    // for (int i = 0; i < 3; i++) {
+    //     debug_print("%f %f %f\n", p->lattice[i * 3], p->lattice[i * 3 + 1],
+    //                 p->lattice[i * 3 + 2]);
+    // }
 }
-#else
-    #define debug_show(...)
-#endif
 
 int get_num_attempts() {
     char const *num_attempts_str = getenv("SPGLIB_NUM_ATTEMPTS");

--- a/src/niggli.c
+++ b/src/niggli.c
@@ -104,7 +104,7 @@ int get_num_attempts() {
         if (end != num_attempts_str && num_attempts > 0 &&
             num_attempts < INT_MAX)
             return (int)num_attempts;
-        warning_print("Could not parse SPGLIB_NUM_ATTEMPTS=%s\n",
+        warning_print("spglib: Could not parse SPGLIB_NUM_ATTEMPTS=%s\n",
                       num_attempts_str);
     }
     // Otherwise return default number of attempts

--- a/src/overlap.c
+++ b/src/overlap.c
@@ -399,8 +399,7 @@ static void *perm_argsort_work_malloc(int n) {
 
     if ((work = (ValueWithIndex *)(malloc(sizeof(ValueWithIndex) * n))) ==
         NULL) {
-        warning_print(
-            "spglib: Memory could not be allocated for argsort workspace.");
+        warning_memory("work");
         return NULL;
     }
     return work;
@@ -503,12 +502,12 @@ static OverlapChecker *overlap_checker_alloc(int size) {
     blob_size = offset;
 
     if ((checker = (OverlapChecker *)malloc(sizeof(OverlapChecker))) == NULL) {
-        warning_print("spglib: Memory could not be allocated for checker.");
+        warning_memory("checker");
         return NULL;
     }
 
     if ((checker->blob = malloc(blob_size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated for checker.");
+        warning_memory("checker->blob");
         free(checker);
         checker = NULL;
         return NULL;
@@ -627,7 +626,7 @@ static int check_total_overlap_for_sorted(
     found = NULL;
 
     if ((found = (int *)malloc(num_pos * sizeof(int))) == NULL) {
-        warning_print("spglib: Memory could not be allocated");
+        warning_memory("found");
         return -1;
     }
 
@@ -690,7 +689,7 @@ static int check_layer_total_overlap_for_sorted(
     found = NULL;
 
     if ((found = (int *)malloc(num_pos * sizeof(int))) == NULL) {
-        warning_print("spglib: Memory could not be allocated");
+        warning_memory("found");
         return -1;
     }
 

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -401,8 +401,7 @@ Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
         get_axes(axes, pointgroup.laue, &pointsym, aperiodic_axis);
         set_transformation_matrix(transform_mat, axes);
     } else {
-        warning_print("spglib: No point group was found ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: No point group was found\n");
         pointgroup.number = 0;
     }
 
@@ -537,8 +536,7 @@ static int get_pointgroup_class_table(int table[10],
     return 1;
 
 err:
-    warning_print("spglib: No point group symbol found ");
-    warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+    warning_print("spglib: No point group symbol found\n");
     return 0;
 }
 
@@ -902,8 +900,7 @@ static int laue_one_axis(int axes[3], PointSymmetry const* pointsym,
     }
 
 err: /* axes are not correctly found. */
-    warning_print("spglib: Secondary axis is not found.");
-    warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+    warning_print("spglib: Secondary axis is not found.\n");
     return 0;
 
 end:
@@ -1121,8 +1118,7 @@ static void layer_check_and_sort_axes(int axes[3], int const aperiodic_axis) {
     } else {
         // Warning when rot_axes[axes[i]][aperiodic_axis] == -2, -3, 2, 3
         // I am not sure if this would ever happen.
-        warning_print("spglib: Invalid axes were found ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: Invalid axes were found\n");
         for (i = 0; i < 3; i++) {
             axes[i] = 0;
         }

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -401,7 +401,7 @@ Pointgroup ptg_get_transformation_matrix(int transform_mat[3][3],
         get_axes(axes, pointgroup.laue, &pointsym, aperiodic_axis);
         set_transformation_matrix(transform_mat, axes);
     } else {
-        warning_print("spglib: No point group was found\n");
+        info_print("spglib: No point group was found\n");
         pointgroup.number = 0;
     }
 

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -276,8 +276,7 @@ static Primitive *get_primitive(Cell const *cell, double const symprec,
         pure_trans = NULL;
 
         tolerance *= REDUCE_RATE;
-        warning_print("spglib: Reduce tolerance to %f ", tolerance);
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        debug_print("spglib: Reduce tolerance to %f ", tolerance);
     }
 
     prm_free_primitive(primitive);
@@ -369,8 +368,7 @@ static Cell *get_primitive_cell(int *mapping_table, Cell const *cell,
     return primitive_cell;
 
 not_found:
-    warning_print("spglib: Primitive cell could not be found ");
-    warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+    warning_print("spglib: Primitive cell could not be found\n");
     return NULL;
 }
 
@@ -453,9 +451,9 @@ static int get_primitive_lattice_vectors(double prim_lattice[3][3],
                 goto fail;
             }
 
-            warning_print("spglib: Tolerance is reduced to %f (%d), ",
-                          tolerance, attempt);
-            warning_print("num_pure_trans = %d\n", pure_trans_reduced->size);
+            debug_print("spglib: Tolerance is reduced to %f (%d), ", tolerance,
+                        attempt);
+            debug_print("num_pure_trans = %d\n", pure_trans_reduced->size);
 
             tolerance *= REDUCE_RATE;
         }
@@ -548,8 +546,7 @@ static int find_primitive_lattice_vectors(double prim_lattice[3][3],
     }
 
     /* Not found */
-    warning_print("spglib: Primitive lattice vectors could not be found ");
-    warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+    warning_print("spglib: Primitive lattice vectors could not be found\n");
     return 0;
 
     /* Found */
@@ -566,8 +563,7 @@ ret:
         mat_cast_matrix_3i_to_3d(inv_mat_dbl, inv_mat_int);
         mat_inverse_matrix_d3(relative_lattice, inv_mat_dbl, 0);
     } else {
-        warning_print("spglib: Primitive lattice cleaning is incomplete ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: Primitive lattice cleaning is incomplete\n");
     }
     mat_multiply_matrix_d3(prim_lattice, cell->lattice, relative_lattice);
 

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -368,7 +368,7 @@ static Cell *get_primitive_cell(int *mapping_table, Cell const *cell,
     return primitive_cell;
 
 not_found:
-    warning_print("spglib: Primitive cell could not be found\n");
+    debug_print("spglib: Primitive cell could not be found\n");
     return NULL;
 }
 
@@ -546,7 +546,7 @@ static int find_primitive_lattice_vectors(double prim_lattice[3][3],
     }
 
     /* Not found */
-    warning_print("spglib: Primitive lattice vectors could not be found\n");
+    debug_print("spglib: Primitive lattice vectors could not be found\n");
     return 0;
 
     /* Found */

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -79,7 +79,7 @@ Primitive *prm_alloc_primitive(int const size) {
     primitive = NULL;
 
     if ((primitive = (Primitive *)malloc(sizeof(Primitive))) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("primitive");
         return NULL;
     }
 
@@ -93,8 +93,7 @@ Primitive *prm_alloc_primitive(int const size) {
     if (size > 0) {
         if ((primitive->mapping_table = (int *)malloc(sizeof(int) * size)) ==
             NULL) {
-            warning_print("spglib: Memory could not be allocated ");
-            warning_print("(Primitive, line %d, %s).\n", __LINE__, __FILE__);
+            warning_memory("primitive->mapping_table");
             free(primitive);
             primitive = NULL;
             return NULL;
@@ -163,7 +162,7 @@ int prm_get_primitive_with_pure_trans(Primitive *primitive, Cell const *cell,
     primitive->angle_tolerance = angle_tolerance;
     if ((primitive->orig_lattice =
              (double(*)[3])malloc(sizeof(double[3]) * 3)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("primitive->orig_lattice");
         return 0;
     }
     mat_copy_matrix_d3(primitive->orig_lattice, cell->lattice);

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -167,30 +167,30 @@ ExactStructure *ref_get_exact_structure_and_symmetry(Spacegroup *spacegroup,
     }
 
     if ((wyckoffs = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("wyckoffs");
         goto err;
     }
 
     if ((site_symmetry_symbols =
              (char(*)[7])malloc(sizeof(char[7]) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("site_symmetry_symbols");
         goto err;
     }
 
     if ((equivalent_atoms = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("equivalent_atoms");
         goto err;
     }
 
     if ((crystallographic_orbits = (int *)malloc(sizeof(int) * cell->size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("crystallographic_orbits");
         goto err;
     }
 
     if ((std_mapping_to_primitive =
              (int *)malloc(sizeof(int) * primitive->size * 4)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("std_mapping_to_primitive");
         goto err;
     }
 
@@ -205,7 +205,7 @@ ExactStructure *ref_get_exact_structure_and_symmetry(Spacegroup *spacegroup,
 
     if ((exact_structure = (ExactStructure *)malloc(sizeof(ExactStructure))) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("exact_structure");
         sym_free_symmetry(symmetry);
         symmetry = NULL;
         cel_free_cell(bravais);
@@ -308,13 +308,13 @@ static Cell *get_Wyckoff_positions(
 
     if ((wyckoffs_bravais = (int *)malloc(sizeof(int) * primitive->size * 4)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("wyckoffs_bravais");
         return NULL;
     }
 
     if ((site_symmetry_symbols_bravais = (char(*)[7])malloc(
              sizeof(char[7]) * primitive->size * 4)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("site_symmetry_symbols_bravais");
         free(wyckoffs_bravais);
         wyckoffs_bravais = NULL;
         return NULL;
@@ -322,7 +322,7 @@ static Cell *get_Wyckoff_positions(
 
     if ((equiv_atoms_bravais =
              (int *)malloc(sizeof(int) * primitive->size * 4)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("equiv_atoms_bravais");
         free(wyckoffs_bravais);
         wyckoffs_bravais = NULL;
         free(site_symmetry_symbols_bravais);
@@ -417,13 +417,13 @@ static Cell *get_bravais_exact_positions_and_lattice(
     /* Symmetrize atomic positions of conventional unit cell */
     if ((wyckoffs_prim = (int *)malloc(sizeof(int) * primitive->size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("wyckoffs_prim");
         return NULL;
     }
 
     if ((site_symmetry_symbols_prim =
              (char(*)[7])malloc(sizeof(char[7]) * primitive->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("site_symmetry_symbols_prim");
         free(wyckoffs_prim);
         wyckoffs_prim = NULL;
         return NULL;
@@ -431,7 +431,7 @@ static Cell *get_bravais_exact_positions_and_lattice(
 
     if ((equiv_atoms_prim = (int *)malloc(sizeof(int) * primitive->size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("equiv_atoms_prim");
         free(site_symmetry_symbols_prim);
         site_symmetry_symbols_prim = NULL;
         free(wyckoffs_prim);
@@ -923,7 +923,7 @@ static int set_crystallographic_orbits(int *equiv_atoms_cell,
     equiv_atoms = NULL;
 
     if ((equiv_atoms = (int *)malloc(sizeof(int) * primitive->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("equiv_atoms");
         return 0;
     }
 

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -335,8 +335,7 @@ static Cell *get_Wyckoff_positions(
              equiv_atoms_bravais, std_mapping_to_primitive, spacegroup,
              primitive, symprec)) == NULL) {
         warning_print(
-            "spglib: get_bravais_exact_positions_and_lattice failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+            "spglib: get_bravais_exact_positions_and_lattice failed.\n");
 
         goto ret;
     }
@@ -362,8 +361,7 @@ static Cell *get_Wyckoff_positions(
         cel_free_cell(bravais);
         bravais = NULL;
 
-        warning_print("spglib: set_crystallographic_orbits failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: set_crystallographic_orbits failed.\n");
 
         goto ret;
     }
@@ -478,8 +476,7 @@ static Cell *get_bravais_exact_positions_and_lattice(
              symprec)) == NULL) {
         sym_free_symmetry(conv_sym);
         conv_sym = NULL;
-        warning_print("spglib: ssm_get_exact_positions failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: ssm_get_exact_positions failed.\n");
         goto err;
     }
 
@@ -739,7 +736,8 @@ static void set_monocli(double lattice[3][3], double const metric[3][3],
             lattice[2][0] = a * sin(angle);
             break;
         default:
-            warning_print("spglib: Monoclinic unique axis could not be found.");
+            warning_print(
+                "spglib: Monoclinic unique axis could not be found.\n");
     }
 }
 
@@ -779,7 +777,8 @@ static void set_layer_monocli(double lattice[3][3], double const metric[3][3],
             lattice[2][2] = c;
             break;
         default:
-            warning_print("spglib: Monoclinic unique axis could not be found.");
+            warning_print(
+                "spglib: Monoclinic unique axis could not be found.\n");
     }
 }
 

--- a/src/refinement.c
+++ b/src/refinement.c
@@ -629,7 +629,6 @@ void ref_get_conventional_lattice(double lattice[3][3],
 
     mat_get_metric(metric, spacegroup->bravais_lattice);
 
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("bravais lattice\n");
     debug_print_matrix_d3(spacegroup->bravais_lattice);
     debug_print("%s\n", spacegroup->choice);

--- a/src/site_symmetry.c
+++ b/src/site_symmetry.c
@@ -140,7 +140,7 @@ static VecDBL *get_exact_positions(int *equiv_atoms, Cell const *conv_prim,
     }
 
     if ((indep_atoms = (int *)malloc(sizeof(int) * conv_prim->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("indep_atoms");
         mat_free_VecDBL(positions);
         return NULL;
     }

--- a/src/site_symmetry.c
+++ b/src/site_symmetry.c
@@ -110,9 +110,8 @@ VecDBL *ssm_get_exact_positions(int *wyckoffs, int *equiv_atoms,
                                 num_pure_trans, hall_number, symprec)) {
             break;
         } else {
-            warning_print(
-                "spglib: ssm_get_exact_positions failed (attempt=%d).", i);
-            warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+            debug_print(
+                "spglib: ssm_get_exact_positions failed (attempt=%d).\n", i);
             mat_free_VecDBL(positions);
             positions = NULL;
             tolerance *= INCREASE_RATE;

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -841,7 +841,6 @@ static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
     pointgroup = ptg_get_transformation_matrix(tmat_int, symmetry->rot,
                                                symmetry->size, aperiodic_axis);
 
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("initial transformation matrix\n");
     debug_print_matrix_i3(tmat_int);
 
@@ -883,7 +882,6 @@ static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
     mat_multiply_matrix_id3(tmat, tmat_int, correction_mat);
     mat_multiply_matrix_d3(conv_lattice, primitive->cell->lattice, tmat);
 
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("transformation matrix\n");
     debug_print_matrix_d3(tmat);
 
@@ -900,7 +898,6 @@ static int search_hall_number(double origin_shift[3], double conv_lattice[3][3],
                 origin_shift, conv_lattice, /* <-- modified only matched */
                 primitive->orig_lattice, candidates[i], pointgroup.number,
                 pointgroup.holohedry, centering, conv_symmetry, symprec)) {
-            debug_print("[line %d, %s]\n", __LINE__, __FILE__);
             debug_print("origin shift\n");
             debug_print_vector_d3(origin_shift);
 

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -718,7 +718,7 @@ static Spacegroup *search_spacegroup_with_symmetry(
 
     pointsym = ptg_get_pointsymmetry(symmetry->rot, symmetry->size);
     if (pointsym.size < symmetry->size) {
-        warning_print("spglib: Point symmetry of primitive cell is broken.\n");
+        info_print("spglib: Point symmetry of primitive cell is broken.\n");
         return NULL;
     }
 

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -587,8 +587,7 @@ Cell *spa_transform_to_primitive(int *mapping_table, Cell const *cell,
     mat_multiply_matrix_d3(prim_lat, cell->lattice, tmat);
     if ((primitive = cel_trim_cell(mapping_table, prim_lat, cell, symprec)) ==
         NULL) {
-        warning_print("spglib: cel_trim_cell failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: cel_trim_cell failed.\n");
     }
 
     return primitive;
@@ -719,8 +718,7 @@ static Spacegroup *search_spacegroup_with_symmetry(
 
     pointsym = ptg_get_pointsymmetry(symmetry->rot, symmetry->size);
     if (pointsym.size < symmetry->size) {
-        warning_print("spglib: Point symmetry of primitive cell is broken. ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: Point symmetry of primitive cell is broken.\n");
         return NULL;
     }
 
@@ -795,9 +793,8 @@ static int iterative_search_hall_number(
 
     tolerance = symprec;
     for (attempt = 0; attempt < NUM_ATTEMPT; attempt++) {
-        warning_print("spglib: Attempt %d tolerance = %e failed", attempt,
-                      tolerance);
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        debug_print("spglib: Attempt %d tolerance = %e failed", attempt,
+                    tolerance);
 
         tolerance *= REDUCE_RATE;
         sym_reduced = sym_reduce_operation(primitive->cell, symmetry, tolerance,
@@ -1903,8 +1900,7 @@ static Centering get_base_center(int const tmat[3][3]) {
     }
 
     /* This should not happen. */
-    warning_print("spglib: No centring was found (line %d, %s).\n", __LINE__,
-                  __FILE__);
+    warning_print("spglib: No centring was found.\n");
     return PRIMITIVE;
 
 end:

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -641,7 +641,7 @@ Cell *spa_transform_from_primitive(Cell const *primitive,
 
     if ((mapping_table =
              (int *)malloc(sizeof(int) * primitive->size * multi)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("mapping_table");
         goto ret;
     }
 
@@ -746,7 +746,7 @@ static Spacegroup *get_spacegroup(int const hall_number,
     spacegroup = NULL;
 
     if ((spacegroup = (Spacegroup *)malloc(sizeof(Spacegroup))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("spacegroup");
         return NULL;
     }
 

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -447,7 +447,7 @@ int spgms_get_symmetry_with_collinear_spin(
     int *spin_flips;
 
     if ((spin_flips = (int *)malloc(sizeof(int) * max_size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("spin_flips");
         return 0;
     }
 
@@ -1340,7 +1340,7 @@ static SpglibDataset *init_dataset(void) {
     dataset = NULL;
 
     if ((dataset = (SpglibDataset *)malloc(sizeof(SpglibDataset))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset");
         return NULL;
     }
 
@@ -1384,7 +1384,7 @@ static SpglibMagneticDataset *init_magnetic_dataset(void) {
 
     if ((dataset = (SpglibMagneticDataset *)malloc(
              sizeof(SpglibMagneticDataset))) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset");
         return NULL;
     }
 
@@ -1441,13 +1441,13 @@ static int set_dataset(SpglibDataset *dataset, Cell const *cell,
 
     if ((dataset->rotations = (int(*)[3][3])malloc(
              sizeof(int[3][3]) * dataset->n_operations)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->rotations");
         goto err;
     }
 
     if ((dataset->translations = (double(*)[3])malloc(
              sizeof(double[3]) * dataset->n_operations)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->translations");
         goto err;
     }
 
@@ -1459,25 +1459,25 @@ static int set_dataset(SpglibDataset *dataset, Cell const *cell,
     /* Wyckoff positions */
     if ((dataset->wyckoffs = (int *)malloc(sizeof(int) * dataset->n_atoms)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->wyckoffs");
         goto err;
     }
 
     if ((dataset->site_symmetry_symbols =
              (char(*)[7])malloc(sizeof(char[7]) * dataset->n_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->site_symmetry_symbols");
         goto err;
     }
 
     if ((dataset->equivalent_atoms =
              (int *)malloc(sizeof(int) * dataset->n_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->equivalent_atoms");
         goto err;
     }
 
     if ((dataset->crystallographic_orbits =
              (int *)malloc(sizeof(int) * dataset->n_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->crystallographic_orbits");
         goto err;
     }
 
@@ -1493,7 +1493,7 @@ static int set_dataset(SpglibDataset *dataset, Cell const *cell,
 
     if ((dataset->mapping_to_primitive =
              (int *)malloc(sizeof(int) * dataset->n_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->mapping_to_primitive");
         goto err;
     }
 
@@ -1517,19 +1517,19 @@ static int set_dataset(SpglibDataset *dataset, Cell const *cell,
 
     if ((dataset->std_positions = (double(*)[3])malloc(
              sizeof(double[3]) * dataset->n_std_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->std_positions");
         goto err;
     }
 
     if ((dataset->std_types =
              (int *)malloc(sizeof(int) * dataset->n_std_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->std_types");
         goto err;
     }
 
     if ((dataset->std_mapping_to_primitive =
              (int *)malloc(sizeof(int) * dataset->n_std_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->std_mapping_to_primitive");
         goto err;
     }
 
@@ -1608,17 +1608,17 @@ static int set_magnetic_dataset(SpglibMagneticDataset *dataset,
     dataset->n_operations = magnetic_symmetry->size;
     if ((dataset->rotations = (int(*)[3][3])malloc(
              sizeof(int[3][3]) * dataset->n_operations)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->rotations");
         goto err;
     }
     if ((dataset->translations = (double(*)[3])malloc(
              sizeof(double[3]) * dataset->n_operations)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->translations");
         goto err;
     }
     if ((dataset->time_reversals =
              (int *)malloc(sizeof(int *) * dataset->n_operations)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->time_reversals");
         goto err;
     }
     for (i = 0; i < dataset->n_operations; i++) {
@@ -1632,7 +1632,7 @@ static int set_magnetic_dataset(SpglibMagneticDataset *dataset,
     dataset->n_atoms = num_atoms;
     if ((dataset->equivalent_atoms =
              (int *)malloc(sizeof(int) * dataset->n_atoms)) == NULL) {
-        warning_print("spglib: Memory could not be allocated.");
+        warning_memory("dataset->equivalent_atoms");
         goto err;
     }
     for (i = 0; i < dataset->n_atoms; i++) {
@@ -1886,7 +1886,7 @@ static int standardize_primitive(double lattice[3][3], double position[][3],
     dataset = NULL;
 
     if ((mapping_table = (int *)malloc(sizeof(int) * bravais->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("mapping_table");
         cel_free_cell(bravais);
         bravais = NULL;
         goto err;
@@ -2011,7 +2011,7 @@ static int get_standardized_cell(double lattice[3][3], double position[][3],
     cel_set_cell(cell, lattice, position, types);
 
     if ((mapping_table = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("mapping_table");
         cel_free_cell(cell);
         cell = NULL;
         spg_free_dataset(dataset);

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -1898,11 +1898,10 @@ static int standardize_primitive(double lattice[3][3], double position[][3],
     for (i = 0; i < primitive->size; i++) {
         /* This is an assertion. */
         if (mapping_table[i] != i) {
-            warning_print("spglib: spa_transform_to_primitive failed.");
+            warning_print("spglib: spa_transform_to_primitive failed.\n");
             warning_print(
                 "Unexpected atom index mapping to primitive (%d != %d).\n",
                 mapping_table[i], i);
-            warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
             free(mapping_table);
             mapping_table = NULL;
             cel_free_cell(bravais);
@@ -2022,18 +2021,16 @@ static int get_standardized_cell(double lattice[3][3], double position[][3],
     if ((primitive = spa_transform_to_primitive(mapping_table, cell,
                                                 dataset->transformation_matrix,
                                                 centering, symprec)) == NULL) {
-        warning_print("spglib: spa_transform_to_primitive failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: spa_transform_to_primitive failed.\n");
     }
 
     for (i = 0; i < cell->size; i++) {
         /* This is an assertion. */
         if (mapping_table[i] != dataset->mapping_to_primitive[i]) {
-            warning_print("spglib: spa_transform_to_primitive failed.");
+            warning_print("spglib: spa_transform_to_primitive failed.\n");
             warning_print(
                 "Unexpected atom index mapping to primitive (%d != %d).\n",
                 mapping_table[i], dataset->mapping_to_primitive[i]);
-            warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
             free(mapping_table);
             mapping_table = NULL;
             cel_free_cell(cell);
@@ -2065,8 +2062,7 @@ static int get_standardized_cell(double lattice[3][3], double position[][3],
 
     if ((std_cell = spa_transform_from_primitive(primitive, centering,
                                                  symprec)) == NULL) {
-        warning_print("spglib: spa_transform_from_primitive failed.");
-        warning_print(" (line %d, %s).\n", __LINE__, __FILE__);
+        warning_print("spglib: spa_transform_from_primitive failed.\n");
     }
     cel_free_cell(primitive);
     primitive = NULL;

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -1497,7 +1497,6 @@ static int set_dataset(SpglibDataset *dataset, Cell const *cell,
         goto err;
     }
 
-    debug_print("[line %d, %s]\n", __LINE__, __FILE__);
     debug_print("refined cell after ref_get_Wyckoff_positions\n");
     debug_print_matrix_d3(exstr->bravais->lattice);
     for (i = 0; i < exstr->bravais->size; i++) {

--- a/src/symmetry.c
+++ b/src/symmetry.c
@@ -126,7 +126,7 @@ Symmetry *sym_alloc_symmetry(int const size) {
     }
 
     if ((symmetry = (Symmetry *)malloc(sizeof(Symmetry))) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("symmetry");
         return NULL;
     }
 
@@ -136,16 +136,14 @@ Symmetry *sym_alloc_symmetry(int const size) {
 
     if ((symmetry->rot = (int(*)[3][3])malloc(sizeof(int[3][3]) * size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_memory("symmetry->rot");
         free(symmetry);
         symmetry = NULL;
         return NULL;
     }
     if ((symmetry->trans = (double(*)[3])malloc(sizeof(double[3]) * size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_memory("symmetry->trans");
         free(symmetry->rot);
         symmetry->rot = NULL;
         free(symmetry);
@@ -178,7 +176,7 @@ MagneticSymmetry *sym_alloc_magnetic_symmetry(int const size) {
 
     if ((symmetry = (MagneticSymmetry *)malloc(sizeof(MagneticSymmetry))) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("symmetry");
         return NULL;
     }
 
@@ -189,16 +187,14 @@ MagneticSymmetry *sym_alloc_magnetic_symmetry(int const size) {
 
     if ((symmetry->rot = (int(*)[3][3])malloc(sizeof(int[3][3]) * size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_memory("symmetry->rot");
         free(symmetry);
         symmetry = NULL;
         return NULL;
     }
     if ((symmetry->trans = (double(*)[3])malloc(sizeof(double[3]) * size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_memory("symmetry->trans");
         free(symmetry->rot);
         symmetry->rot = NULL;
         free(symmetry);
@@ -206,8 +202,7 @@ MagneticSymmetry *sym_alloc_magnetic_symmetry(int const size) {
         return NULL;
     }
     if ((symmetry->timerev = (int *)malloc(sizeof(int *) * size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+        warning_memory("symmetry->timerev");
         free(symmetry->rot);
         symmetry->rot = NULL;
         free(symmetry->trans);
@@ -450,7 +445,7 @@ static VecDBL *get_translation(int const rot[3][3], Cell const *cell,
     trans = NULL;
 
     if ((is_found = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("is_found");
         return NULL;
     }
 
@@ -639,7 +634,7 @@ static int get_index_with_least_atoms(Cell const *cell) {
     mapping = NULL;
 
     if ((mapping = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("mapping");
         return -1;
     }
 
@@ -689,7 +684,7 @@ static VecDBL *get_layer_translation(int const rot[3][3], Cell const *cell,
     trans = NULL;
 
     if ((is_found = (int *)malloc(sizeof(int) * cell->size)) == NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("is_found");
         return NULL;
     }
 
@@ -862,7 +857,7 @@ static Symmetry *get_space_group_operations(PointSymmetry const *lattice_sym,
 
     if ((trans = (VecDBL **)malloc(sizeof(VecDBL *) * lattice_sym->size)) ==
         NULL) {
-        warning_print("spglib: Memory could not be allocated ");
+        warning_memory("trans");
         return NULL;
     }
 

--- a/src/symmetry.c
+++ b/src/symmetry.c
@@ -256,16 +256,15 @@ VecDBL *sym_get_pure_translation(Cell const *cell, double const symprec) {
         pure_trans = get_layer_translation(identity, cell, symprec, 1);
     }
     if (pure_trans == NULL) {
-        warning_print("spglib: get_translation failed.\n");
+        debug_print("spglib: get_translation failed.\n");
         return NULL;
     }
 
     multi = pure_trans->size;
     if ((cell->size / multi) * multi == cell->size) {
-        debug_print("  sym_get_pure_translation: pure_trans->size = %d\n",
+        debug_print("spglib: sym_get_pure_translation: pure_trans->size = %d\n",
                     multi);
     } else {
-        ;
         warning_print("spglib: Finding pure translation failed.\n");
         warning_print("        cell->size %d, multi %d\n", cell->size, multi);
     }

--- a/src/symmetry.c
+++ b/src/symmetry.c
@@ -256,8 +256,7 @@ VecDBL *sym_get_pure_translation(Cell const *cell, double const symprec) {
         pure_trans = get_layer_translation(identity, cell, symprec, 1);
     }
     if (pure_trans == NULL) {
-        warning_print("spglib: get_translation failed (line %d, %s).\n",
-                      __LINE__, __FILE__);
+        warning_print("spglib: get_translation failed.\n");
         return NULL;
     }
 
@@ -267,9 +266,7 @@ VecDBL *sym_get_pure_translation(Cell const *cell, double const symprec) {
                     multi);
     } else {
         ;
-        warning_print(
-            "spglib: Finding pure translation failed (line %d, %s).\n",
-            __LINE__, __FILE__);
+        warning_print("spglib: Finding pure translation failed.\n");
         warning_print("        cell->size %d, multi %d\n", cell->size, multi);
     }
 
@@ -998,17 +995,15 @@ static PointSymmetry get_lattice_symmetry(Cell const *cell,
                                            angle_tol)) {
                         if ((aperiodic_axis == -1 && num_sym >= 48) ||
                             (aperiodic_axis != -1 && num_sym >= 24)) {
-                            warning_print(
-                                "spglib: Too many lattice symmetries was "
+                            debug_print(
+                                "spglib: Too many lattice symmetries were "
                                 "found.\n");
                             if (angle_tol > 0) {
                                 angle_tol *= ANGLE_REDUCE_RATE;
-                                warning_print(
-                                    "        Reduce angle tolerance to %f\n",
+                                debug_print(
+                                    "        Reducing angle tolerance to %f\n",
                                     angle_tol);
                             }
-                            warning_print("        (line %d, %s).\n", __LINE__,
-                                          __FILE__);
                             goto next_attempt;
                         }
 
@@ -1118,8 +1113,7 @@ static PointSymmetry transform_pointsymmetry(
             mat_cast_matrix_3d_to_3i(lat_sym_new.rot[size], drot);
             if (abs(mat_get_determinant_i3(lat_sym_new.rot[size])) != 1) {
                 warning_print(
-                    "spglib: A point symmetry operation is not unimodular.");
-                warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+                    "spglib: A point symmetry operation is not unimodular.\n");
                 goto err;
             }
             size++;
@@ -1128,8 +1122,7 @@ static PointSymmetry transform_pointsymmetry(
 
     if (!(lat_sym_orig->size == size)) {
         warning_print(
-            "spglib: Some of point symmetry operations were dropped.");
-        warning_print("(line %d, %s).\n", __LINE__, __FILE__);
+            "spglib: Some of point symmetry operations were dropped.\n");
     }
 
     lat_sym_new.size = size;


### PR DESCRIPTION
- [x] Refactor message implementation. Avoid macros whenever possible
- [x] Enable/Disable messages by environment variable. `SPGLIB_DEBUG` and `SPGLIB_WARNINGS` cmake variables are for controlling if these messages are compiled at all or not
- [x] Write appropriately to `stdout` for debug messages and `stderr` for warning
- [x] Review what messages are warnings and which ones are debug messages
  - [x] Check that warning messages are not associated with `attempt`
  - [ ] Check that warning messages are associated with a failure/error 
  - [ ] Add `warning_print`/`info_print` at the end of `for (attempt)` loops

Closes #338, Closes #336

Depends-on: #431 