### PR TITLE
PR to fix (python) get_spacegroup_type_from_symmetry

### DIFF
--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -1155,7 +1155,7 @@ def get_spacegroup_type_from_symmetry(
     if lattice is None:
         _lattice = np.eye(3, dtype="double", order="C")
     else:
-        _lattice = np.array(lattice, dtype="double", order="C")
+        _lattice = np.array(np.transpose(lattice), dtype="double", order="C")
 
     _set_no_error()
 

--- a/test/functional/python/test_spacegrouop_type_from_symmetry.py
+++ b/test/functional/python/test_spacegrouop_type_from_symmetry.py
@@ -8,6 +8,7 @@ import pytest
 from spglib import (
     get_spacegroup_type,
     get_spacegroup_type_from_symmetry,
+    get_symmetry_dataset,
 )
 
 if TYPE_CHECKING:
@@ -36,3 +37,36 @@ def test_spacegroup_type_from_symmetry(
     assert spgtype.number == dataset.number
     spgtype_ref = get_spacegroup_type(dataset.hall_number)
     assert spgtype == spgtype_ref
+
+
+def test_spacegroup_type_from_symmetry_with_oblique_basis_vectors():
+    """Test spacegroup_type_from_symmetry with oblique basis vectors."""
+    lattice = [
+        [0.0000, 6.4345, 1.8319],
+        [5.245, -6.4345, 0.0000],
+        [0.0000, 0.0000, -3.6638],
+    ]
+    position = [
+        [0.6416, 0.7350, 0.0708],
+        [0.8284, 0.2350, 0.4142],
+        [0.3584, 0.2650, 0.4292],
+        [0.1716, 0.7650, 0.5858],
+        [0.6994, 0.5334, 0.2150],
+        [0.3674, 0.0334, 0.2990],
+        [0.3006, 0.4666, 0.5156],
+        [0.0000, 0.0000, 0.5902],
+        [0.0000, 0.5000, 0.8402],
+        [0.6326, 0.9666, 0.9316],
+    ]
+    types = [1, 1, 1, 1, 6, 6, 6, 6, 6, 6]
+
+    dataset = get_symmetry_dataset((lattice, position, types), symprec=1e-5)
+    assert dataset.hall_number == 212
+
+    spg_type = get_spacegroup_type_from_symmetry(
+        dataset.rotations,
+        dataset.translations,
+        lattice=lattice,
+        symprec=1e-5,
+    )
+    assert spg_type.hall_number == 212

--- a/test/functional/python/test_spacegrouop_type_from_symmetry.py
+++ b/test/functional/python/test_spacegrouop_type_from_symmetry.py
@@ -41,6 +41,7 @@ def test_spacegroup_type_from_symmetry(
 
 def test_spacegroup_type_from_symmetry_with_oblique_basis_vectors():
     """Test spacegroup_type_from_symmetry with oblique basis vectors."""
+    # Structure derived from 1509692 in the crystallography open database.
     lattice = [
         [0.0000, 6.4345, 1.8319],
         [5.245, -6.4345, 0.0000],


### PR DESCRIPTION
This PR will fix the bug in the python interface of `get_spacegroup_type_from_symmetry`. The bug is that `lattice` is not transposed.