### PR TITLE
Update document for (spg_)get_spacegroup_type_from_symmetry

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -378,13 +378,17 @@ SpglibSpacegroupType spg_get_spacegroup_type_from_symmetry(
 );
 ```
 
-The `SpglibSpacegroupType` structure is explained at {ref}`api_spg_spacegroup_type`.
-The parameter `lattice` is used as the distance measure for `symprec`. If it
-is unknown, the following may be a reasonable choice.
+The `SpglibSpacegroupType` structure is explained at
+{ref}`api_spg_spacegroup_type`. The parameter `lattice` should be the same as
+that used to find `rotations` and `translations`. If it is unknown, the
+following may be a possible choice:
 
 ```
 lattice[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 ```
+
+unless the `rotations` and `translations` were obtained for an unusual (very
+oblique) choice of basis vectors.
 
 ## Magnetic symmetry
 

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -1134,7 +1134,7 @@ def get_spacegroup_type_from_symmetry(
     lattice : array_like, optional
         Basis vectors a, b, c given in row vectors. Default is None, which gives
         unit matrix. This should be the same as that used to find ``rotations``
-        and ``translations`. If it is unknown, the cubic basis vector may be a
+        and ``translations``. If it is unknown, the cubic basis vector may be a
         possible choice unless the ``rotations`` and ``translations`` were
         obtained for an unusual (very oblique) choice of basis vectors.
         shape=(3, 3), order='C', dtype='double'

--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -1119,10 +1119,9 @@ def get_spacegroup_type_from_symmetry(
     """Return space-group type information from symmetry operations.
 
     This is expected to work well for the set of symmetry operations whose
-    distortion is small. The aim of making this feature is to find space-group-type
-    for the set of symmetry operations given by the other source than spglib. The
-    parameter ``lattice`` is used as the distance measure for ``symprec``. If this
-    is not given, the cubic basis vector whose lengths are one is used.
+    distortion is small. The aim of making this feature is to find
+    space-group-type for the set of symmetry operations given by the other
+    source than spglib.
 
     Parameters
     ----------
@@ -1133,8 +1132,11 @@ def get_spacegroup_type_from_symmetry(
         Vector parts of space group operations.
         shape=(n_operations, 3), order='C', dtype='double'
     lattice : array_like, optional
-        Basis vectors a, b, c given in row vectors. This is used as the measure of
-        distance. Default is None, which gives unit matrix.
+        Basis vectors a, b, c given in row vectors. Default is None, which gives
+        unit matrix. This should be the same as that used to find ``rotations``
+        and ``translations`. If it is unknown, the cubic basis vector may be a
+        possible choice unless the ``rotations`` and ``translations`` were
+        obtained for an unusual (very oblique) choice of basis vectors.
         shape=(3, 3), order='C', dtype='double'
     symprec: float
         See :func:`get_symmetry`.


### PR DESCRIPTION
~~@LecrisUT, I could not build document locally. Could you tell me what is the best way to check the doc build?~~

#584 revealed that the `lattice` parameter of `(spg_)get_spacegroup_type_from_symmetry` is necessary to transform symmetry operations in a reasonable form when the matrix representations of those operations were obtained with respect to oblique basis vectors. Following this, the documentation has been updated.