### PR TITLE
Update reference of Bilbao Crystallographic Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ int main(void) {
 
     // Obtain data in SpglibDataset.
     // The space group number 186 corresponds to the wurtzite-type (P6_3mc).
-    // See https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-table
+    // See https://web.archive.org/web/20250505150336/https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-table
     assert(dataset->spacegroup_number == 186);
 
     // Deallocate SpglibDataset, otherwise induce memory leak.

--- a/docs/references.md
+++ b/docs/references.md
@@ -7,9 +7,9 @@ understanding the crystallography ashamedly.
 
 ## General materials
 
-- [Bilbao Crystallographic Server](https://www.cryst.ehu.es/). The
+- [Bilbao Crystallographic Server](https://web.archive.org/web/20250505150336/https://www.cryst.ehu.es/). The
   references of many useful papers are found in the
-  [Articles page](https://www.cryst.ehu.es/wiki/index.php/Articles).
+  [Articles page](https://web.archive.org/web/20250505150336/https://www.cryst.ehu.es/wiki/index.php/Articles).
 - [Online dictionary of crystallography](https://dictionary.iucr.org/Main_Page)
 
 {cite:empty}`gen-ITA2016`

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -60,7 +60,7 @@ program spglib_example
     ! No need to deallocate SpglibDataset manually as contrasted to C
     dset = spg_get_dataset(lattice, positions, atom_types, num_atom, symprec)
     ! The space group number 186 corresponds to the wurtzite-type (P6_3mc).
-    ! See https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-table
+    ! See https://web.archive.org/web/20250505150336/https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-table
     print '(a)', dset%international_symbol
     print '(i0)', dset%spacegroup_number
 end program spglib_example


### PR DESCRIPTION
Based on the wikipedia link they have changed the url:

https://en.wikipedia.org/w/index.php?title=Bilbao_Crystallographic_Server&diff=1319848753&oldid=1317128441

Closes #615 