### PR TITLE
Convert warnings to error inside the CI

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -106,9 +106,10 @@ jobs:
       - uses: lukka/get-cmake@latest
       - name: Install spglib and dependencies
         run: |
-          pip install -e .[test] ${{ matrix.pre && '--pre' }}
+          python3 -W ignore -m pip install --upgrade pip
+          python3 -m pip install -e .[test] ${{ matrix.pre && '--pre' }}
           # If numpy-runtime (${{ matrix.numpy-runtime }}) is undefined, the following has no effect
-          pip install "numpy${{ matrix.numpy-runtime }}"
+          python3 -m pip install "numpy${{ matrix.numpy-runtime }}"
       - name: Test spglib
         run: pytest
 

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -91,8 +91,10 @@ jobs:
     env:
       # This is a comma-separated list, add filters as needed with relevant documentation
       #   error: Treat all python warnings as error (always use)
+      #   pip._internal.metadata.importlib._dists: https://github.com/pypa/pip/issues/11684
       PYTHONWARNINGS: "\
         error,\
+        ignore::DeprecationWarning:pip._internal.metadata.importlib._dists,\
         "
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -88,6 +88,12 @@ jobs:
             numpy-runtime: "<2.0"
           - python-version: "3.12"
             numpy-runtime: "<2.0"
+    env:
+      # This is a comma-separated list, add filters as needed with relevant documentation
+      #   error: Treat all python warnings as error (always use)
+      PYTHONWARNINGS: "\
+        error,\
+        "
     steps:
       - uses: actions/checkout@v4
         with:

--- a/cmake/CMakePresets-CI.json
+++ b/cmake/CMakePresets-CI.json
@@ -33,7 +33,13 @@
           "value": true
         }
       },
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "uninitialized": true
+      },
       "errors": {
+        "dev": true,
         "deprecated": true
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,11 +119,11 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 repair-wheel-command = "DYLD_LIBRARY_PATH=_install/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.pytest.ini_options]
-addopts = "-Werror -m 'not benchmark'"
+addopts = "-m 'not benchmark'"
 testpaths = ["test/functional/python"]
 markers = [
     # Define benchmark marker to avoid warnings of marker not defined
-    "benchmark: benchmarking tets",
+    "benchmark: benchmarking tests",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Using `PYTHONWARNINGS` environment variable to catch all in both `pip install` and `pytest`. Additional filters should be added as needed with appropriate documentations

This addresses an issue that if there are warnings during the `pip install`, these are generally ignored due to lack of visibility. Therefore at least within the CI we should catch all warnings and address them