### PR TITLE
fix: linkcheck issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,8 +76,11 @@ linkcheck_ignore = [
     r"https://www.jstor.org/.*",
     # Cannot check for 403 error only
     r"https://doi.org/10.1002/qua.20747",
-    r"https://github.com/spglib/spglib/pull/.*",
     r"https://doi.org/10.1080/27660400.2024.2384822",
+    # Getting 403 error (maybe because cloudflare)
+    r"https://.*\.iucr.org/",
+    # No need to check these
+    r"https://github.com/spglib/spglib/pull/.*",
 ]
 linkcheck_allowed_redirects = {
     r"https://doi.org/.*": r".*",

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ The detailed algorithm of spglib is described the following text:
 ## Requirements
 
 - C standard: As of version 2.1.0, Spglib explicitly enforces a minimum standard of
-  [C11](https://en.cppreference.com/w/c/11)
+  [C11](https://en.cppreference.com/w/c/11.html)
 
 ## Features
 


### PR DESCRIPTION
- https://en.cppreference.com/w/c/11 page, just needed to be more specific
- https://dictionary.iucr.org/ getting 403 issues now, maybe due to cloudflare. I've tried to fix it by adding `User-Agent` header, but that didn't really help.