### PR TITLE
fix: Python installation

### DIFF
--- a/.distro/spglib.spec
+++ b/.distro/spglib.spec
@@ -85,7 +85,10 @@ tomcli set pyproject.toml arrays replace "build-system.requires" "numpy.*" "nump
 
 %cmake_build
 %if %{with python}
-%pyproject_wheel
+# Use the C library built at previous step to avoid building bundled version
+%{pyproject_wheel %{shrink:
+  -C cmake.define.Spglib_ROOT=%{__cmake_builddir}
+}}
 %endif
 
 
@@ -95,14 +98,6 @@ tomcli set pyproject.toml arrays replace "build-system.requires" "numpy.*" "nump
 %if %{with python}
 %pyproject_install
 %pyproject_save_files spglib
-%endif
-
-%if %{with python}
-rm %{buildroot}%{python3_sitearch}/spglib/lib/libsymspg.so*
-rm %{buildroot}%{python3_sitearch}/spglib/include/spglib.h
-# Delete from pyproject_files as well
-sed -i "/libsymspg.so/d" %{pyproject_files}
-sed -i "/spglib.h/d" %{pyproject_files}
 %endif
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,8 @@ mark_as_advanced(
 # Include basic tools
 include(cmake/PackageCompsHelper.cmake)
 include(FetchContent)
-if (SPGLIB_INSTALL)
-    include(CMakePackageConfigHelpers)
-    include(GNUInstallDirs)
-endif ()
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 # Define basic parameters
 set(BUILD_SHARED_LIBS ${SPGLIB_SHARED_LIBS})
@@ -139,11 +137,7 @@ endif ()
 
 # Copy PackageCompsHelper to make it available for build import
 configure_file(cmake/PackageCompsHelper.cmake PackageCompsHelper.cmake COPYONLY)
-
-# TODO: Temporarily disable installing cmake files when using scikit-build-core
-#  Check how bundled cmake searches CMAKE_MODULE_DIR and add accordingly
-#  (use SKBUILD_PLATLIB_DIR for install root)
-if (NOT SKBUILD AND SPGLIB_INSTALL)
+if (SPGLIB_INSTALL)
     # pkg-config files
     configure_file(cmake/spglib.pc.in spglib.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ message(STATUS "Spglib:: Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Spglib:: Version ${PROJECT_VERSION_FULL}")
 
 #[=============================================================================[
+#                                Public targets                                #
+]=============================================================================]
+
+add_library(Spglib_symspg)
+add_library(Spglib::symspg ALIAS Spglib_symspg)
+
+#[=============================================================================[
 #                              External packages                              #
 ]=============================================================================]
 
@@ -100,22 +107,21 @@ endif ()
 ]=============================================================================]
 
 # Main project
-add_library(Spglib_symspg)
 set_target_properties(Spglib_symspg PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         EXPORT_NAME symspg
-        OUTPUT_NAME symspg)
-add_library(Spglib::symspg ALIAS Spglib_symspg)
+        OUTPUT_NAME symspg
+)
 # Main definitions inside src
 add_subdirectory(include)
 add_subdirectory(src)
 
 # Bindings
-if (SPGLIB_WITH_Fortran)
+if (NOT TARGET Spglib::fortran AND SPGLIB_WITH_Fortran)
     add_subdirectory(fortran)
 endif ()
-if (SPGLIB_WITH_Python)
+if (NOT TARGET Spglib::python AND SPGLIB_WITH_Python)
     add_subdirectory(python)
 endif ()
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,16 @@ Users can now access the rotation and translation operations from the database, 
   reliable type annotation. This will be revisited when refactoring the interface to datastructures.
 - Added runtime and annotation deprecations using `warnings.deprecated`
 
+### Main changes
+
+The python bindings are now linked to the C library at build time, see the Python changes for more details.
+
+### Python API
+
+- The PyPI wheel contains a bundled `libsymspg` library, and it *always* has priority through RPATH priority.
+- When building from source (repository or sdist) it will try to link to a system installed `spglib` and fallback to
+  the bundled version if it failed.
+
 ## v2.5.0 (9 Jul. 2024)
 
 ### Main changes

