### PR TITLE
ci: Update readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,11 @@ python:
       extra_requirements:
         - docs
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3"
+    python: latest
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
I thought I had already set `sphinx.configuration` for spglib, but apparently not. I've also simplified a few aliases