### PR TITLE
fix: Build python bindings in the build-dir `spglib` subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,10 @@ if (SPGLIB_INSTALL)
     )
 
     # cmake export files
+    if(NOT PROJECT_VERSION)
+            # Fallback if setuptools_scm / DynamicVersion.cmake failed
+            set(PROJECT_VERSION "0.0.0")
+    endif()
     write_basic_package_version_file(
             ${CMAKE_CURRENT_BINARY_DIR}/SpglibConfigVersion.cmake
             VERSION ${PROJECT_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,6 @@ if (SPGLIB_INSTALL)
     )
 
     # cmake export files
-    if(NOT PROJECT_VERSION)
-            # Fallback if setuptools_scm / DynamicVersion.cmake failed
-            set(PROJECT_VERSION "0.0.0")
-    endif()
     write_basic_package_version_file(
             ${CMAKE_CURRENT_BINARY_DIR}/SpglibConfigVersion.cmake
             VERSION ${PROJECT_VERSION}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -84,10 +84,15 @@ endif ()
 file(COPY spglib
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 # Link the built library to the package in the binary directory
+if (WIN32)
+    set(_cmake_link_mode copy)  # require admin to create symlink on Win
+else ()
+    set(_cmake_link_mode create_symlink)
+endif ()
 add_custom_command(TARGET Spglib_python POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E create_symlink
-        $<TARGET_FILE:Spglib_python>
-        ${CMAKE_CURRENT_BINARY_DIR}/spglib/$<TARGET_FILE_NAME:Spglib_python>
+    COMMAND ${CMAKE_COMMAND} -E ${_cmake_link_mode}
+    $<TARGET_FILE:Spglib_python>
+    ${CMAKE_CURRENT_BINARY_DIR}/spglib/$<TARGET_FILE_NAME:Spglib_python>
 )
 # On Windows make sure the dll files are in the build directory
 # https://stackoverflow.com/a/73550650

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -82,6 +82,10 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/spglib/_version.py)
     configure_file(_version.py.in spglib/_version.py)
 endif ()
 
+# Copy all python packages to the build directory
+file(COPY spglib
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+
 # On Windows make sure the dll files are in the build directory
 # https://stackoverflow.com/a/73550650
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,6 +63,7 @@ endif ()
 set_target_properties(Spglib_python PROPERTIES
         OUTPUT_NAME _spglib
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spglib
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spglib
         INSTALL_RPATH "$<IF:$<BOOL:${APPLE}>,@loader_path,$ORIGIN>/${CMAKE_INSTALL_LIBDIR}"
 )
 target_sources(Spglib_python PRIVATE

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -62,6 +62,7 @@ endif ()
 # Define main target
 set_target_properties(Spglib_python PROPERTIES
         OUTPUT_NAME _spglib
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spglib
         INSTALL_RPATH "$<IF:$<BOOL:${APPLE}>,@loader_path,$ORIGIN>/${CMAKE_INSTALL_LIBDIR}"
 )
 target_sources(Spglib_python PRIVATE
@@ -80,20 +81,6 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/spglib/_version.py)
     configure_file(_version.py.in spglib/_version.py)
 endif ()
 
-# Copy all python packages to the build directory
-file(COPY spglib
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-# Link the built library to the package in the binary directory
-if (WIN32)
-    set(_cmake_link_mode copy)  # require admin to create symlink on Win
-else ()
-    set(_cmake_link_mode create_symlink)
-endif ()
-add_custom_command(TARGET Spglib_python POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E ${_cmake_link_mode}
-    $<TARGET_FILE:Spglib_python>
-    ${CMAKE_CURRENT_BINARY_DIR}/spglib/$<TARGET_FILE_NAME:Spglib_python>
-)
 # On Windows make sure the dll files are in the build directory
 # https://stackoverflow.com/a/73550650
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)


### PR DESCRIPTION
fix #552

The original issue turns out to be [Windows requires Admin to create symlink by default](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links#default-values):
```
EXEC : CMake error : failed to create symbolic link 'C:/Users/Yang/AppData/Local/Temp/tmph2mhsunn/build/python/spglib/_spglib.cp313-win_amd64.pyd': A required privilege is not held by the client. [C:\Users\Yang\AppData\Local\Temp\tmph2mhsunn\build\python\Spglib_python.vcxproj]
```

Tested on my Windows 11 24H2 machine
