### PR TITLE
Fix doc API of SpglibSpacegroupType

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -347,11 +347,11 @@ typedef struct {
     char international_full[20];
     char international[32];
     char schoenflies[7];
-    char hall_symbol[17];
     int hall_number;
+    char hall_symbol[17];
     char choice[6];
-    char pointgroup_schoenflies[4];
     char pointgroup_international[6];
+    char pointgroup_schoenflies[4];
     int arithmetic_crystal_class_number;
     char arithmetic_crystal_class_symbol[7];
 } SpglibSpacegroupType;


### PR DESCRIPTION
Hello,

I just noticed that the [documented C-API](https://spglib.readthedocs.io/en/latest/api.html#spg-get-spacegroup-type) for `SpglibSpacegroupType` does not actually reflect the [underlying C struct](https://github.com/spglib/spglib/blob/5c7046bae1bfcf3c203f7af55d5ad0cfa23161dc/include/spglib.h#L173-L186)... This PR fixes that.

For the `hall_symbol` - `hall_number` switch, the documentation was added at the same time as the field in the wrong order in #176, two years ago.
For the `pointgroup_international` - `pointgroup_schoenflies` switch, I believe that comes from 3512320, that is eight years ago!

The [Python interface](https://github.com/spglib/spglib/blob/5c7046bae1bfcf3c203f7af55d5ad0cfa23161dc/python/spglib/spglib.py#L1161-L1174) does not look affected, the keys are in the same order as the C struct.