--- a/cmake/SpglibConfig.cmake.in
+++ b/cmake/SpglibConfig.cmake.in
@@ -13,6 +13,17 @@ set(Spglib_Python @SPGLIB_WITH_Python@)
 set(Spglib_OMP @SPGLIB_USE_OMP@)
 set(Spglib_LIB_TYPE @SPGLIB_LIB_TYPE@)
 
+# Workaround for pip build isolation issue
+# https://github.com/pypa/pip/issues/12976
+# Check that this installation is built within scikit-build-core
+# and that wer are rebuilding the same spglib python project
+set(_spglib_built_from_skbuild_project "@SKBUILD_PROJECT_NAME@")
+if(_spglib_built_from_skbuild_project STREQUAL "spglib" AND
+    SKBUILD_PROJECT_NAME STREQUAL "spglib")
+	set(Spglib_FOUND FALSE)
+	return()
+endif()
+
 ## Parse find_package request
 
 if (NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/PackageCompsHelper.cmake)

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -46,6 +46,7 @@ endif ()
 #                            Project configuration                            #
 ]=============================================================================]
 
+include(GNUInstallDirs)
 include(../cmake/PackageCompsHelper.cmake)
 
 # Define basic parameters
@@ -153,11 +154,10 @@ if (SPGLIB_INSTALL)
     endif ()
     install(TARGETS Spglib_fortran Spglib_fortran_include
             EXPORT SpglibTargets-fortran
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Spglib_Runtime
-            NAMELINK_COMPONENT Spglib_Development
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Spglib_Development
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Spglib_Development
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Spglib_Runtime
+            LIBRARY COMPONENT Spglib_Runtime NAMELINK_COMPONENT Spglib_Development
+            ARCHIVE COMPONENT Spglib_Development
+            PUBLIC_HEADER COMPONENT Spglib_Development
+            RUNTIME COMPONENT Spglib_Runtime
     )
     export_components(
             PROJECT Spglib

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -64,25 +64,30 @@ if (NOT CMAKE_Fortran_MODULE_DIRECTORY)
 endif ()
 
 #[=============================================================================[
+#                                Public targets                                #
+]=============================================================================]
+
+add_library(Spglib_fortran)
+add_library(Spglib::fortran ALIAS Spglib_fortran)
+
+#[=============================================================================[
 #                              External packages                              #
 ]=============================================================================]
 
-set(external_libs)
-include(FetchContent)
-
 # Get Spglib if it's run as stand-alone project
-if (NOT Spglib_SOURCE_DIR)
-    find_package(Spglib REQUIRED CONFIG)
+if (NOT TARGET Spglib::symspg)
+    find_package(Spglib CONFIG)
+    if (NOT Spglib_FOUND)
+        message(STATUS "Using bundled spglib sources")
+        add_subdirectory(${PROJECT_SOURCE_DIR}/.. _deps/spglib-build)
+    endif ()
 endif ()
-FetchContent_MakeAvailable(${external_libs})
 
 #[=============================================================================[
 #                               Main definition                               #
 ]=============================================================================]
 
