### PR TITLE
Release v2.6.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ GitHub release pages and in the git history.
 
 ## [Unreleased]
 
+## v2.6.0 (10 Mar. 2025)
+
 ### Fortran API
 
 - Expose `spg_get_symmetry_from_database`.


### PR DESCRIPTION
I have already pushed the `v2.6.0` tag because I didn't understand well the order of commands for releasing...