### PR TITLE
Format pointer alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ IncludeBlocks: Preserve
 QualifierAlignment: Right
 IndentPPDirectives: BeforeHash
 BreakAfterAttributes: Always
+PointerAlignment: Right

--- a/python/py_bindings.cpp
+++ b/python/py_bindings.cpp
@@ -18,7 +18,7 @@ py::str spglib::version_string() { return spg_get_version(); }
 py::str spglib::version_full() { return spg_get_version_full(); }
 py::str spglib::commit() { return spg_get_commit(); }
 
-py::list build_python_list_from_dataset(SpglibDataset* dataset) {
+py::list build_python_list_from_dataset(SpglibDataset *dataset) {
     py::list array{21};
     array[0] = dataset->spacegroup_number;
     array[1] = dataset->hall_number;
@@ -110,7 +110,7 @@ py::list build_python_list_from_dataset(SpglibDataset* dataset) {
     return array;
 }
 
-py::list build_python_list_from_magnetic_dataset(SpglibMagneticDataset* dataset,
+py::list build_python_list_from_magnetic_dataset(SpglibMagneticDataset *dataset,
                                                  int tensor_rank) {
     py::list array{19};
     array[0] = dataset->uni_number;
@@ -203,7 +203,7 @@ py::list build_python_list_from_magnetic_dataset(SpglibMagneticDataset* dataset,
 }
 
 py::list build_python_list_from_spacegroup_type(
-    SpglibSpacegroupType& spg_type) {
+    SpglibSpacegroupType &spg_type) {
     py::list array{12};
     array[0] = spg_type.number;
     array[1] = spg_type.international_short;
@@ -221,7 +221,7 @@ py::list build_python_list_from_spacegroup_type(
 }
 
 py::list build_python_list_from_magnetic_spacegroup_type(
-    SpglibMagneticSpacegroupType& spg_type) {
+    SpglibMagneticSpacegroupType &spg_type) {
     py::list array{6};
     array[0] = spg_type.uni_number;
     array[1] = spg_type.litvin_number;
@@ -235,7 +235,7 @@ py::list build_python_list_from_magnetic_spacegroup_type(
 std::optional<py::list> spglib::dataset(
     array_double lattice, array_double positions, array_int atom_types,
     py::int_ hall_number, py::float_ symprec, py::float_ angle_tolerance) {
-    SpglibDataset* dataset;
+    SpglibDataset *dataset;
     if ((dataset = spgat_get_dataset_with_hall_number(
              (double (*)[3])lattice.data(), (double (*)[3])positions.data(),
              atom_types.data(), atom_types.size(), hall_number, symprec,
@@ -250,7 +250,7 @@ std::optional<py::list> spglib::layer_dataset(array_double lattice,
                                               array_int atom_types,
                                               py::int_ aperiodic_dir,
                                               py::float_ symprec) {
-    SpglibDataset* dataset;
+    SpglibDataset *dataset;
     if ((dataset = spg_get_layer_dataset(
              (double (*)[3])lattice.data(), (double (*)[3])positions.data(),
              atom_types.data(), atom_types.size(), aperiodic_dir, symprec)) ==
@@ -264,7 +264,7 @@ std::optional<py::list> spglib::magnetic_dataset(
     array_double lattice, array_double positions, array_int atom_types,
     array_double magmoms, py::int_ tensor_rank, py::bool_ is_axial,
     py::float_ symprec, py::float_ angle_tolerance, py::float_ mag_symprec) {
-    SpglibMagneticDataset* dataset;
+    SpglibMagneticDataset *dataset;
     if ((dataset = spgms_get_magnetic_dataset(
              (double (*)[3])lattice.data(), (double (*)[3])positions.data(),
              atom_types.data(), magmoms.data(), tensor_rank, positions.shape(0),
@@ -306,7 +306,7 @@ std::optional<py::list> spglib::magnetic_spacegroup_type_from_symmetry(
     array_double lattice, py::float_ symprec) {
     auto msg_type = spg_get_magnetic_spacegroup_type_from_symmetry(
         (int (*)[3][3])rotations.data(), (double (*)[3])translations.data(),
-        (int*)time_reversals.data(), time_reversals.size(),
+        (int *)time_reversals.data(), time_reversals.size(),
         (double (*)[3])lattice.data(), symprec);
     if (msg_type.number == 0) return {};
     return build_python_list_from_magnetic_spacegroup_type(msg_type);
@@ -326,7 +326,7 @@ std::optional<py::int_> spglib::magnetic_symmetry_from_database(
         return {};
     return spg_get_magnetic_symmetry_from_database(
         (int (*)[3][3])rotations.data(), (double (*)[3])translations.data(),
-        (int*)time_reversals.data(), uni_number, hall_number);
+        (int *)time_reversals.data(), uni_number, hall_number);
 }
 std::optional<py::tuple> spglib::pointgroup(array_int rotations) {
     char symbol[6];
@@ -386,7 +386,7 @@ std::optional<py::int_> spglib::symmetry_with_site_tensors(
     py::int_ with_time_reversal, py::int_ is_axial, py::float_ symprec,
     py::float_ angle_tolerance, py::float_ mag_symprec) {
     int tensor_rank = tensors.ndim() - 1;
-    int* spin_flips_ptr;
+    int *spin_flips_ptr;
     switch (tensor_rank) {
         case 0:
         case 1:

--- a/src/debug.c
+++ b/src/debug.c
@@ -11,7 +11,7 @@
 #include "debug.h"
 
 bool debug_enabled(void) {
-    char const* debug_env = getenv("SPGLIB_DEBUG");
+    char const *debug_env = getenv("SPGLIB_DEBUG");
     // If SPGLIB_DEBUG is not defined, do not output any debug info
     if (debug_env == NULL) return false;
     // Here we are not checking if SPGLIB_DEBUG is true/1/etc. we only check if
@@ -19,7 +19,7 @@ bool debug_enabled(void) {
     return true;
 }
 bool warning_enabled(void) {
-    char const* warning_env = getenv("SPGLIB_WARNING");
+    char const *warning_env = getenv("SPGLIB_WARNING");
     // If SPGLIB_WARNING is not defined assume warning is on
     if (warning_env == NULL) return true;
     // Check if SPGLIB_WARNING is disabled. Not performing case-insensitive
@@ -29,7 +29,7 @@ bool warning_enabled(void) {
     return true;
 }
 bool info_enabled(void) {
-    char const* info_env = getenv("SPGLIB_INFO");
+    char const *info_env = getenv("SPGLIB_INFO");
     // If SPGLIB_INFO is not defined, do not output any info messages
     if (info_env == NULL) return false;
     // Here we are not checking if SPGLIB_INFO is true/1/etc. we only check if
@@ -71,7 +71,7 @@ void debug_print_vectors_with_label(double const a[][3], int const b[],
         fprintf(stdout, "%d: %f %f %f\n", b[i], a[i][0], a[i][1], a[i][2]);
     }
 }
-void debug_print(char const* format, ...) {
+void debug_print(char const *format, ...) {
     if (!debug_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
@@ -81,20 +81,20 @@ void debug_print(char const* format, ...) {
 #endif
 
 #ifdef SPGWARNING
-void warning_print(char const* format, ...) {
+void warning_print(char const *format, ...) {
     if (!warning_enabled()) return;
     va_list argptr;
     va_start(argptr, format);
     vfprintf(stderr, format, argptr);
     va_end(argptr);
 }
-void warning_memory(char const* what) {
+void warning_memory(char const *what) {
     warning_print("Spglib: Memory could not be allocated: %s\n", what);
 }
 #endif
 
 #ifdef SPGINFO
-void info_print(char const* format, ...) {
+void info_print(char const *format, ...) {
     if (!info_enabled()) return;
     va_list argptr;
     va_start(argptr, format);

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,21 +16,21 @@ static inline void debug_print_vector_d3(double const a[3]) {}
 
 static inline void debug_print_vectors_with_label(double const a[][3],
                                                   int const b[], int size) {}
-static inline void debug_print(char const* format, ...) {}
+static inline void debug_print(char const *format, ...) {}
 #endif
 #ifndef SPGWARNING
-static inline void warning_print(char const* format, ...) {}
-static inline void warning_memory(char const* what) {}
+static inline void warning_print(char const *format, ...) {}
+static inline void warning_memory(char const *what) {}
 #endif
 #ifndef SPGINFO
-static inline void info_print(char const* format, ...) {}
+static inline void info_print(char const *format, ...) {}
 #endif
 
 // Otherwise the print functions are proper functions
 // Main print interface
-void warning_print(char const* format, ...);
-void debug_print(char const* format, ...);
-void info_print(char const* format, ...);
+void warning_print(char const *format, ...);
+void debug_print(char const *format, ...);
+void info_print(char const *format, ...);
 void debug_print_matrix_d3(double const a[3][3]);
 void debug_print_matrix_i3(int const a[3][3]);
 void debug_print_vector_d3(double const a[3]);
@@ -39,4 +39,4 @@ void debug_print_vectors_with_label(double const a[][3], int const b[],
                                     int size);
 
 // Common messages
-void warning_memory(char const* what);
+void warning_memory(char const *what);

--- a/src/mathfunc.h
+++ b/src/mathfunc.h
@@ -61,10 +61,10 @@ double mat_Dabs(double const a);
 int mat_Nint(double const a);
 double mat_Dmod1(double const a);
 double mat_rem1(double const a);
-MatINT* mat_alloc_MatINT(int const size);
-void mat_free_MatINT(MatINT* matint);
-VecDBL* mat_alloc_VecDBL(int const size);
-void mat_free_VecDBL(VecDBL* vecdbl);
+MatINT *mat_alloc_MatINT(int const size);
+void mat_free_MatINT(MatINT *matint);
+VecDBL *mat_alloc_VecDBL(int const size);
+void mat_free_VecDBL(VecDBL *vecdbl);
 int mat_is_int_matrix(double const mat[3][3], double const symprec);
 
 #endif

--- a/src/niggli.h
+++ b/src/niggli.h
@@ -14,7 +14,7 @@
 int niggli_get_major_version(void);
 int niggli_get_minor_version(void);
 int niggli_get_micro_version(void);
-SPG_API_TEST int niggli_reduce(double* lattice_, double const eps_,
+SPG_API_TEST int niggli_reduce(double *lattice_, double const eps_,
                                int const aperiodic_axis);
 
 #endif

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -321,22 +321,22 @@ static int rot_axes[][3] = {
 
 static int get_pointgroup_number_by_rotations(int const rotations[][3][3],
                                               int const num_rotations);
-static int get_pointgroup_number(PointSymmetry const* pointsym);
+static int get_pointgroup_number(PointSymmetry const *pointsym);
 static int get_pointgroup_class_table(int table[10],
-                                      PointSymmetry const* pointsym);
+                                      PointSymmetry const *pointsym);
 static int get_rotation_type(int const rot[3][3]);
 static int get_rotation_axis(int const rot[3][3]);
 static int get_orthogonal_axis(int ortho_axes[], int const proper_rot[3][3],
                                int const rot_order);
-static int laue2m(int axes[3], PointSymmetry const* pointsym);
-static int layer_laue2m(int axes[3], PointSymmetry const* pointsym,
+static int laue2m(int axes[3], PointSymmetry const *pointsym);
+static int layer_laue2m(int axes[3], PointSymmetry const *pointsym,
                         int const aperiodic_axis);
 
-static int laue_one_axis(int axes[3], PointSymmetry const* pointsym,
+static int laue_one_axis(int axes[3], PointSymmetry const *pointsym,
                          int const rot_order);
-static int lauennn(int axes[3], PointSymmetry const* pointsym,
+static int lauennn(int axes[3], PointSymmetry const *pointsym,
                    int const rot_order, int const aperiodic_axis);
-static int get_axes(int axes[3], Laue const laue, PointSymmetry const* pointsym,
+static int get_axes(int axes[3], Laue const laue, PointSymmetry const *pointsym,
                     int const aperiodic_axis);
 static void get_proper_rotation(int prop_rot[3][3], int const rot[3][3]);
 static void set_transformation_matrix(int tmat[3][3], int const axes[3]);
@@ -434,7 +434,7 @@ static int get_pointgroup_number_by_rotations(int const rotations[][3][3],
     return get_pointgroup_number(&pointsym);
 }
 
-static int get_pointgroup_number(PointSymmetry const* pointsym) {
+static int get_pointgroup_number(PointSymmetry const *pointsym) {
     int i, j, pg_num, counter;
     int table[10];
     PointgroupType pointgroup_type;
@@ -472,7 +472,7 @@ end:
 // or roto-rotations
 // @param[in] pointsym
 static int get_pointgroup_class_table(int table[10],
-                                      PointSymmetry const* pointsym) {
+                                      PointSymmetry const *pointsym) {
     /* Look-up table */
     /* Operation   -6 -4 -3 -2 -1  1  2  3  4  6 */
     /* Trace     -  2 -1  0  1 -3  3 -1  0  1  2 */
@@ -567,7 +567,7 @@ static int get_rotation_type(int const rot[3][3]) {
 // @param[in] laue
 // @param[in] pointsym
 // @param[in] aperiodic_axis
-static int get_axes(int axes[3], Laue const laue, PointSymmetry const* pointsym,
+static int get_axes(int axes[3], Laue const laue, PointSymmetry const *pointsym,
                     int const aperiodic_axis) {
     switch (laue) {
         case LAUE1:
@@ -616,7 +616,7 @@ static int get_axes(int axes[3], Laue const laue, PointSymmetry const* pointsym,
     return 1;
 }
 
-static int laue2m(int axes[3], PointSymmetry const* pointsym) {
+static int laue2m(int axes[3], PointSymmetry const *pointsym) {
     int i, num_ortho_axis, norm, min_norm, is_found;
     int prop_rot[3][3];
     int ortho_axes[NUM_ROT_AXES];
@@ -693,7 +693,7 @@ err:
 
 // @note The two-fold axis is set to axis-a. Axes b and c forms the periodic
 // plane.
-static int layer_laue2m(int axes[3], PointSymmetry const* pointsym,
+static int layer_laue2m(int axes[3], PointSymmetry const *pointsym,
                         int const aperiodic_axis) {
     int i, num_ortho_axis, norm, min_norm, is_found;
     int prop_rot[3][3];
@@ -800,7 +800,7 @@ err:
 }
 
 // For Laue classes 4/m, 4/mmm, -3, -3/m, 6/m, 6/mmm
-static int laue_one_axis(int axes[3], PointSymmetry const* pointsym,
+static int laue_one_axis(int axes[3], PointSymmetry const *pointsym,
                          int const rot_order) {
     int i, j, num_ortho_axis, det, is_found, tmpval;
     int axis_vec[3], tmp_axes[3];
@@ -889,7 +889,7 @@ end:
 }
 
 // For Laue classes mmm, m-3, m-3m
-static int lauennn(int axes[3], PointSymmetry const* pointsym,
+static int lauennn(int axes[3], PointSymmetry const *pointsym,
                    int const rot_order, int const aperiodic_axis) {
     int i, count, axis;
     int prop_rot[3][3];

--- a/src/site_symmetry.h
+++ b/src/site_symmetry.h
@@ -9,9 +9,9 @@
 #include "mathfunc.h"
 #include "symmetry.h"
 
-VecDBL* ssm_get_exact_positions(int* wyckoffs, int* equiv_atoms,
+VecDBL *ssm_get_exact_positions(int *wyckoffs, int *equiv_atoms,
                                 char (*site_symmetry_symbols)[7],
-                                Cell const* bravais, Symmetry const* conv_sym,
+                                Cell const *bravais, Symmetry const *conv_sym,
                                 int const num_pure_trans, int const hall_number,
                                 double const symprec);
 

--- a/src/spg_database.h
+++ b/src/spg_database.h
@@ -23,7 +23,7 @@ typedef struct {
 void spgdb_decode_symmetry(int rot[3][3], double trans[3], int const encoded);
 int spgdb_get_operation(int rot[3][3], double trans[3], int const hall_number);
 void spgdb_get_operation_index(int indices[2], int const hall_number);
-Symmetry* spgdb_get_spacegroup_operations(int const hall_number);
+Symmetry *spgdb_get_spacegroup_operations(int const hall_number);
 SpacegroupType spgdb_get_spacegroup_type(int const hall_number);
 int spgdb_remove_space(char symbol[], int const num_char);
 

--- a/test/example/c_api/example.c
+++ b/test/example/c_api/example.c
@@ -2,8 +2,8 @@
 
 #include "spglib.h"
 
-int main(int argc, char* argv[]) {
-    SpglibDataset* dataset;
+int main(int argc, char *argv[]) {
+    SpglibDataset *dataset;
     int i, j;
     char const wl[26] = "abcdefghijklmnopqrstuvwxyz";
 

--- a/test/package/src/main.c
+++ b/test/package/src/main.c
@@ -2,7 +2,7 @@
 
 #include "spglib.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     printf("Spglib version: %s\n", spg_get_version());
     return 0;
 }

--- a/test/unit/test_error.cpp
+++ b/test/unit/test_error.cpp
@@ -18,5 +18,5 @@ TEST(Error, thread_safety) {
     std::list<std::thread> thread_jobs{};
     thread_jobs.emplace_back(thread_func, SPGLIB_SUCCESS);
     thread_jobs.emplace_back(thread_func, SPGERR_NONE);
-    for (auto& job : thread_jobs) job.join();
+    for (auto &job : thread_jobs) job.join();
 }

--- a/test/unit/test_niggli.cpp
+++ b/test/unit/test_niggli.cpp
@@ -25,7 +25,7 @@ TEST(Niggli, Niggli_reduce) {
     auto setenv_result = setenv("SPGLIB_NUM_ATTEMPTS", "100", 1);
     ASSERT_EQ(setenv_result, 0);
 
-    int succeeded = niggli_reduce((double*)min_lattice, symprec, -1);
+    int succeeded = niggli_reduce((double *)min_lattice, symprec, -1);
     // Default get_num_attempts() == 1000 --> succeeded == 1.
     // With get_num_attempts() == 100 --> succeeded == 0.
     EXPECT_EQ(succeeded, 0);
@@ -33,7 +33,7 @@ TEST(Niggli, Niggli_reduce) {
     setenv_result = setenv("SPGLIB_NUM_ATTEMPTS", "1000", 1);
     ASSERT_EQ(setenv_result, 0);
 
-    succeeded = niggli_reduce((double*)min_lattice, symprec, -1);
+    succeeded = niggli_reduce((double *)min_lattice, symprec, -1);
     EXPECT_EQ(succeeded, 1);
 
     mat_inverse_matrix_d3(inv_lat, lattice, symprec);


### PR DESCRIPTION
Clang-format from CI starts complaining about `PointerAlignment` somehow. This PR fixes the format issue.