-# Main fortran wrapper
-add_library(Spglib_fortran)
-add_library(Spglib::fortran ALIAS Spglib_fortran)
+# Define main target
 set_target_properties(Spglib_fortran PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ testing = [
 ]
 
 [tool.scikit-build]
-wheel.packages = ["python/spglib"]
+cmake.source-dir = "python"
+wheel.install-dir = "spglib"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["python/spglib/_version.py"]
 
@@ -93,6 +94,11 @@ sdist.include = ["python/spglib/_version.py"]
 SPGLIB_WITH_Python = "ON"
 SPGLIB_WITH_TESTS = "OFF"
 SPGLIB_USE_OMP = "OFF"
+
+[[tool.scikit-build.overrides]]
+if.env.CIBUILDWHEEL = true
+# Make sure cibuildwheel builds with a bundled spglib
+cmake.define.CMAKE_DISABLE_FIND_PACKAGE_Spglib = "ON"
 
 [tool.setuptools_scm]
 write_to = "python/spglib/_version.py"
@@ -211,6 +217,3 @@ disallow_incomplete_defs = true
 [tool.codespell]
 ignore-words = "docs/codespell.txt"
 skip = "docs/references.bib"
-
-[tool.check-wheel-contents]
-ignore = "W002"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,22 +102,6 @@ write_to = "python/spglib/_version.py"
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-extras = "test"
 test-command = "pytest {package}/test/functional/python"
-before-build = [
-    "cmake -B _build -DSPGLIB_WITH_TESTS=OFF -DCMAKE_BUILD_TYPE=Release",
-    "cmake --build _build --config Release",
-    "cmake --install _build --config Release --prefix {project}/_install",
-]
-
-[tool.cibuildwheel.linux]
-before-build = [
-    "cmake -B _build -DSPGLIB_WITH_TESTS=OFF -DCMAKE_BUILD_TYPE=Release",
-    "cmake --build _build",
-    "cmake --install _build",
-]
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
-
-[tool.cibuildwheel.macos]
-repair-wheel-command = "DYLD_LIBRARY_PATH=_install/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.pytest.ini_options]
 addopts = "-Werror -m 'not benchmark'"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,26 +31,37 @@ option(SPGLIB_SHARED_LIBS "Spglib: Build as a shared library" ${PROJECT_IS_TOP_L
 set(BUILD_SHARED_LIBS ${SPGLIB_SHARED_LIBS})
 
 #[=============================================================================[
+#                                Public targets                                #
+]=============================================================================]
+
+# Running `find_package(Python)` early to be able to define target with `Python_add_library`
+find_package(Python 3.9 COMPONENTS REQUIRED Interpreter Development.Module NumPy)
+Python_add_library(Spglib_python MODULE WITH_SOABI)
+add_library(Spglib::python ALIAS Spglib_python)
+
+#[=============================================================================[
 #                              External packages                              #
 ]=============================================================================]
 
-set(external_libs)
-include(FetchContent)
-
 # Get Spglib if it's run as stand-alone project
-if (NOT Spglib_SOURCE_DIR)
-    find_package(Spglib REQUIRED CONFIG)
+if (NOT TARGET Spglib::symspg)
+    find_package(Spglib CONFIG)
+    if (NOT Spglib_FOUND)
+        message(STATUS "Using bundled spglib sources")
+        add_subdirectory(${PROJECT_SOURCE_DIR}/.. _deps/spglib-build)
+    endif ()
 endif ()
-find_package(Python 3.9 COMPONENTS REQUIRED Interpreter Development.Module NumPy)
-FetchContent_MakeAvailable(${external_libs})
 
 #[=============================================================================[
 #                               Main definition                               #
 ]=============================================================================]
 
-Python_add_library(Spglib_python MODULE WITH_SOABI _spglib.c)
+# Define main target
 set_target_properties(Spglib_python PROPERTIES
         OUTPUT_NAME _spglib
+)
+target_sources(Spglib_python PRIVATE
+        _spglib.c
 )
 target_link_libraries(Spglib_python PRIVATE
         Spglib::symspg Python::NumPy

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -28,6 +28,8 @@ option(SPGLIB_SHARED_LIBS "Spglib: Build as a shared library" ${PROJECT_IS_TOP_L
 #                            Project configuration                            #
 ]=============================================================================]
 
+include(GNUInstallDirs)
+
 set(BUILD_SHARED_LIBS ${SPGLIB_SHARED_LIBS})
 
 #[=============================================================================[
@@ -59,6 +61,7 @@ endif ()
 # Define main target
 set_target_properties(Spglib_python PROPERTIES
         OUTPUT_NAME _spglib
+        INSTALL_RPATH "$<IF:$<BOOL:${APPLE}>,@loader_path,$ORIGIN>/${CMAKE_INSTALL_LIBDIR}"
 )
 target_sources(Spglib_python PRIVATE
         _spglib.c
@@ -83,45 +86,35 @@ add_custom_command(TARGET Spglib_python POST_BUILD
 )
 # On Windows make sure the dll files are in the build directory
 # https://stackoverflow.com/a/73550650
-if (CMAKE_IMPORT_LIBRARY_SUFFIX)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+    # This form works when no files are specified
     add_custom_command(TARGET Spglib_python POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:Spglib_python> ${CMAKE_CURRENT_BINARY_DIR}/spglib/
+            COMMAND ${CMAKE_COMMAND} -E copy -t ${CMAKE_CURRENT_BINARY_DIR}/spglib/ $<TARGET_RUNTIME_DLLS:Spglib_python>
             COMMAND_EXPAND_LISTS
     )
+else ()
+    if(WIN32)
+        add_custom_command(TARGET Spglib_python POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:Spglib_python> ${CMAKE_CURRENT_BINARY_DIR}/spglib/
+                COMMAND_EXPAND_LISTS
+        )
+    endif ()
 endif ()
 
 #[=============================================================================[
 #                              Install or Export                              #
 ]=============================================================================]
 
