### PR TITLE
fix: Remove `ref-names` from `.git_archival.txt`

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Temporary fix for the `.git_archival.txt` creating archives that change over time

More context about the issue. You can check the results of [`%D`](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emDem) via:
```console
$ git checkout v2.4.0
$ git branch temp
$ git checkout temp
$ git log -1 --format="%D"
HEAD -> temp, tag: v2.4.0, origin/develop, origin/HEAD, develop
$ git commit --allow-empty -m "Any commit"
$ git checkout v2.4.0
$ git log -1 --format="%D"
HEAD, tag: v2.4.0, origin/develop, origin/HEAD, develop
```

Note how now the branch `temp` is gone. This is what is happening with `develop` when a commit is pushed to it.

So far it seems `ref-names` can be avoided on [`setuptools_scm`](https://github.com/pypa/setuptools_scm/blob/d081257ea39dfae710603796a9e85033256cc012/src/setuptools_scm/git.py#L319-L322) when `describe` works, although ref names seems like quite a good option to have.