### PR TITLE
Improve docstring of std_lattice of SpglibDataset

### DIFF
--- a/python/spglib/spglib.py
+++ b/python/spglib/spglib.py
@@ -218,7 +218,7 @@ class SpglibDataset(DictInterface):
     """
     # Idealized standardized unit cell
     std_lattice: NDArray[np.double]
-    """Basis vectors a, b, c of a standardized cell in row vectors.
+    """Basis vectors a, b, c of an idealized standardized cell in row vectors.
 
     shape=(3, 3), order='C', dtype='double'
     """


### PR DESCRIPTION
Hello!

To my understanding of the spglib's documentation ``SpglibDataset.std_lattice`` is an idealised standardised lattice.

Here is an example to illustrate it

### Code example

```
import spglib
import numpy as np

print(f"spglib version: {spglib.__version__}\n")

# Example structure
basis_vectors = np.diag([1, 1, 1])
atomic_points = [[0, 0, 0]]
types = [1]

# Rotate around z axis
theta = 42/180 * np.pi
R = np.array(
    [
        [np.cos(theta), -np.sin(theta), 0],
        [np.sin(theta), np.cos(theta), 0],
        [0, 0, 1],
    ]
)
basis_vectors = basis_vectors @ R.T

# Get a dataset
dataset = spglib.get_symmetry_dataset((basis_vectors, atomic_points, types))

# Print some info about the basis vectors
print(f"original basis vectors\n\n{basis_vectors}\n")
print(f"dataset.std_lattice\n\n{dataset.std_lattice}\n")
```

### Code output

```
spglib version: 2.6.0

original basis vectors

[[ 0.74314483  0.66913061  0.        ]
 [-0.66913061  0.74314483  0.        ]
 [ 0.          0.          1.        ]]

dataset.std_lattice

[[1. 0. 0.]
 [0. 1. 0.]
 [0. 0. 1.]]
```

### Visualisation of two cells from code example

<img width="612" height="363" alt="wulfric-plot" src="https://github.com/user-attachments/assets/8ab82f6e-c78a-4e7e-adfe-32d849472da5" />

As one can see the ``dataset.std_lattice`` is an idealised one, according to [docs](https://spglib.readthedocs.io/en/stable/definition.html#def-idealize-cell).

Proposed changes make this fact more clear in the docs.

Best,
Andrey