-if (NOT Python_INSTALL_DIR)
-    if (SKBUILD)
-        # If built with scikit-build-core, let it handle the installation
-        set(Python_INSTALL_DIR ".")
-    else ()
-        # Otherwise try to install in current python executable's setup
-        set(Python_INSTALL_DIR ${Python_SITEARCH})
-    endif ()
-endif ()
-if (SPGLIB_INSTALL)
+if (NOT SKBUILD AND SPGLIB_INSTALL)
+    message(WARNING "Installing the python bindings outside of scikit-build-core environment is not supported.")
+elseif (SPGLIB_INSTALL)
     if (TARGET Spglib_symspg)
-        # If Spglib is not already installed on the system, install it in ${Python_INSTALL_DIR}
-        # TODO: Cmake forces to install PUBLIC_HEADER when defined
-        # https://gitlab.kitware.com/cmake/cmake/-/issues/24326
+        # For windows systems we need to also install a copy of the dll files
         install(TARGETS Spglib_symspg
-                LIBRARY DESTINATION ${Python_INSTALL_DIR}/spglib/lib COMPONENT Spglib_Runtime
-                NAMELINK_COMPONENT Spglib_Development
-                ARCHIVE DESTINATION ${Python_INSTALL_DIR}/spglib/lib COMPONENT Spglib_Development
-                PUBLIC_HEADER DESTINATION ${Python_INSTALL_DIR}/spglib/include COMPONENT Spglib_Development
-                RUNTIME DESTINATION ${Python_INSTALL_DIR}/spglib COMPONENT Spglib_Runtime
+                RUNTIME DESTINATION . COMPONENT Spglib_Runtime
         )
     endif ()
     install(TARGETS Spglib_python
-            LIBRARY DESTINATION ${Python_INSTALL_DIR}/spglib COMPONENT Spglib_Runtime
+            LIBRARY DESTINATION . COMPONENT Spglib_Runtime
     )
-
-    # Install spglib module to local python path
-    if (NOT SKBUILD)
-        install(DIRECTORY spglib/ DESTINATION ${Python_INSTALL_DIR}/spglib COMPONENT Spglib_Runtime)
-    endif ()
 endif ()

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -42,33 +42,9 @@ from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
+from . import _spglib
 from ._compat.typing import TypeAlias
 from ._compat.warnings import deprecated
-
-try:
-    from . import _spglib
-except ImportError:
-    from ctypes import cdll
-
-    from ._compat.importlib.resources import as_file, files
-
-    root = files("spglib.lib")
-    for file in root.iterdir():
-        if "symspg." in file.name:
-            with as_file(file) as bundled_lib:
-                try:
-                    cdll.LoadLibrary(str(bundled_lib))
-                    from . import _spglib
-
-                    break
-                except ImportError as err:
-                    raise FileNotFoundError(
-                        "Could not load bundled Spglib C library"
-                    ) from err
-    else:
-        raise FileNotFoundError(
-            "Spglib C library is not installed and no bundled version was detected"
-        )
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,14 +82,13 @@ endif ()
 
 
 # Install
-if (NOT SKBUILD AND SPGLIB_INSTALL)
+if (SPGLIB_INSTALL)
     # Normal installation target to system. When using scikit-build this is installed again in python path
     install(TARGETS Spglib_symspg
             EXPORT SpglibTargets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Spglib_Runtime
-            NAMELINK_COMPONENT Spglib_Development
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Spglib_Development
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Spglib_Development
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Spglib_Runtime
+            LIBRARY COMPONENT Spglib_Runtime NAMELINK_COMPONENT Spglib_Development
+            ARCHIVE COMPONENT Spglib_Development
+            PUBLIC_HEADER COMPONENT Spglib_Development
+            RUNTIME COMPONENT Spglib_Runtime
     )
 endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,15 +23,15 @@ set(CMAKE_C_EXTENSIONS OFF)
 include(CMakeDependentOption)
 include(FeatureSummary)
 
