### PR TITLE
ci: Fix CI builders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,16 +6,6 @@ run-name: >
 on:
   workflow_dispatch:
     inputs:
-      cibw_archs_linux:
-        required: false
-        type: string
-        default: auto aarch64
-        description: Linux architectures
-      cibw_archs_macos:
-        required: false
-        type: string
-        default: x86_64 arm64
-        description: Macos architectures
       cibw_build:
         required: false
         type: string
@@ -56,8 +46,6 @@ jobs:
     uses: ./.github/workflows/step_build-wheel.yaml
     needs: [ tests ]
     with:
-      cibw_archs_linux: ${{ inputs.cibw_archs_linux || 'x86_64' }}
-      cibw_archs_macos: ${{ inputs.cibw_archs_macos || 'x86_64' }}
       cibw_build: ${{ inputs.cibw_build || 'cp311-*' }}
 
   test-docs:

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -7,16 +7,6 @@ on:
   # Make it able to be used in other workflows
   workflow_call:
     inputs:
-      cibw_archs_linux:
-        required: false
-        type: string
-        default: auto aarch64
-        description: Linux architectures
-      cibw_archs_macos:
-        required: false
-        type: string
-        default: x86_64 arm64
-        description: Macos architectures
       cibw_build:
         required: false
         type: string
