### PR TITLE
Choose more intuitive orientation of Bravais lattice in magnetic space group

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,14 @@ GitHub release pages and in the git history.
 
 ## [Unreleased]
 
+## Main changes
+
+- [[#610]](https://github.com/spglib/spglib/pull/610) Try to preserve the
+  Bravais lattice orientation with respect to the input one in magnetic space
+  group when there are symmetrically equivalent candidates. By this
+  `transformation_matrix`, `origin_shift`, `std_*` in `SpglibMagneticDataset`
+  can be chosen differently.
+
 ### Python API
 
 - Switched to using pybind11 for generating the python bindings

--- a/src/magnetic_spacegroup.c
+++ b/src/magnetic_spacegroup.c
@@ -71,6 +71,7 @@ MagneticDataset *msg_identify_magnetic_space_group_type(
     double rigid_rot[3][3];
     double tmat[3][3], tmat_cor[3][3];
     double shift[3], shift_cor[3];
+    double blat_orig[3][3], blat_inv[3][3], blat_rot[3][3];
 
     transformations = NULL;
     ref_sg = NULL;
@@ -170,6 +171,14 @@ MagneticDataset *msg_identify_magnetic_space_group_type(
 
     mat_multiply_matrix_d3(ref_sg->bravais_lattice, lattice,
                            ref_sg->bravais_lattice);
+
+    /* Find more intuitive orientation of Bravais lattice*/
+    mat_copy_matrix_d3(blat_orig, ref_sg->bravais_lattice);
+    ref_find_similar_bravais_lattice(ref_sg, symprec);
+    mat_inverse_matrix_d3(blat_inv, ref_sg->bravais_lattice, 0);
+    mat_multiply_matrix_d3(blat_rot, blat_inv, blat_orig);
+    mat_multiply_matrix_d3(tmat, blat_rot, tmat);
+
     /* Rigid rotation to standardized lattice */
     get_rigid_rotation(rigid_rot, lattice, tmat, ref_sg);
 


### PR DESCRIPTION
The Bravais lattice for a magnetic space group is chosen approximately randomly when symmetrically equivalent options exist. This can change the orientation of the input cell even if it is already standardized, which is non-intuitive. This PR addresses this issue by preserving the cell orientation when possible.