-cmake_dependent_option(SPGLIB_TEST_COVERAGE "Spglib: Test with coverage" OFF "Spglib_IS_TOP_LEVEL" OFF)
-add_feature_info(Coverage SPGLIB_TEST_COVERAGE "Compile with test coverage")
-mark_as_advanced(SPGLIB_TEST_COVERAGE)
-if (Spglib_IS_TOP_LEVEL)
-    set(SPGLIB_USE_SANITIZER "" CACHE STRING "Spglib: Sanitizer used in compilation")
-endif ()
-mark_as_advanced(SPGLIB_USE_SANITIZER)
+option(SPGLIB_TEST_COVERAGE "Spglib: Test with coverage" OFF)
+set(SPGLIB_USE_SANITIZER "" CACHE STRING "Spglib: Sanitizer used in compilation")
 option(SPGLIB_WITH_Fortran "Spglib: Build Fortran interface" OFF)
 option(SPGLIB_WITH_Python "Spglib: Build Python interface" OFF)
+add_feature_info(Coverage SPGLIB_TEST_COVERAGE "Compile with test coverage")
+mark_as_advanced(
+        SPGLIB_TEST_COVERAGE
+        SPGLIB_USE_SANITIZER
+)
 
 #[=============================================================================[
 #                            Project configuration                            #
@@ -74,8 +74,14 @@ set(external_libs)
 include(FetchContent)
 
 # Get Spglib if it's run as stand-alone project
-if (NOT Spglib_SOURCE_DIR)
-    find_package(Spglib REQUIRED CONFIG)
+if (NOT TARGET Spglib::symspg)
+    set(spglib_find_package_args)
+    if (SPGLIB_WITH_Fortran)
+        list(APPEND
+                COMPONENTS Fortran
+        )
+    endif ()
+    find_package(Spglib REQUIRED CONFIG ${spglib_find_package_args})
 endif ()
 
 set(BUILD_GMOCK OFF)
@@ -86,14 +92,13 @@ FetchContent_Declare(GTest
         GIT_TAG v1.15.2
         FIND_PACKAGE_ARGS CONFIG
 )
-list(APPEND external_libs GTest)
 
 find_package(Threads REQUIRED)
 if (SPGLIB_WITH_Python)
     find_package(Python 3.9 REQUIRED)
 endif ()
 
-FetchContent_MakeAvailable(${external_libs})
+FetchContent_MakeAvailable(GTest)
 include(GoogleTest)
 
 #[=============================================================================[


### PR DESCRIPTION
Reworked a lot of the CMake build
- Python bindings installation outside of `scikit-build-core` is no longer supported. Avoids dangling files that cannot be removed due to lacking python package metadata files (`spglib.dist-info`)
- Reworked the detection of when the bundled project needs to be included:
  - Check for Target `Spglib::symspg` (more robust than checking for any cache variables)
  - Use `find_package` to check for system installed `Spglib`
    - Use [`CMAKE_DISABLE_FIND_PACKAGE_Spglib=ON`](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) to make sure the bundled version is used
    - Use [`CMAKE_REQUIRE_FIND_PACKAGE_Spglib=ON`](https://cmake.org/cmake/help/latest/variable/CMAKE_REQUIRE_FIND_PACKAGE_PackageName.html) to make sure a system version is used
  - If `find_package` failed (and `CMAKE_REQUIRE_FIND_PACKAGE_Spglib` was not set), use the bundled sources
- Removed the dynamic loading of the `spglib` C library, `libsymspg` must be resolved at build time
- Added `INSTALL_RPATH` for the python `_spglib` library pointing to `$ORIGIN/${CMAKE_INSTALL_LIBDIR}`. *If* you want to use a system installed library, there *must not* be a `libsysmspg` library there
- Reverted the `cibuildweel` workaround from #507

Depends-on: #458 

Closes #510 Closes #462