### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           name: Spglib ${{ github.ref_name }}
           draft: true

--- a/.github/workflows/step_build-wheel.yaml
+++ b/.github/workflows/step_build-wheel.yaml
@@ -29,11 +29,11 @@ jobs:
         # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
       - name: Set up QEMU for Linux-arm
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_ARCHS_LINUX: auto aarch64

--- a/.github/workflows/step_coverage.yaml
+++ b/.github/workflows/step_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: lukka/get-cmake@latest
       - name: Get test coverage for ${{ matrix.coverage }}
-        uses: lukka/run-cmake@v10.3
+        uses: lukka/run-cmake@v10.7
         with:
           workflowPreset: "ci-coverage-${{ matrix.coverage }}"
       - name: Get lcov data
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Setup spglib

--- a/.github/workflows/step_pre-commit.yaml
+++ b/.github/workflows/step_pre-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/step_test-docs.yaml
+++ b/.github/workflows/step_test-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install the project and docs dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: src\/msg_database.c
 fail_fast: false
 repos:
   - repo: https://github.com/Takishima/cmake-pre-commit-hooks
-    rev: v1.9.5
+    rev: v1.9.6
     hooks:
       - id: clang-format
         additional_dependencies: [ clang-format >= 16 ]
@@ -23,20 +23,20 @@ repos:
           - '-DSPGLIB_WITH_TESTS=ON'
         stages: [ manual ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.5.1
     hooks:
       - id: ruff
         args: [ "--fix", "--show-fixes" ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.1
     hooks:
     - id: mypy
       pass_filenames: false
@@ -60,7 +60,7 @@ repos:
           - mdformat-myst
         files: docs\/(?!README).*\.md$
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.3
+    rev: 0.29.0
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs
@@ -71,7 +71,7 @@ repos:
         args: [ '-i', '4' ]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: "v2.3.0"
     hooks:
       - id: codespell
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,16 +101,22 @@ write_to = "python/spglib/_version.py"
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-extras = "test"
 test-command = "pytest {package}/test/functional/python"
+before-build = [
+    "cmake -B _build -DSPGLIB_WITH_TESTS=OFF -DCMAKE_BUILD_TYPE=Release",
+    "cmake --build _build --config Release",
+    "cmake --install _build --config Release --prefix {project}/_install",
+]
 
 [tool.cibuildwheel.linux]
-# TODO: auditwheel fails if LD_LIBRARY_PATH is not set correctly. Not sure about apprropriate value to set to
-#repair-wheel-command = "LD_LIBRARY_PATH=. auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
-repair-wheel-command = ""
+before-build = [
+    "cmake -B _build -DSPGLIB_WITH_TESTS=OFF -DCMAKE_BUILD_TYPE=Release",
+    "cmake --build _build",
+    "cmake --install _build",
+]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-# TODO: similar to above
-#repair-wheel-command = "DYLD_LIBRARY_PATH=. delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
-repair-wheel-command = ""
+repair-wheel-command = "DYLD_LIBRARY_PATH=_install/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.pytest.ini_options]
 addopts = "-Werror -m 'not benchmark'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,11 @@ source = ['spglib']
 
 [tool.ruff]
 line-length = 88
+exclude = [
+    "database/*"
+]
+
+[tool.ruff.lint]
 extend-select = [
     "F",           # pyflakes
     # "W",           # pycodestyle-warnings
@@ -182,7 +187,7 @@ extend-ignore = [
     "D101",
     "D102",
     "D103",
-    "D203",  # Confilct with D211
+    "D203",  # Conflict with D211
     "D205",
     "D213",  # Conflict with D212
 ]

--- a/python/spglib/__init__.py
+++ b/python/spglib/__init__.py
@@ -33,7 +33,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
 from ._version import __version__, __version_tuple__  # noqa: F401
 
 # fmt: off

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -750,6 +750,7 @@ def get_magnetic_symmetry(
     Notes
     -----
     .. versionadded:: 2.0
+
     """
     _set_no_error()
 
@@ -906,6 +907,7 @@ def get_symmetry_dataset(
     dataset: :class:`SpglibDataset` | None
         If it fails, None is returned. Otherwise a dictionary is returned.
         More details are found at :ref:`spglib-dataset`.
+
     """
     _set_no_error()
 
@@ -1260,6 +1262,7 @@ def get_magnetic_spacegroup_type_from_symmetry(
     Returns
     -------
     magnetic_spacegroup_type: :class:`MagneticSpaceGroupType` | None
+
     """
     rots = np.array(rotations, dtype="intc", order="C")
     trans = np.array(translations, dtype="double", order="C")
@@ -1368,6 +1371,7 @@ def standardize_cell(
     About the default choice of the setting, see the documentation of ``hall_number``
     argument of :func:`get_symmetry_dataset`. More detailed explanation is
     shown in the spglib (C-API) document.
+
     """
     _set_no_error()
 
@@ -1413,6 +1417,7 @@ def refine_cell(cell: Cell, symprec=1e-5, angle_tolerance=-1.0) -> Cell | None:
 
     The detailed control of standardization of unit cell can be done using
     :func:`standardize_cell`.
+
     """
     _set_no_error()
 
@@ -1455,6 +1460,7 @@ def find_primitive(cell: Cell, symprec=1e-5, angle_tolerance=-1.0) -> Cell | Non
 
     The detailed control of standardization of unit cell can be done using
     :func:`standardize_cell`.
+
     """
     _set_no_error()
 
@@ -1492,6 +1498,7 @@ def get_symmetry_from_database(hall_number) -> dict | None:
             Rotation parts of symmetry operations corresponding to ``hall_number``.
         - translations
             Translation parts of symmetry operations corresponding to ``hall_number``.
+
     """
     _set_no_error()
 
@@ -1534,6 +1541,7 @@ def get_magnetic_symmetry_from_database(uni_number, hall_number=0) -> dict | Non
     Notes
     -----
     .. versionadded:: 2.0
+
     """
     _set_no_error()
 
@@ -1960,6 +1968,7 @@ def delaunay_reduce(lattice, eps=1e-5):
     Notes
     -----
     .. versionadded:: 1.9.4
+
     """  # noqa: E501
     _set_no_error()
 
@@ -2021,6 +2030,7 @@ def niggli_reduce(lattice, eps=1e-5):
     Notes
     -----
     .. versionadded:: 1.9.4
+
     """  # noqa: E501
     _set_no_error()
 
@@ -2044,6 +2054,7 @@ def get_error_message():
     Notes
     -----
     .. versionadded:: 1.9.5
+
     """
     return spglib_error.message
 

--- a/test/example/python_api/example.py
+++ b/test/example/python_api/example.py
@@ -1,4 +1,5 @@
 """Example to use get_symmetry_dataset with Wurtzite structure input (P6_3mc)."""
+
 from spglib import get_symmetry_dataset
 
 lattice = [[3.111, 0, 0], [-1.5555, 2.6942050311733885, 0], [0, 0, 4.988]]

--- a/test/functional/python/conftest.py
+++ b/test/functional/python/conftest.py
@@ -1,4 +1,5 @@
 """Pytest configuration."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/test/functional/python/test_hall_number_from_symmetry.py
+++ b/test/functional/python/test_hall_number_from_symmetry.py
@@ -1,4 +1,5 @@
 """Test of get_hall_number_from_symmetry."""
+
 from __future__ import annotations
 
 import os

--- a/test/functional/python/test_niggli_delaunay.py
+++ b/test/functional/python/test_niggli_delaunay.py
@@ -1,4 +1,5 @@
 """Tests of delaunay_reduce and niggli_reduce."""
+
 from pathlib import Path
 
 import numpy as np

--- a/test/functional/python/test_spacegrouop_type_from_symmetry.py
+++ b/test/functional/python/test_spacegrouop_type_from_symmetry.py
@@ -1,4 +1,5 @@
 """Test of spacegroup_type_from_symmetry."""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
- Update CI dependencies
- Fix trivial pre-commit issues
- (Temporarily) Fix `cibuildwheel`
  - Make sure `auditwheel` is run. Apparently the wheel tags generated by `scikit-build-core` were not meant to have `manylinux`, instead `auditwheel` **must** be used to re-link to check and relink to appropriate libc
  - For now the wheel will always link to the bundled spglib library. Unfortunately I can't find a good way to keep the fallback feature, but it should not be a destructive breakage, i.e. the python library will guarantee to work.
  - Proper fix will be in #510