### PR TITLE
doc: Allow building documentations without C library

### DIFF
--- a/.github/workflows/step_test-docs.yaml
+++ b/.github/workflows/step_test-docs.yaml
@@ -19,6 +19,9 @@ jobs:
           # Run default html builder with warnings as error
           - builder: html
             args: -W
+    env:
+      # Defined and used in pyproject.toml
+      BUILD_DOCS: ${{ ( matrix.builder != 'doctest' )  }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ if.env.CIBUILDWHEEL = true
 # Make sure cibuildwheel builds with a bundled spglib
 cmake.define.CMAKE_DISABLE_FIND_PACKAGE_Spglib = "ON"
 
+# Do not build spglib C library on documentation builders
+[[tool.scikit-build.overrides]]
+if.any.env.READTHEDOCS = true
+if.any.env.BUILD_DOCS = true
+wheel.cmake = false
+
 [tool.setuptools_scm]
 write_to = "python/spglib/_version.py"
 

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -42,7 +42,20 @@ from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
-from . import _spglib
+try:
+    from . import _spglib
+except ImportError:
+    import os
+
+    # If we are only building the documentation create a stub _spglib
+    if (
+        os.getenv("READTHEDOCS", "False").lower() == "true"
+        or os.getenv("BUILD_DOCS", "False").lower() == "true"
+    ):
+        _spglib = object  # type: ignore[assignment]
+    else:
+        # Otherwise re-raise the error
+        raise
 from ._compat.typing import TypeAlias
 from ._compat.warnings import deprecated
 


### PR DESCRIPTION
For now this is just a proof of concept, the implementation will depend on how https://github.com/scikit-build/scikit-build-core/issues/978 goes.

Depends on: #520