### PR TITLE
Make licence information compatibile with new version of scikit-build…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "scikit_build_core.build"
 name = "spglib"
 requires-python = ">=3.9"
 description = "This is the spglib module."
-license = { text = "BSD-3-Clause" }
-license-files = { paths = ["COPYING"] }
+license = "BSD-3-Clause"
+license-files = ["COPYING"]
 readme = "python/README.rst"
 dynamic = ["version"]
 dependencies = [
@@ -32,7 +32,6 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: C",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
With new python, build of spglib failed due to wrong format of licence-files. Moreover, specifying licence informations both by classifier and SPDX licence is forbidden, same as both by licence-files and licence, when licence is not in SPDX format.      