### PR TITLE
ci: Drop windows_2019 runner

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -29,8 +29,6 @@ jobs:
             toolchain: macos
           - os: macos-latest
             toolchain: macos
-          - os: windows-2019
-            toolchain: windows
           - os: windows-latest
             toolchain: windows
     steps:


### PR DESCRIPTION
It has already been dropped by github

Closes #587