### PR TITLE
fix: Move the inlined `debug` definitions to header

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -108,18 +108,6 @@ void debug_print(char const* format, ...) {
     vfprintf(stdout, format, argptr);
     va_end(argptr);
 }
-#else
-void debug_print_matrix_d3(double const a[3][3]) {}
-
-void debug_print_matrix_i3(int const a[3][3]) {}
-
-void debug_print_vectors_d3(double const a[][3], int size) {}
-
-void debug_print_vector_d3(double const a[3]) {}
-
-void debug_print_vectors_with_label(double const a[][3], int const b[],
-                                    int size) {}
-void debug_print(char const* format, ...) {}
 #endif
 
 #ifdef SPGWARNING
@@ -130,8 +118,6 @@ void warning_print(char const* format, ...) {
     vfprintf(stderr, format, argptr);
     va_end(argptr);
 }
-#else
-void warning_print(char const* format, ...) {}
 #endif
 
 #ifdef SPGINFO
@@ -142,10 +128,4 @@ void info_print(char const* format, ...) {
     vfprintf(stderr, format, argptr);
     va_end(argptr);
 }
-#else
-void info_print(char const* format, ...) {}
 #endif
-
-void warning_memory(char const* what) {
-    warning_print("Spglib: Memory could not be allocated: %s\n", what);
-}

--- a/src/debug.h
+++ b/src/debug.h
@@ -34,16 +34,40 @@
 
 #pragma once
 
+// If printing is disabled define empty inlined functions to be optimized out
+#ifndef SPGDEBUG
+static inline void debug_print_matrix_d3(double const a[3][3]) {}
+
+static inline void debug_print_matrix_i3(int const a[3][3]) {}
+
+static inline void debug_print_vectors_d3(double const a[][3], int size) {}
+
+static inline void debug_print_vector_d3(double const a[3]) {}
+
+static inline void debug_print_vectors_with_label(double const a[][3],
+                                                  int const b[], int size) {}
+static inline void debug_print(char const* format, ...) {}
+#endif
+#ifndef SPGWARNING
+static inline void warning_print(char const* format, ...) {}
+#endif
+#ifndef SPGINFO
+static inline void info_print(char const* format, ...) {}
+#endif
+
+// Otherwise the print functions are proper functions
 // Main print interface
-extern inline void warning_print(char const* format, ...);
-extern inline void debug_print(char const* format, ...);
-extern inline void info_print(char const* format, ...);
-extern inline void debug_print_matrix_d3(double const a[3][3]);
-extern inline void debug_print_matrix_i3(int const a[3][3]);
-extern inline void debug_print_vector_d3(double const a[3]);
-extern inline void debug_print_vectors_d3(double const a[][3], int size);
-extern inline void debug_print_vectors_with_label(double const a[][3],
-                                                  int const b[], int size);
+void warning_print(char const* format, ...);
+void debug_print(char const* format, ...);
+void info_print(char const* format, ...);
+void debug_print_matrix_d3(double const a[3][3]);
+void debug_print_matrix_i3(int const a[3][3]);
+void debug_print_vector_d3(double const a[3]);
+void debug_print_vectors_d3(double const a[][3], int size);
+void debug_print_vectors_with_label(double const a[][3], int const b[],
+                                    int size);
 
 // Common messages
-extern inline void warning_memory(char const* what);
+inline void warning_memory(char const* what) {
+    warning_print("Spglib: Memory could not be allocated: %s\n", what);
+}


### PR DESCRIPTION
Switched it up a bit, basically we only care about inlining when the printing is empty, so I just moved those definitions in the header itself with the appropriate guard. When the printing is needed, than it would just create normal functions.

Closes #516