### PR TITLE
chore: Fix pre-commit links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.1
+    rev: v0.5.6
     hooks:
       - id: ruff
         args: [ "--fix", "--show-fixes" ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.1
     hooks:
     - id: mypy
       pass_filenames: false
@@ -60,7 +60,7 @@ repos:
           - mdformat-myst
         files: docs\/(?!README).*\.md$
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.0
+    rev: 0.29.1
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs
-  - repo: https://github.com/pseewald/fprettify
+  - repo: https://github.com/fortran-lang/fprettify
     rev: v0.3.7
     hooks:
       - id: fprettify


### PR DESCRIPTION
- `fprettify` link moved to https://github.com/fortran-lang/fprettify
- Bumped pre-commits while at it