### PR TITLE
doc: Use autodoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,6 @@ test-suite.log
 docs_build/
 CMakeUserPresets.json
 
-docs/api/python-api/
-
 /python/spglib/_version.py
 venv
 env

--- a/docs/api/develop.md
+++ b/docs/api/develop.md
@@ -4,26 +4,34 @@ These APIs are for the internal usage and development of Spglib itself.
 
 ## Python interface
 
-```{autodoc2-object} spglib.spglib.get_pointgroup
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_pointgroup
 ```
 
-```{autodoc2-object} spglib.spglib.get_layergroup
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_layergroup
 ```
 
-```{autodoc2-object} spglib.spglib.get_symmetry_layerdataset
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_symmetry_layerdataset
 ```
 
-```{autodoc2-object} spglib.spglib.get_grid_point_from_address
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_grid_point_from_address
 ```
 
-```{autodoc2-object} spglib.spglib.get_stabilized_reciprocal_mesh
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_stabilized_reciprocal_mesh
 ```
 
-```{autodoc2-object} spglib.spglib.get_grid_points_by_rotations
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_grid_points_by_rotations
 ```
 
-```{autodoc2-object} spglib.spglib.get_BZ_grid_points_by_rotations
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_BZ_grid_points_by_rotations
 ```
 
-```{autodoc2-object} spglib.spglib.relocate_BZ_grid_address
+```{eval-rst}
+.. autofunction:: spglib.spglib.relocate_BZ_grid_address
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,6 +4,6 @@
 ---
 maxdepth: 1
 ---
