### PR TITLE
cmake: Simplify `install` instruction a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (SPGLIB_INSTALL)
     configure_file(cmake/spglib.pc.in spglib.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib.pc
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-            COMPONENT Spglib_Development)
+    )
 
     # cmake export files
     write_basic_package_version_file(
@@ -157,7 +157,7 @@ if (SPGLIB_INSTALL)
             ${CMAKE_CURRENT_BINARY_DIR}/SpglibConfig.cmake
             cmake/PackageCompsHelper.cmake
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Spglib
-            COMPONENT Spglib_Development)
+    )
     export_components(LIB_TYPE ${Spglib_LIB_TYPE})
 endif ()
 

--- a/cmake/PackageCompsHelper.cmake
+++ b/cmake/PackageCompsHelper.cmake
@@ -448,7 +448,7 @@ function(export_components)
             FILE ${CmakeTargetFile}
             NAMESPACE ${ARGS_PROJECT}::
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ARGS_PROJECT}
-            COMPONENT ${ARGS_PROJECT}_Development)
+    )
     export(EXPORT ${CmakeTarget}
             FILE ${${ARGS_PROJECT}_BINARY_DIR}/${CmakeTargetFile}
             NAMESPACE ${ARGS_PROJECT}::)

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -154,10 +154,6 @@ if (SPGLIB_INSTALL)
     endif ()
     install(TARGETS Spglib_fortran Spglib_fortran_include
             EXPORT SpglibTargets-fortran
-            LIBRARY COMPONENT Spglib_Runtime NAMELINK_COMPONENT Spglib_Development
-            ARCHIVE COMPONENT Spglib_Development
-            PUBLIC_HEADER COMPONENT Spglib_Development
-            RUNTIME COMPONENT Spglib_Runtime
     )
     export_components(
             PROJECT Spglib
@@ -166,16 +162,13 @@ if (SPGLIB_INSTALL)
     )
     install(FILES try_compile.f90
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Spglib
-            COMPONENT Spglib_Development
     )
     install(FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/spglib_f08.mod
             DESTINATION ${CMAKE_INSTALL_MODULEDIR}
-            COMPONENT Spglib_Development
     )
     configure_file(spglib_f08.pc.in spglib_f08.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/spglib_f08.pc
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-            COMPONENT Spglib_Development
     )
 endif ()
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,7 @@
-set_target_properties(Spglib_symspg PROPERTIES
-        PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/spglib.h
+target_sources(Spglib_symspg PUBLIC
+    FILE_SET HEADERS
+    FILES
+        spglib.h
 )
 
 target_include_directories(Spglib_symspg PUBLIC

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -111,10 +111,10 @@ elseif (SPGLIB_INSTALL)
     if (TARGET Spglib_symspg)
         # For windows systems we need to also install a copy of the dll files
         install(TARGETS Spglib_symspg
-                RUNTIME DESTINATION . COMPONENT Spglib_Runtime
+                RUNTIME DESTINATION .
         )
     endif ()
     install(TARGETS Spglib_python
-            LIBRARY DESTINATION . COMPONENT Spglib_Runtime
+            LIBRARY DESTINATION .
     )
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ endif ()
 if (SPGLIB_INSTALL)
     # Normal installation target to system. When using scikit-build this is installed again in python path
     install(TARGETS Spglib_symspg
-            EXPORT SpglibTargets
+        EXPORT SpglibTargets
+        FILE_SET HEADERS
     )
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,9 +86,5 @@ if (SPGLIB_INSTALL)
     # Normal installation target to system. When using scikit-build this is installed again in python path
     install(TARGETS Spglib_symspg
             EXPORT SpglibTargets
-            LIBRARY COMPONENT Spglib_Runtime NAMELINK_COMPONENT Spglib_Development
-            ARCHIVE COMPONENT Spglib_Development
-            PUBLIC_HEADER COMPONENT Spglib_Development
-            RUNTIME COMPONENT Spglib_Runtime
     )
 endif ()


### PR DESCRIPTION
`install(COMPONENT)` is not that useful, might as well make the cmake file more compact. `target_sources(FILE_SET)` is supposed to be the recommended way of declaring public/private headers, but not sure if it can be made to work for Fortran modules as well.