@@ -29,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-11 ]
+        os: [ ubuntu-latest, windows-latest, macOS-11, macOS-13, macOS-14 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -43,11 +33,10 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16
+        uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_BUILD: ${{ inputs.cibw_build }}
-          CIBW_ARCHS_LINUX: ${{ inputs.cibw_archs_linux }}
-          CIBW_ARCHS_MACOS: ${{ inputs.cibw_archs_macos }}
+          CIBW_ARCHS_LINUX: auto aarch64
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -27,20 +27,24 @@ jobs:
         toolchain: [ gcc, llvm, intel ]
         python-version: [ "3.8", "3.x" ]
         include:
-#          - os: windows-2019
-#            toolchain: windows
-#            python-version: "3.x"
           - os: macos-11
             toolchain: macos
+            python-version: "3.x"
+          - os: macos-latest
+            toolchain: macos
+            python-version: "3.x"
+          - os: macos-13
+            toolchain: macos
+            python-version: "3.x"
+          - os: macos-14
+            toolchain: macos
+            python-version: "3.x"
+          - os: windows-2019
+            toolchain: windows
             python-version: "3.x"
           - os: windows-latest
             toolchain: windows
             python-version: "3.x"
-            experimental: true
-          - os: macos-latest
-            toolchain: macos
-            python-version: "3.x"
-            experimental: true
 #          - python-version: "3.13"
 #            experimental: true
 #            pre: true

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -30,9 +30,6 @@ jobs:
           - os: macos-11
             toolchain: macos
             python-version: "3.x"
-          - os: macos-latest
-            toolchain: macos
-            python-version: "3.x"
           - os: macos-13
             toolchain: macos
             python-version: "3.x"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,7 @@ GitHub release pages and in the git history.
   - Environment variable `SPGLIB_DEBUG`: Define any value to enable printing of debug messages
   - Environment variable `SPGLIB_WARNING`: Set to `OFF` to disable warning printing
   - CMake option `SPGLIB_DEBUG`, `SPGLIB_WARNINGS`: Disable the compilation of these messages all-together
+- Expanded Python distribution to more MacOS variants, including MacOS-14 (M1)
 
 ### C Interface
 
@@ -50,6 +51,8 @@ GitHub release pages and in the git history.
 - [\[#402\]](https://github.com/spglib/spglib/pull/402) - Bump artifact actions to v4
 - [\[#402\]](https://github.com/spglib/spglib/pull/402) - Build and inspect python sdist
 - [\[#431\]](https://github.com/spglib/spglib/pull/431) - Test CMake versions
+- [\[#459\]](https://github.com/spglib/spglib/pull/459) - Fix various CI issues
+- [\[#459\]](https://github.com/spglib/spglib/pull/459) - Building for MacOS 14 (M1)
 
 ## v2.3.1 (10 Feb. 2024)
 

--- a/include/spglib.h
+++ b/include/spglib.h
@@ -48,7 +48,7 @@ extern "C" {
         // On Unix this is not necessary
         #define SPG_API __attribute__((visibility("default")))
     #endif
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(SPG_STATIC_LIBRARY)
     // Otherwise mark it for import (Only needed for windows)
     #define SPG_API __declspec(dllimport)
 #else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,8 @@ SPGLIB_USE_OMP = "OFF"
 write_to = "python/spglib/_version.py"
 
 [tool.cibuildwheel]
-# cp312: Cannot build numpy yet
-# macosx_arm64: Cannot test on Github. Could add Cirrus CI/Circle CI
 # pp, win32, i686, muslinux: Remove 32bit variants, PyPY interpreter and unnecessary musl variant
-skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*", "*-macosx_arm64", "cp312-*"]
+skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-extras = "test"
 test-command = "pytest {package}/test/functional/python"
 # Do not run test on emulated environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ write_to = "python/spglib/_version.py"
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-extras = "test"
 test-command = "pytest {package}/test/functional/python"
-# Do not run test on emulated environments
-test-skip = "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
 
 [tool.cibuildwheel.linux]
 # TODO: auditwheel fails if LD_LIBRARY_PATH is not set correctly. Not sure about apprropriate value to set to

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,10 @@ set_property(DIRECTORY APPEND PROPERTY
 )
 add_dependencies(Spglib_symspg Spglib_GitHash)
 target_compile_definitions(Spglib_symspg PRIVATE SPG_BUILD)
+# For windows consumers we need to disable __declspec(dllimport) if it's built as a static library
+if (WIN32 AND NOT SPGLIB_SHARED_LIBS)
+    target_compile_definitions(Spglib_symspg PUBLIC SPG_STATIC_LIBRARY)
+endif ()
 
 # Add compiler warnings
 if (SPGLIB_COMPILATION_WARNING)

--- a/test/example/c_api/example_full.c
+++ b/test/example/c_api/example_full.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "spglib.h"
 
@@ -35,6 +36,9 @@ static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
                                      double const symprec,
                                      int const to_primitive,
                                      int const no_idealize);
+
+// Windows C compilers do not accept variable length array. Need to use a macro
+#define max_size -1
 
 int main(int argc, char *argv[]) {
     example_spg_find_primitive_BCC();
@@ -357,7 +361,8 @@ static void example_spg_get_symmetry(void) {
         {0.3, 0.3, 0.5},  {0.7, 0.7, 0.5},  {0.2, 0.8, 0.75}, {0.8, 0.2, 0.75}};
     int types[] = {1, 1, 2, 2, 2, 2, 1, 1, 2, 2, 2, 2};
     int num_atom = 12;
-    int max_size = 50;
+#undef max_size
+#define max_size 50
     int rotation[max_size][3][3];
     double translation[max_size][3];
 
@@ -388,7 +393,8 @@ static void example_spg_get_symmetry_with_collinear_spin(void) {
     int equivalent_atoms[2];
     double spins[2];
     int num_atom = 2;
-    int max_size = 300;
+#undef max_size
+#define max_size 300
     int rotation[max_size][3][3];
     double translation[max_size][3];
 
@@ -526,11 +532,12 @@ static void example_spg_get_ir_reciprocal_mesh(void) {
     };
     int types[] = {1, 1, 2, 2, 2, 2};
     int num_atom = 6;
-    int m = 40;
-    int mesh[] = {m, m, m};
+#undef max_size
+#define max_size 40
+    int mesh[] = {max_size, max_size, max_size};
     int is_shift[] = {1, 1, 1};
-    int grid_address[m * m * m][3];
-    int grid_mapping_table[m * m * m];
+    int grid_address[max_size * max_size * max_size][3];
+    int grid_mapping_table[max_size * max_size * max_size];
 
     printf(
         "*** Example of spg_get_ir_reciprocal_mesh of Rutile structure ***:\n");
@@ -676,8 +683,11 @@ static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
                                      double const symprec,
                                      int const to_primitive,
                                      int const no_idealize) {
-    double lat[3][3], pos[4 * num_atom][3];
-    int typ[4 * num_atom];
+    double lat[3][3], (*pos)[3];
+    int *typ;
+
+    pos = (double(*)[3])malloc(sizeof(double[3]) * 4 * num_atom);
+    typ = (int *)malloc(sizeof(int) * 4 * num_atom);
 
     for (int i = 0; i < 3; i++) {
         lat[i][0] = lattice[i][0];
@@ -716,6 +726,11 @@ static void sub_spg_standardize_cell(double lattice[3][3], double position[][3],
     for (int i = 0; i < num_primitive_atom; i++) {
         printf("%f %f %f\n", pos[i][0], pos[i][1], pos[i][2]);
     }
+
+    free(typ);
+    typ = NULL;
+    free(pos);
+    pos = NULL;
 }
 
 static void show_cell(double lattice[3][3], double position[][3],


### PR DESCRIPTION
- [x] Enable all macos/windows buidlers
- [x] Fix windows builders
- [ ] Fix Macos builders. Maybe we just skip `macos-12`: https://github.com/spglib/spglib/pull/459#issuecomment-2023171931
- [x] Update `ci-build-wheel` to include M1 variants: Running all configurations at https://github.com/LecrisUT/spglib/actions/runs/8456467424

Depends-on: #431 

Closes #414 