### PR TITLE
Check if primitive symmetry search is passed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+## Fixes (magnetic space group)
+
+- Fix to check internal primitive symmetry search to avoid SEGV
+
 ## v2.4.0 (11 Apr. 2024)
 
 ### Main Changes

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -585,6 +585,11 @@ static Symmetry *get_space_group_with_magnetic_symmetry(
 
     /* (a, b, c) = (a_prim, b_prim, c_prim) @ tmat */
     prim_sym = prm_get_primitive_symmetry(tmat, sym, symprec);
+    if (prim_sym == NULL) {
+        sym_free_symmetry(sym);
+        return NULL;
+    }
+
     *spacegroup =
         spa_search_spacegroup_with_symmetry(prim_sym, unit_lat, symprec);
     /* refine bravais_lattice and origin_shift */

--- a/src/primitive.c
+++ b/src/primitive.c
@@ -170,8 +170,9 @@ int prm_get_primitive_with_pure_trans(Primitive *primitive, Cell const *cell,
     return 1;
 }
 
-/* t_mat transforms primitive cell to conventional: */
-/* (a_p, b_p, c_p) t_mat = (a_c, b_c, c_c) */
+// t_mat transforms primitive cell to conventional:
+// (a_p, b_p, c_p) t_mat = (a_c, b_c, c_c)
+// If failed, return NULL
 Symmetry *prm_get_primitive_symmetry(double t_mat[3][3],
                                      Symmetry const *symmetry,
                                      double const symprec) {

--- a/test/functional/c/test_magnetic_dataset.cpp
+++ b/test/functional/c/test_magnetic_dataset.cpp
@@ -330,7 +330,7 @@ TEST(MagneticDataset, test_with_slightly_distorted_positions) {
     spg_free_magnetic_dataset(dataset);
 }
 
-TEST(MagneticDataset, test_with_slightly_distorted_positions2) {
+TEST(MagneticDataset, test_failure_with_slightly_distorted_positions) {
     double lattice[3][3] = {
         {4.79573126, 4.79573126, -1.60862362},
         {-1.38874873, 1.38874873, 0.},

--- a/test/functional/c/test_magnetic_dataset.cpp
+++ b/test/functional/c/test_magnetic_dataset.cpp
@@ -330,4 +330,33 @@ TEST(MagneticDataset, test_with_slightly_distorted_positions) {
     spg_free_magnetic_dataset(dataset);
 }
 
+TEST(MagneticDataset, test_with_slightly_distorted_positions2) {
+    double lattice[3][3] = {
+        {4.79573126, 4.79573126, -1.60862362},
+        {-1.38874873, 1.38874873, 0.},
+        {0., 0., 5.31736928},
+    };
+    double positions[][3] = {
+        {0.51669908, 0.51669908, 0.22675739},
+        {0.5166947, 0.5166947, 0.72675256},
+        {0.19685353, 0.19685353, 0.56683556},
+        {0.83653907, 0.83653907, 0.88667445},
+        {0.83653365, 0.83653365, 0.38666685},
+        {0.19685074, 0.19685074, 0.0668282},
+    };
+    int types[] = {0, 0, 1, 1, 1, 1};
+    double tensors[] = {0, 0, 0, 0, 0, 0};
+    int num_atoms = 6;
+    double symprec = 1e-4;  // too large symprec for this input
+
+    SpglibMagneticDataset *dataset;
+    dataset = spg_get_magnetic_dataset(lattice, positions, types, tensors,
+                                       0 /* tensor_rank */, num_atoms,
+                                       0 /* is_axial */, symprec);
+    EXPECT_EQ(spg_get_error_code(),
+              SpglibError::SPGERR_SPACEGROUP_SEARCH_FAILED);
+
+    if (dataset) spg_free_magnetic_dataset(dataset);
+}
+
 // TODO: test get_magnetic_dataset with distorted positions

--- a/test/functional/c/test_magnetic_dataset.cpp
+++ b/test/functional/c/test_magnetic_dataset.cpp
@@ -331,6 +331,7 @@ TEST(MagneticDataset, test_with_slightly_distorted_positions) {
 }
 
 TEST(MagneticDataset, test_failure_with_slightly_distorted_positions) {
+    // This structure was randomly generated
     double lattice[3][3] = {
         {4.79573126, 4.79573126, -1.60862362},
         {-1.38874873, 1.38874873, 0.},

--- a/test/functional/c/test_magnetic_dataset.cpp
+++ b/test/functional/c/test_magnetic_dataset.cpp
@@ -347,7 +347,9 @@ TEST(MagneticDataset, test_failure_with_slightly_distorted_positions) {
     int types[] = {0, 0, 1, 1, 1, 1};
     double tensors[] = {0, 0, 0, 0, 0, 0};
     int num_atoms = 6;
-    double symprec = 1e-4;  // too large symprec for this input
+    // prm_get_primitive_symmetry seems to change behavior with symprec=1e-4 and
+    // 1e-5 for this distorted structure
+    double symprec = 1e-4;
 
     SpglibMagneticDataset *dataset;
     dataset = spg_get_magnetic_dataset(lattice, positions, types, tensors,


### PR DESCRIPTION
`prm_get_primitive_symmetry` seems to be failed with some symprec and the current MSG implementation cannot recover from it. This PR fixes to check the returned primitive symmetry to avoid SEGV.