### PR TITLE
fix: rpmlint issues

### DIFF
--- a/.distro/plans/rpmlint.fmf
+++ b/.distro/plans/rpmlint.fmf
@@ -8,3 +8,8 @@ discover:
   ref: main
 execute:
   how: tmt
+
+adjust:
+  when: distro < fedora-40
+  because: Rpmlint fails with empty entry_points.txt
+  enabled: false

--- a/.distro/spglib.rpmlintrc
+++ b/.distro/spglib.rpmlintrc
@@ -1,1 +1,0 @@
-addFilter("python.?-spglib.* zero-length .*/entry_points.txt")


### PR DESCRIPTION
Either rpmlint or the python build fixed the empty `entry_points.txt` complaint