### PR TITLE
fix: Add missing `license-files`

### DIFF
--- a/.distro/spglib.spec
+++ b/.distro/spglib.spec
@@ -97,7 +97,7 @@ tomcli set pyproject.toml arrays replace "build-system.requires" "numpy.*" "nump
 
 %if %{with python}
 %pyproject_install
-%pyproject_save_files spglib
+%pyproject_save_files -l spglib
 %endif
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ name = "spglib"
 requires-python = ">=3.9"
 description = "This is the spglib module."
 license = "BSD-3-Clause"
+license-files = ["COPYING"]
 readme = "python/README.rst"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
Without it `License-File` is missing in the python metadata, which is needed for Fedora `%license`

Fixup for #554 