### PR TITLE
Refine the API documentation to point to top-level package

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,7 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+    pre_install:
+      - python3 ./docs/workaround-pep695.py
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
     "sphinxcontrib.bibtex",
     "myst_parser",
     "sphinx.ext.doctest",

--- a/docs/workaround-pep695.py
+++ b/docs/workaround-pep695.py
@@ -1,0 +1,28 @@
+# /// script
+# ///
+"""Workaround for sphinx and pep695 support.
+
+Sphinx currently only properly supports typealias documentation
+using the PEP695 format (sphinx#13508, sphinx#8934).
+
+We cannot use this new standard until the minimum python version
+is 3.12. As a workaround, we can just convert these for the
+documentation generation on RTD.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.parent
+PYTHON_API_DIR = ROOT_DIR / "python/spglib"
+
+
+for py_file in PYTHON_API_DIR.glob("**/*.py"):
+    with py_file.open("r+") as f:
+        content = f.read()
+        content = re.sub(r"(.+): TypeAlias =", r"type \1 =", content)
+        f.seek(0)
+        f.write(content)
+        f.truncate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,9 @@ test = [
     "pyyaml",
 ]
 docs = [
-    "Sphinx >= 7.0",
+    "Sphinx >= 9.0",
     "sphinxcontrib-bibtex >= 2.5",
     "sphinx-book-theme",
-    "sphinx-autodoc-typehints",
     "myst-parser >= 2.0",
     "linkify-it-py",
     "sphinx-tippy",

--- a/python/spglib/__init__.py
+++ b/python/spglib/__init__.py
@@ -6,11 +6,32 @@
 # TODO: _internal should not be exposed, we only continue to do so for
 #  backwards compatibility
 from ._internal import *  # noqa: F403
-from ._version import __version__, __version_tuple__  # noqa: F401
+from ._internal import __all__ as _internal_all
+from ._version import __version__, __version_tuple__
 from .cell import *  # noqa: F403
+from .cell import __all__ as _cell_all
 from .error import *  # noqa: F403
+from .error import __all__ as _error_all
 from .kpoints import *  # noqa: F403
+from .kpoints import __all__ as _kpoints_all
 from .msg import *  # noqa: F403
+from .msg import __all__ as _msg_all
 from .reduce import *  # noqa: F403
+from .reduce import __all__ as _reduce_all
 from .spg import *  # noqa: F403
+from .spg import __all__ as _spg_all
 from .utils import *  # noqa: F403
+from .utils import __all__ as _utils_all
+
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+    *_internal_all,
+    *_cell_all,
+    *_error_all,
+    *_kpoints_all,
+    *_msg_all,
+    *_reduce_all,
+    *_spg_all,
+    *_utils_all,
+]

--- a/python/spglib/msg.py
+++ b/python/spglib/msg.py
@@ -28,8 +28,11 @@ __all__ = [
 ]
 
 MsgCell: TypeAlias = tuple[Lattice, Positions, Numbers, Magmoms]
-"""Magnetic crystal structure represented by a tuple of
-(lattice, positions, numbers, magmoms)."""
+"""
+Magnetic crystal structure represented by a tuple of
+(:py:type:`spglib.utils.Lattice`, :py:type:`spglib.utils.Positions`,
+:py:type:`spglib.utils.Numbers`, :py:type:`spglib.utils.Magmoms`).
+"""
 
 
 @dataclasses.dataclass(eq=False, frozen=True)

--- a/python/spglib/spg.py
+++ b/python/spglib/spg.py
@@ -35,7 +35,10 @@ __all__ = [
 
 
 SpgCell: TypeAlias = tuple[Lattice, Positions, Numbers]
-"""Crystal structure represented by a tuple of (lattice, positions, numbers)."""
+"""
+Crystal structure represented by a tuple of (:py:type:`spglib.utils.Lattice`,
+:py:type:`spglib.utils.Positions`, :py:type:`spglib.utils.Numbers`).
+"""
 
 
 @dataclasses.dataclass(eq=False, frozen=True)

--- a/python/spglib/utils.py
+++ b/python/spglib/utils.py
@@ -42,13 +42,17 @@ warnings.filterwarnings(
 
 
 Lattice: TypeAlias = Sequence[Sequence[float]]
+"""Basis vectors in ``(3, 3)`` shape."""
 Positions: TypeAlias = Sequence[Sequence[float]]
+"""Point coordinates of atoms in ``(N, 3)`` shape."""
 Numbers: TypeAlias = Sequence[int]
+"""Integer numbers for identifying atoms in ``(N,)`` shape."""
 Magmoms: TypeAlias = Union[Sequence[float], Sequence[Sequence[float]]]
+"""Magnetic moments of atoms in either ``(N,)`` or ``(N, 3)`` shape."""
 
 # Compatibility alias for some deprecated interfaces
 Cell: TypeAlias = Union["spglib.spg.SpgCell", "spglib.msg.MsgCell"]
-"""Either SpgCell or MsgCell."""
+"""Either :py:type:`spglib.spg.SpgCell` or :py:type:`spglib.msg.MsgCell`."""
 
 
 @dataclasses.dataclass(eq=True, frozen=True)

--- a/python/spglib/utils.py
+++ b/python/spglib/utils.py
@@ -25,6 +25,11 @@ if typing.TYPE_CHECKING:
     from typing import Any
 
 __all__ = [
+    "Lattice",
+    "Positions",
+    "Numbers",
+    "Magmoms",
+    "Cell",
     "get_version",
     "spg_get_version",
     "spg_get_version_full",


### PR DESCRIPTION
Seems like whatever issues we had with documenting the top-level package in sphinx is gone, so we can revisit the documentation and export of all pulbic objects.

Depends-on #619 
Closes #617