### PR TITLE
Expose `spg_get_symmetry_from_database` in the Fortran interface

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,12 @@ GitHub release pages and in the git history.
 
 ## \[Unreleased\]
 
+### Fortran API
+
+- Expose `spg_get_symmetry_from_database`.
+
+Users can now access the rotation and translation operations from the database, provided the Hall number.
+
 ## v2.5.0 (9 Jul. 2024)
 
 ### Main changes

--- a/fortran/spglib_f08.F90
+++ b/fortran/spglib_f08.F90
@@ -23,6 +23,7 @@ module spglib_f08
             & spg_get_stabilized_reciprocal_mesh, &
             & spg_get_error_code, spg_get_error_message, &
             & spg_get_spacegroup_type, &
+            & spg_get_symmetry_from_database, &
             & spg_get_magnetic_spacegroup_type, &
             & version, version_full, commit, &
             & spg_get_version, spg_get_version_full, spg_get_commit
@@ -199,6 +200,15 @@ module spglib_f08
             real(c_double), intent(in), value :: symprec
             integer(c_int) :: retval
         end function spg_get_symmetry
+
+        function spg_get_symmetry_from_database(rotation, translation, &
+            & hall_number) bind(c) result(retval)
+            import c_int, c_double
+            integer(c_int), intent(out) :: rotation(3, 3, *)
+            real(c_double), intent(out) :: translation(3, *)
+            integer(c_int), intent(in), value :: hall_number
+            integer(c_int) :: retval
+        end function spg_get_symmetry_from_database
 
         function spgat_get_symmetry(rotation, translation, max_size, lattice, &
              & position, types, num_atom, symprec, angle_tolerance) bind(c) &


### PR DESCRIPTION
I added a simple Fortran wrapper for spg_get_symmetry_from_database based on spg_get_symmetry wrapper.