### PR TITLE
fix: Remove usage of `test.pypi.org`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,14 +36,7 @@ jobs:
           pattern: cibw-wheels-*
           path: dist
           merge-multiple: true
-      - name: Publish package to TestPyPI
-        if: ${{ contains(github.ref, 'rc') }}
-        # TODO: Maybe we can move this to main PyPI since it is marked rc
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository_url: https://test.pypi.org/legacy/
       - name: Publish package to PyPI
-        if: ${{ !contains(github.ref, 'rc') }}
         uses: pypa/gh-action-pypi-publish@release/v1
   release:
     needs: [ upload_pypi ]

--- a/docs/python-interface.md
+++ b/docs/python-interface.md
@@ -25,13 +25,6 @@ To install it use the standard pip install commands:
 $ pip install spglib
 ```
 
-Release candidates can be found at the equivalent [PyPI testing project page](https://pypi.org/project/spglib/).
-You can test a specific release candidate locally using the following command:
-
-```console
-$ pip install -i https://test.pypi.org/simple/ spglib==2.1.0rc1
-```
-
 ### Using conda
 
 We also maintain a [conda package](https://anaconda.org/conda-forge/spglib) which you


### PR DESCRIPTION
I recently reviewed the usage of `test.pypi.org` and found this is a significant issue, because dependencies, in this case [`numpy`](https://test.pypi.org/project/numpy/) is not guaranteed to be present there. Instead in order to get release candidates, the user should either:
```console
$ pip install --pre spglib
```
which would propagate to the dependencies as well, or simply
```
$ pip install spglib==x.y.zrc1
```