### PR TITLE
Fix references to outdated `master` branch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,4 +123,5 @@ linkcheck_anchors_ignore_for_url = [
 extlinks = {
     "issue": ("https://github.com/spglib/spglib/issues/%s", "issue %s"),
     "path": ("https://github.com/spglib/spglib/tree/develop/%s", "%s"),
+    "user": ("https://github.com/%s", "%s"),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@ extensions = [
     "myst_parser",
     "autodoc2",
     "sphinx.ext.doctest",
+    "sphinx.ext.extlinks",
 ]
 
 exclude_patterns = [
@@ -109,7 +110,17 @@ linkcheck_allowed_redirects = {
     r"https://spglib.readthedocs.io/.*": r"https://spglib.readthedocs.io/.*",
     r"https://docs.rs/crate/spglib/": r"https://docs.rs/crate/spglib/.*",
     r"https://github.com/chrisjsewell/sphinx-autodoc2": r"https://github.com/sphinx-extensions2/sphinx-autodoc2",
+    r"https://github.com/spglib/spglib/tree/.*": r"https://github.com/spglib/spglib/blob/.*",
 }
 linkcheck_anchors_ignore_for_url = [
     r"https://github.com",
 ]
+
+# -----------------------------------------------------------------------------
+# extlinks
+# -----------------------------------------------------------------------------
+
+extlinks = {
+    "issue": ("https://github.com/spglib/spglib/issues/%s", "issue %s"),
+    "path": ("https://github.com/spglib/spglib/tree/develop/%s", "%s"),
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,9 +61,9 @@ Spglib thrives from the contributions of the community, and we would like to tha
 
 The current main developers of Spglib are:
 
-- [Atsushi Togo] (National Institute for Materials Science)
-- [Kohei Shinohara]
-- [Cristian Le]
+- {user}`Atsushi Togo <atztogo>` (National Institute for Materials Science)
+- {user}`Kohei Shinohara <lan496>`
+- {user}`Cristian Le <LecrisUT>`
 
 ## Acknowledgments
 
@@ -76,9 +76,6 @@ Seto for the Crystallographic database, Jingheng Fu for layer group
 implementation, Juan Rodriguez-Carvajal for the Magnetic space-group database,
 Dimitar Pashov for the Fortran interface, and many other contributors.
 
-[atsushi togo]: https://github.com/atztogo
 [contributors]: https://github.com/spglib/spglib/graphs/contributors
-[cristian le]: https://github.com/LecrisUT
 [discussion]: https://github.com/spglib/spglib/discussions
 [issue]: https://github.com/spglib/spglib/issues
-[kohei shinohara]: https://github.com/lan496

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-The source code is downloaded at <https://github.com/spglib/spglib/archive/develop.zip> or you can
+The source code is downloaded at <https://github.com/spglib/spglib/releases> or you can
 git-clone the spglib repository by
 
 ```
@@ -51,16 +51,14 @@ way is recommended
 % cmake --install . --config Release
 ```
 
-The detail of the windows installation process is discussed at
-https://github.com/spglib/spglib/issues/118.
+The detail of the windows installation process is discussed in {issue}`118`.
 
 ## Usage
 
 1. Include `spglib.h`
 2. Link `libsymspg.a` or `libsymspg.so`
-3. A compilation example is shown in
-   [example/README.md](https://github.com/spglib/spglib/blob/develop/example/README.md).
+3. A compilation example is shown in {path}`example/README.md`.
 
 ## Example
 
-A few examples are found in [example](https://github.com/spglib/spglib/tree/master/example) directory.
+A few examples are found in {path}`example` directory.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -7,12 +7,9 @@ level, but not supported as well as the Python interface.
 
 ## Fortran interface
 
-Fortran interface [spglib.f90](https://github.com/spglib/spglib/blob/master/example/example.f90) is found
-in [example](https://github.com/spglib/spglib/tree/master/example) directory.
+Fortran interface is found in {path}`fortran/spglib_f08.F90`.
 This fortran interface is originally contributed by Dimitar Pashov and has been
 updated by some other people.
-[spglib_f.c](https://github.com/spglib/spglib/blob/master/src/spglib_f.c) is
-obsolete and is not recommended to use.
 
 ## Rust interface
 
@@ -45,5 +42,4 @@ Some more options are shown with `--help` option:
 % ruby symPoscar.rb --help
 ```
 
-The way to compile the ruby module is explained in
-[ruby/README](https://github.com/spglib/spglib/blob/develop/ruby/README.md).
+The way to compile the ruby module is explained in {path}`ruby/README.md`.

--- a/docs/python-interface.md
+++ b/docs/python-interface.md
@@ -133,7 +133,7 @@ In version 1.8.3 or later, the version number is obtained by
 
 ## Example
 
-Examples are found in [examples](https://github.com/spglib/spglib/tree/master/python/examples) directory.
+Examples are found in {path}`example/python_api` directory.
 
 (py_variables)=
 


### PR DESCRIPTION
After removing the outdated branches following https://github.com/spglib/spglib/issues/512#issuecomment-2234790304, there apparently were links that pointed to outdated files. This PR fixes this issue and introduces the roles to simplify the linkage.

Currently the `linkcheck` will fail on PRs since the links to `path` point statically to `develop` branch. I will probably adapt a similar fix that I have investigated in `tmt`, where the link construction points to `branch`/`tag`/`commit`, whichever it manages to detect first.