### PR TITLE
feat: Add renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "groupName": "CI and devDependencies",
+      "matchManagers": ["github-actions", "pre-commit"]
+    },
+    {
+      "groupName": "Runtime",
+      "matchManagers": ["pep621"]
+    }
+  ],
+  "separateMajorMinor": false,
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    "schedule:weekly",
+    ":enablePreCommit",
+    ":semanticCommitTypeAll(chore)"
+  ]
+}


### PR DESCRIPTION
Compared to dependabot, this does not constantly close and reopen PRs and it is able to group updates. That way we don't need to constantly babysit it and we can just address the 1/2 PRs when we have time or at the very least when we are close to release

- [x] I've sent a request, and I should be able to configure it after that.