-Python API <python-api/index>
+Python API <python-api>
 Unreleased API <develop>
 ```

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1,0 +1,6 @@
+# Python API
+
+```{eval-rst}
+.. automodule:: spglib.spglib
+   :members:
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@ extensions = [
     "myst_parser",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
+    "sphinx_tippy",
 ]
 
 exclude_patterns = [
@@ -98,3 +100,18 @@ extlinks = {
     "path": ("https://github.com/spglib/spglib/tree/develop/%s", "%s"),
     "user": ("https://github.com/%s", "%s"),
 }
+
+# -----------------------------------------------------------------------------
+# intersphinx and tippy
+# -----------------------------------------------------------------------------
+
+intersphinx_mapping = {
+    "cmake": ("https://cmake.org/cmake/help/latest", None),
+    "scikit": ("https://scikit-build-core.readthedocs.io/en/latest/", None),
+}
+
+tippy_rtd_urls = [
+    # Only works with RTD hosted intersphinx
+    # "https://cmake.org/cmake/help/latest",
+    "https://scikit-build-core.readthedocs.io/en/latest/",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-from spglib import __version__ as version
+import importlib.metadata
 
 project = "Spglib"
 copyright = "2009, Atsushi Togo"
@@ -55,7 +55,7 @@ bibtex_default_style = "unsrt"
 # -----------------------------------------------------------------------------
 
 html_theme = "sphinx_book_theme"
-html_title = f"Spglib v{version}"
+html_title = f"Spglib v{importlib.metadata.version('spglib')}"
 html_theme_options = {
     # https://sphinx-book-theme.readthedocs.io/en/latest/reference.html
     "repository_url": "https://github.com/spglib/spglib",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@ copyright = "2009, Atsushi Togo"
 extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
+    "sphinx.ext.autodoc",
     "sphinxcontrib.bibtex",
     "myst_parser",
-    "autodoc2",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
 ]
@@ -62,34 +62,6 @@ html_theme_options = {
     "show_toc_level": 3,
 }
 html_static_path = ["_static"]
-
-# -----------------------------------------------------------------------------
-# Autodoc2
-# -----------------------------------------------------------------------------
-autodoc2_output_dir = "api/python-api"
-autodoc2_render_plugin = "myst"
-autodoc2_docstring_parser_regexes = [
-    (r".*", "rst"),
-]
-autodoc2_annotations = False
-autodoc2_packages = [
-    {
-        "path": "../python/spglib",
-    },
-]
-autodoc2_hidden_objects = ["dunder", "private", "inherited"]
-autodoc2_hidden_regexes = [
-    "spglib.spglib.get_pointgroup",
-    # Layer group
-    "spglib.spglib.get_layergroup",
-    "spglib.spglib.get_symmetry_layerdataset",
-    # Kpoints
-    "spglib.spglib.get_grid_point_from_address",
-    "spglib.spglib.get_stabilized_reciprocal_mesh",
-    "spglib.spglib.get_grid_points_by_rotations",
-    "spglib.spglib.get_BZ_grid_points_by_rotations",
-    "spglib.spglib.relocate_BZ_grid_address",
-]
 
 # -----------------------------------------------------------------------------
 # linkcheck

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "sphinxcontrib.bibtex",
     "myst_parser",
     "sphinx.ext.doctest",

--- a/docs/python-interface.md
+++ b/docs/python-interface.md
@@ -194,67 +194,49 @@ details, see {ref}`variables_symprec`, {ref}`variables_angle_tolerance`, and
 
 ### Version
 
-```{autodoc2-summary}
-  spglib.spglib.get_version
-```
+- {py:func}`spglib.spglib.get_version`
 
 ### Error
 
-```{autodoc2-summary}
-  spglib.spglib.get_error_message
-```
+- {py:func}`spglib.spglib.get_error_message`
 
 ### Space-group symmetry search
 
-```{autodoc2-summary}
-  spglib.spglib.get_symmetry
-  spglib.spglib.get_symmetry_dataset
-```
+- {py:func}`spglib.spglib.get_symmetry`
+- {py:func}`spglib.spglib.get_symmetry_dataset`
 
 ### Space-group type search
 
-```{autodoc2-summary}
-  spglib.spglib.get_spacegroup
-```
+- {py:func}`spglib.spglib.get_spacegroup`
 
 ### Standardization and finding primitive cell
 
-```{autodoc2-summary}
-  spglib.spglib.standardize_cell
-  spglib.spglib.find_primitive
-  spglib.spglib.refine_cell
-```
+- {py:func}`spglib.spglib.standardize_cell`
+- {py:func}`spglib.spglib.find_primitive`
+- {py:func}`spglib.spglib.refine_cell`
 
 ### Space-group dataset access
 
-```{autodoc2-summary}
-  spglib.spglib.get_symmetry_from_database
-  spglib.spglib.get_spacegroup_type
-  spglib.spglib.get_spacegroup_type_from_symmetry
-```
+- {py:func}`spglib.spglib.get_symmetry_from_database`
+- {py:func}`spglib.spglib.get_spacegroup_type`
+- {py:func}`spglib.spglib.get_spacegroup_type_from_symmetry`
 
 ### Magnetic symmetry
 
-```{autodoc2-summary}
-  spglib.spglib.get_magnetic_symmetry
-  spglib.spglib.get_magnetic_symmetry_dataset
-  spglib.spglib.get_magnetic_spacegroup_type
-  spglib.spglib.get_magnetic_spacegroup_type_from_symmetry
-  spglib.spglib.get_magnetic_symmetry_from_database
-```
+- {py:func}`spglib.spglib.get_magnetic_symmetry`
+- {py:func}`spglib.spglib.get_magnetic_symmetry_dataset`
+- {py:func}`spglib.spglib.get_magnetic_spacegroup_type`
+- {py:func}`spglib.spglib.get_magnetic_spacegroup_type_from_symmetry`
+- {py:func}`spglib.spglib.get_magnetic_symmetry_from_database`
 
 ### Lattice reduction
 
-```{autodoc2-summary}
-  spglib.spglib.niggli_reduce
-  spglib.spglib.delaunay_reduce
-```
+- {py:func}`spglib.spglib.niggli_reduce`
+- {py:func}`spglib.spglib.delaunay_reduce`
 
 ### Kpoints
 
-```{autodoc2-summary}
-  spglib.spglib.get_ir_reciprocal_mesh
-```
+- {py:func}`spglib.spglib.get_ir_reciprocal_mesh`
 
 ```python
 mapping, grid = get_ir_reciprocal_mesh(mesh, cell, is_shift=[0, 0, 0])
@@ -329,6 +311,6 @@ print((grid[np.unique(mapping)] + [0.5, 0.5, 0.5]) / mesh)
 ```{caution} Following functions are deprecated!
 ```
 
-```{autodoc2-summary}
-  spglib.spglib.get_hall_number_from_symmetry
+```{eval-rst}
+.. autofunction:: spglib.spglib.get_hall_number_from_symmetry
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ docs = [
     "Sphinx >= 7.0",
     "sphinxcontrib-bibtex >= 2.5",
     "sphinx-book-theme",
+    "sphinx-autodoc-typehints",
     "myst-parser >= 2.0",
     "linkify-it-py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ docs = [
     "Sphinx >= 7.0",
     "sphinxcontrib-bibtex >= 2.5",
     "sphinx-book-theme",
-    "sphinx-autodoc2",
     "myst-parser >= 2.0",
     "linkify-it-py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
     "sphinx-autodoc-typehints",
     "myst-parser >= 2.0",
     "linkify-it-py",
+    "sphinx-tippy",
 ]
 test-cov = [
     "spglib[test]",

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -76,6 +76,43 @@ if TYPE_CHECKING:
 
     from numpy.typing import ArrayLike, NDArray
 
+__all__ = [
+    "MagneticSpaceGroupType",
+    "SpaceGroupType",
+    "SpglibDataset",
+    "SpglibMagneticDataset",
+    "delaunay_reduce",
+    "find_primitive",
+    # "get_BZ_grid_points_by_rotations",
+    "get_error_message",
+    # "get_grid_point_from_address",
+    # "get_grid_points_by_rotations",
+    # "get_hall_number_from_symmetry",
+    "get_ir_reciprocal_mesh",
+    # "get_layergroup",
+    "get_magnetic_spacegroup_type",
+    "get_magnetic_spacegroup_type_from_symmetry",
+    "get_magnetic_symmetry",
+    "get_magnetic_symmetry_dataset",
+    "get_magnetic_symmetry_from_database",
+    # "get_pointgroup",
+    "get_spacegroup",
+    "get_spacegroup_type",
+    "get_spacegroup_type_from_symmetry",
+    # "get_stabilized_reciprocal_mesh",
+    "get_symmetry",
+    "get_symmetry_dataset",
+    "get_symmetry_from_database",
+    "get_version",
+    "niggli_reduce",
+    "refine_cell",
+    # "relocate_BZ_grid_address",
+    # "spg_get_commit",
+    # "spg_get_version",
+    "spg_get_version_full",
+    "standardize_cell",
+]
+
 warnings.filterwarnings(
     "module", category=DeprecationWarning, message=r"dict interface.*"
 )
@@ -453,6 +490,7 @@ def spg_get_version() -> str:
     """Get the X.Y.Z version of the detected spglib C library.
 
     .. versionadded:: 2.3.0
+
     :return: version string
     """
     _set_no_error()
@@ -463,6 +501,7 @@ def spg_get_version_full() -> str:
     """Get the full version of the detected spglib C library.
 
     .. versionadded:: 2.3.0
+
     :return: full version string
     """
     _set_no_error()
@@ -473,6 +512,7 @@ def spg_get_commit() -> str:
     """Get the commit of the detected spglib C library.
 
     .. versionadded:: 2.3.0
+
     :return: commit string
     """
     _set_no_error()
@@ -1873,8 +1913,6 @@ def relocate_BZ_grid_address(
 
     Number of ir-grid-points inside Brillouin zone is returned.
     It is assumed that the following arrays have the shapes of
-        bz_grid_address : (num_grid_points_in_FBZ, 3)
-        bz_map (prod(mesh * 2), )
 
     Note that the shape of grid_address is (prod(mesh), 3) and the
     addresses in grid_address are arranged to be in parallelepiped


### PR DESCRIPTION
Trying to revisit #420

In principle we can use `autodoc_type_aliases` to simplify the documentation