### PR TITLE
Increase warning `stacklevel` 

### DIFF
--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -116,6 +116,7 @@ class DictInterface(Mapping[str, "Any"]):
             f"dict interface ({self.__class__.__name__}['{key}']) is deprecated."
             f"Use attribute interface ({self.__class__.__name__}.{key}) instead",
             DeprecationWarning,
+            stacklevel=2,
         )
         return dataclasses.asdict(self)[key]
 
@@ -454,6 +455,7 @@ def get_version():
         "get_version() is deprecated. Use __version__ for the python binding"
         "version and get_spg_version for the detected spglib library version.",
         DeprecationWarning,
+        stacklevel=2,
     )
     _set_no_error()
     return _spglib.version_tuple()
@@ -640,6 +642,7 @@ def get_symmetry(
         warnings.warn(
             "Use get_magnetic_symmetry() for cell with magnetic moments.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return get_magnetic_symmetry(
             cell,
@@ -2137,6 +2140,7 @@ def get_hall_number_from_symmetry(rotations, translations, symprec=1e-5) -> int 
         "get_hall_number_from_symmetry() is deprecated. "
         "Use get_spacegroup_type_from_symmetry() instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
 
     r = np.array(rotations, dtype="intc", order="C")


### PR DESCRIPTION
Currently `stacklevel` for warning is too low (default as `1`), which would point to the **source of the deprecated API** (in this case `spglib` itself), we should [increase the `stacklevel` to refer to **the deprecated API's caller**](https://docs.python.org/3/library/warnings.html#warnings.warn):

> The stacklevel argument can be used by wrapper functions written in Python, like this:

> def deprecated_api(message):
    warnings.warn(message, DeprecationWarning, stacklevel=2)

> This makes the warning refer to deprecated_api’s caller, rather than to the source of deprecated_api itself (since the latter would defeat the purpose of the warning message).

For example [in our unit test](https://github.com/materialsproject/pymatgen/actions/runs/12080508584/job/33687985515?pr=4205), the warning points directly to the source (`spglib`), and making it really hard to figure out what actually triggered the warning:
```
../../../micromamba/envs/pmg/lib/python3.12/site-packages/spglib/spglib.py:115
  /home/runner/micromamba/envs/pmg/lib/python3.12/site-packages/spglib/spglib.py:115: DeprecationWarning: dict interface (SpglibDataset['number']) is deprecated.Use attribute interface ({self.__class__.__name__}.{key}) instead
    warnings.warn(
```
